### PR TITLE
[BE] 댓글 생성 API 구현

### DIFF
--- a/server/controller/comments_controller.ts
+++ b/server/controller/comments_controller.ts
@@ -1,8 +1,12 @@
 import { Request, Response, NextFunction } from "express";
-import { getComments } from "../db/context/comment_context";
+import { createComment, getComments } from "../db/context/comment_context";
 import { ServerError } from "../middleware/errors";
 
-export const getCommentsByPostId = async (req: Request, res: Response, next: NextFunction) => {
+export const getCommentsByPostId = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
     const postId = parseInt(req.params.post_id, 10);
     if (isNaN(postId)) {
@@ -11,6 +15,29 @@ export const getCommentsByPostId = async (req: Request, res: Response, next: Nex
 
     const comments = await getComments(parseInt(req.params.post_id));
     res.status(200).json({ comments });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createCommentByPostId = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const postId = parseInt(req.params.post_id, 10);
+    if (isNaN(postId)) {
+      throw ServerError.badRequest("Invalid post ID");
+    }
+
+    await createComment({
+      post_id: parseInt(req.params.post_id),
+      author_id: req.body.author_id,
+      content: req.body.content,
+    });
+
+    res.status(201).end();
   } catch (err) {
     next(err);
   }

--- a/server/controller/comments_controller.ts
+++ b/server/controller/comments_controller.ts
@@ -1,6 +1,5 @@
 import { Request, Response, NextFunction } from "express";
 import { createComment, getComments } from "../db/context/comment_context";
-import { ServerError } from "../middleware/errors";
 
 export const getCommentsByPostId = async (
   req: Request,
@@ -9,11 +8,9 @@ export const getCommentsByPostId = async (
 ) => {
   try {
     const postId = parseInt(req.params.post_id, 10);
-    if (isNaN(postId)) {
-      throw ServerError.badRequest("Invalid post ID");
-    }
 
-    const comments = await getComments(parseInt(req.params.post_id));
+    const comments = await getComments(postId);
+
     res.status(200).json({ comments });
   } catch (err) {
     next(err);
@@ -27,12 +24,9 @@ export const createCommentByPostId = async (
 ) => {
   try {
     const postId = parseInt(req.params.post_id, 10);
-    if (isNaN(postId)) {
-      throw ServerError.badRequest("Invalid post ID");
-    }
 
     await createComment({
-      post_id: parseInt(req.params.post_id),
+      post_id: postId,
       author_id: req.body.author_id,
       content: req.body.content,
     });

--- a/server/db/context/comment_context.ts
+++ b/server/db/context/comment_context.ts
@@ -1,6 +1,13 @@
-import { PoolConnection } from "mysql2/promise";
+import { FieldPacket, PoolConnection, ResultSetHeader } from "mysql2/promise";
+import { ServerError } from "../../middleware/errors";
 import pool from "../connect";
 import { mapDBToComments } from "../mapper/comments_mapper";
+
+interface ICommentInsertion {
+  post_id: number;
+  author_id: number;
+  content: string;
+}
 
 export const getComments = async (postId: number) => {
   let conn: PoolConnection | null = null;
@@ -34,6 +41,76 @@ export const getComments = async (postId: number) => {
     const [rows]: any[] = await conn.query(sql, values);
     return mapDBToComments(rows);
   } catch (err) {
+    throw err;
+  } finally {
+    if (conn) conn.release();
+  }
+};
+
+export const createComment = async (commentInsertion: ICommentInsertion) => {
+  let conn: PoolConnection | null = null;
+
+  const { post_id, author_id, content } = commentInsertion;
+
+  try {
+    const sql = `
+      INSERT INTO
+        comments (post_id, author_id, content)
+      VALUES
+        (?, ?, ?)
+    `;
+    const values = [post_id, author_id, content];
+
+    conn = await pool.getConnection();
+    const [result]: [ResultSetHeader, FieldPacket[]] = await conn.query(
+      sql,
+      values
+    );
+
+    if (result.affectedRows === 0) {
+      throw ServerError.etcError(500, "댓글 등록하지 못했습니다.");
+    }
+  } catch (err: any) {
+    if (err?.code === "ER_BAD_NULL_ERROR") {
+      const omittedFields = [
+        { fieldDesc: "작성자 ID", value: author_id },
+        { fieldDesc: "게시글 ID", value: post_id },
+        { fieldDesc: "댓글 내용", value: content },
+      ]
+        .filter(({ value }) => value === undefined || value === null)
+        .map(({ fieldDesc }) => fieldDesc)
+        .join(", ");
+
+      throw ServerError.badRequest(
+        `필수 항목이 누락되었습니다. (${omittedFields})`
+      );
+    } else if (err?.code === "ER_TRUNCATED_WRONG_VALUE_FOR_FIELD") {
+      const wrongTypedFields = [
+        { fieldDesc: "작성자 ID", type: typeof author_id, expected: "number" },
+        { fieldDesc: "댓글 내용", type: typeof content, expected: "string" },
+      ]
+        .filter(({ type, expected }) => type !== expected)
+        .map(({ fieldDesc }) => fieldDesc)
+        .join(", ");
+
+      throw ServerError.badRequest(
+        `입력 자료형이 일치하지 않습니다. (${wrongTypedFields})`
+      );
+    } else if (err?.code === "ER_NO_REFERENCED_ROW_2") {
+      const notFoundFields = [
+        { fieldDesc: "작성자 ID", columnName: "author_id" },
+        { fieldDesc: "게시글 ID", columnName: "post_id" },
+      ];
+
+      for (const field of notFoundFields) {
+        if (err?.sqlMessage?.includes(field.columnName)) {
+          throw ServerError.notFound(
+            `${field.fieldDesc} ${field.columnName}이(가) 존재하지 않습니다.`
+          );
+        }
+      }
+    }
+
     throw err;
   } finally {
     if (conn) conn.release();

--- a/server/route/comments_router.ts
+++ b/server/route/comments_router.ts
@@ -1,9 +1,31 @@
 import express from "express";
-import { getCommentsByPostId } from "../controller/comments_controller";
+import { body, param } from "express-validator";
+import {
+  createCommentByPostId,
+  getCommentsByPostId,
+} from "../controller/comments_controller";
+import { validate } from "../middleware/validate";
+
+const postCommentValidation = [
+  body("content")
+    .notEmpty()
+    .withMessage("본문을 입력해 주십시오.")
+    .bail()
+    .isString()
+    .withMessage("본문이 문자열이 아닙니다."),
+  param("post_id")
+    .notEmpty()
+    .withMessage("게시글 ID를 입력해 주십시오.")
+    .bail()
+    .isInt({ min: 1 })
+    .withMessage("게시글 ID가 양의 정수가 아닙니다."),
+  validate,
+];
 
 const router = express.Router();
 router.use(express.json());
 
 router.get("/:post_id", getCommentsByPostId);
+router.post("/:post_id", postCommentValidation, createCommentByPostId);
 
 export default router;

--- a/server/route/comments_router.ts
+++ b/server/route/comments_router.ts
@@ -6,6 +6,16 @@ import {
 } from "../controller/comments_controller";
 import { validate } from "../middleware/validate";
 
+const getCommentValidation = [
+  param("post_id")
+    .notEmpty()
+    .withMessage("게시글 ID를 입력해 주십시오.")
+    .bail()
+    .isInt({ min: 1 })
+    .withMessage("게시글 ID가 양의 정수가 아닙니다."),
+  validate,
+];
+
 const postCommentValidation = [
   body("content")
     .notEmpty()
@@ -25,7 +35,7 @@ const postCommentValidation = [
 const router = express.Router();
 router.use(express.json());
 
-router.get("/:post_id", getCommentsByPostId);
+router.get("/:post_id", getCommentValidation, getCommentsByPostId);
 router.post("/:post_id", postCommentValidation, createCommentByPostId);
 
 export default router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#22

## 📝 작업 내용

- comments context에, DB에 새 댓글을 등록하는 내용 구현
- comments controller에 댓글 생성 API 핸들러 구현
- 댓글 생성 API 등록

## 💬 리뷰 요구사항

- `server/db/context/comment_context.ts`에서 에러를 핸들링하는 패턴이 괜찮은지 의견을 부탁드립니다.
  - `if ... else if ...`을 일일이 작성하는 것과 고민하다가, 배열을 필터하는 방식으로 구현했는데, `if ... else if ...`가 더 읽기 편하다면 에러 핸들링 구현을 변경하겠습니다.
- 현재 구현상 `post_id` param 유효성 검사를 validator와 controller 양쪽에서 각각 진행하는데, 중복이라 한쪽의 유효성 검사를 제거해야 한다면 controller 쪽에서 `post_id` 유효성 검사를 제거해도 괜찮을까요?
  - 이렇게 변경하게 된다면, 이전에 작성한 `GET /api/comment/:post_id` 또한 동일한 방식으로 유효성 검사를 하도록 변경하려고 합니다.
- 그 외 수정이 필요한 부분이나 다른 의견이 있으면 남겨 주세요.