### PR TITLE
fix: 게시글, 댓글, 좋아요 테이블 timestamp 컬럼 자동 초기화, 갱신

### DIFF
--- a/server/db/sql/comments.sql
+++ b/server/db/sql/comments.sql
@@ -3,8 +3,8 @@ CREATE TABLE IF NOT EXISTS comments (
     content TEXT NOT NULL,
     post_id INT NOT NULL,
     author_id INT NOT NULL,
-    created_at TIMESTAMP NOT NULL,
-    updated_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP ON UPDATE NOW(),
     isDelete Boolean NOT NULL DEFAULT FALSE,
     FOREIGN KEY (post_id) REFERENCES posts(id),
     FOREIGN KEY (author_id) REFERENCES users(id)
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS comment_likes (
     id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     comment_id INT NOT NULL,
     user_id INT NOT NULL,
-    created_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     FOREIGN KEY (comment_id) REFERENCES comments(id),
     FOREIGN KEY (user_id) REFERENCES users(id)
 );

--- a/server/db/sql/posts.sql
+++ b/server/db/sql/posts.sql
@@ -3,8 +3,8 @@ CREATE TABLE IF NOT EXISTS posts (
     title TEXT NOT NULL,
     content TEXT NOT NULL,
     author_id INT NOT NULL,
-    created_at TIMESTAMP NOT NULL,
-    updated_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP ON UPDATE NOW(),
     views INT NOT NULL default 0,
     isDelete Boolean NOT NULL DEFAULT FALSE,
     FOREIGN KEY (author_id) REFERENCES users(id)
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS post_likes (
     id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     post_id INT NOT NULL,
     user_id INT NOT NULL,
-    created_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     FOREIGN KEY (post_id) REFERENCES posts(id),
     FOREIGN KEY (user_id) REFERENCES users(id)
 );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#24

## 📝 작업 내용

`posts`, `post_likes`, `comments`, `comment_likes` 테이블의 `TIMESTAMP` 타입 컬럼이 아래와 같이 자동으로 초기화 또는 갱신되도록 변경합니다.

1. `created_at` 컬럼은 레코드 삽입 시 별도의 값을 전달하지 않았다면 `NOW()`로 초기화됩니다.
2. `updated_at` 컬럼은 레코드 수정 시 별도의 값을 전달하지 않았다면 `NOW()`로 변경됩니다.

## 💬 리뷰 요구사항

- `updated_at` 컬럼에는 `DEFAULT` 구문을 일부러 안 넣었는데, 다른 의견 있으신가요?
  - 추후 게시글·댓글의 수정 여부를 `updated_at != null`로 판단하려는 의도입니다.
