### PR TITLE
Feature/patch post

### DIFF
--- a/server/controller/posts_controller.ts
+++ b/server/controller/posts_controller.ts
@@ -14,6 +14,12 @@ export interface ICreatePostRequest {
     author_id : number;
 }
 
+export interface IUpdatePostRequest {
+    title? : string;
+    content? : string;
+    author_id : number;
+}
+
 export const getPosts = async (req : Request, res : Response, next : NextFunction) => {
     try{
         const values : IReadPostRequest = {

--- a/server/controller/posts_controller.ts
+++ b/server/controller/posts_controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { addPost, getPostHeaders, getPostInfo } from '../db/context/posts_context';
+import { addPost, getPostHeaders, getPostInfo, updatePost } from '../db/context/posts_context';
 import { ServerError } from '../middleware/errors';
 
 export interface IReadPostRequest {
@@ -59,6 +59,29 @@ export const createPost = async (req : Request, res : Response, next : NextFunct
         await addPost(reqBody);
 
         res.status(200).json({ message : "게시글 생성 success"});
+    } catch (err) {
+        next(err);
+    }
+}
+
+export const patchPost = async (req : Request, res : Response, next : NextFunction) => {
+    try {
+        const post_id = parseInt(req.params.post_id);
+
+        if (isNaN(post_id)) {
+            throw ServerError.badRequest("Invalid post ID");
+        }
+
+        const reqBody : IUpdatePostRequest = {
+            title : req.body.title,
+            content : req.body.content,
+            // TODO : token 검증 미들웨어 업데이트 시 삭제
+            author_id : parseInt(req.body.author_id)
+        };
+
+        await updatePost(post_id, reqBody);
+
+        res.status(200).json({ message : "게시글 수정 success"});
     } catch (err) {
         next(err);
     }

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -113,16 +113,15 @@ export const updatePost = async (post_id : number, reqBody : IUpdatePostRequest)
 
         let sql = `
                 UPDATE posts
-                SET title = ?, content = ?
-                WHERE id =? AND isDelete = FALSE
+                SET
         `;
 
-        if (reqBody.title !== undefined){
+        if (reqBody.title){
             values.push(reqBody.title);
             sql += ' title = ?'
         }
 
-        if (reqBody.content !== undefined){
+        if (reqBody.content){
             values.push(reqBody.content);
 
             if (values.length > 0) {
@@ -140,6 +139,8 @@ export const updatePost = async (post_id : number, reqBody : IUpdatePostRequest)
         const [rows] : any[] = await conn.query(sql, values);
         
         if (rows.affectedRows === 0) {
+            // 1. 게시글 author_id와 수정 요청한 user_id가 다름 -> client에서 막아야 함
+            // 2. 원인모를 이유로 실패함
             throw ServerError.reference("게시글 수정 실패");
         }
     } catch (err) {

--- a/server/route/posts_router.ts
+++ b/server/route/posts_router.ts
@@ -1,7 +1,8 @@
 import express from 'express';
-import { createPost, getPost, getPosts } from '../controller/posts_controller';
-import { body } from "express-validator";
+import { createPost, getPost, getPosts, patchPost } from '../controller/posts_controller';
+import { body, check } from "express-validator";
 import { validate } from "../middleware/validate";
+import { ServerError } from '../middleware/errors';
 
 // Request body 유효성 검사
 const postBodyValidation = [
@@ -16,6 +17,13 @@ const postBodyValidation = [
   validate,
 ];
 
+const patchBodyValidation = [
+  body("title").custom((value, { req }) => {
+    return value || req.body.content;
+  }).withMessage("수정 사항이 없습니다."),
+  validate
+];
+
 const router = express.Router();
 router.use(express.json());
 
@@ -23,5 +31,7 @@ router.get("/", getPosts);
 router.get("/:post_id", getPost);
 
 router.post("/", postBodyValidation, createPost);
+
+router.patch("/:post_id", patchBodyValidation, patchPost);
 
 export default router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#30 

## 📝 작업 내용

### 게시글을 수정하는 API
- 사전 계획
  - client에서 2개의 state를 다룬다
      - 기존 글, 제목
      - 변경한 글, 제목 (default 값은 기존 글, 제목과 동일)
  - 기존 정보 === 변경한 정보 => 해당 정보는 null 처리한다.
  - 실제로 변경된 정보만 request body에 추가하여 요청을 보낸다.

- 실제 구현한 내용 ( 서버 )
  - [x] PUT /api/post/:post_id (route 추가)
  - [x] Request Body 유효성 검사 (express validator)
  - [x] Posts DB 수정 (title, content)
      - [x] post의 author_id와 요청하는 user_id가 일치하는지 확인
      - [x] isDelete가 FALSE인지 확인  
  - [x] 성공 메세지 반환 ( 안해도됨. status 200만 전달하면 됨 )

## 💬 리뷰 요구사항(선택)

- 함수, 변수 등 이름이 이상한 부분 or 더 잘 어울리는 이름이 있다면 알려주세요