### PR TITLE
Feature/auth middleware

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -6,12 +6,14 @@ import apiRouter from "./route/route";
 import { errorHandler } from "./middleware/errors";
 // cookie-parser -------------
 import cookieParser from "cookie-parser";
+import { authToken } from "./middleware/auth";
 
 dotenv.config();
 const app = express();
 
 // app 등록
 app.use(cookieParser());
+app.use(authToken);
 app.use("/api", apiRouter);
 app.use(errorHandler);
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -4,11 +4,14 @@ import dotenv from "dotenv";
 import apiRouter from "./route/route";
 // handelr ----------------
 import { errorHandler } from "./middleware/errors";
+// cookie-parser -------------
+import cookieParser from "cookie-parser";
 
 dotenv.config();
 const app = express();
 
 // app 등록
+app.use(cookieParser());
 app.use("/api", apiRouter);
 app.use(errorHandler);
 

--- a/server/db/context/token_context.ts
+++ b/server/db/context/token_context.ts
@@ -39,12 +39,12 @@ export const addRefreshToken = async (
   }
 };
 
-export const getRefreshToken = async (user_id: number) => {
+export const getRefreshToken = async (user_id: number, token: string) => {
   let conn: PoolConnection | null = null;
 
   try {
-    const sql = `SELECT token FROM refresh_tokens WHERE user_id = ?`;
-    const value = [user_id];
+    const sql = `SELECT token FROM refresh_tokens WHERE user_id = ? AND token = ? and expired_at > now()`;
+    const value = [user_id, token];
 
     conn = await pool.getConnection();
     const [rows]: [IRefreshTokenResult[], FieldPacket[]] = await conn.query(
@@ -53,10 +53,8 @@ export const getRefreshToken = async (user_id: number) => {
     );
 
     if (rows.length === 0) {
-      throw ServerError.tokenError("db에 저장된 토큰이 없습니다.");
+      throw ServerError.tokenError("잘못된 refresh token 입니다.");
     }
-
-    return rows[0].token;
   } catch (err: any) {
     throw err;
   } finally {

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -44,6 +44,8 @@ export const authToken = async (
           httpOnly: true,
           secure: true,
         });
+
+        req.userId = userId;
         next();
       } catch (err: any) {
         res.clearCookie("accessToken");

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,0 +1,68 @@
+import { Request, Response, NextFunction } from "express";
+import {
+  makeAccessToken,
+  verifyAccessToken,
+  verifyRefreshToken,
+} from "../utils/token";
+import { TokenExpiredError } from "jsonwebtoken";
+import { ServerError } from "./errors";
+
+export const authToken = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const accessToken = req.cookies.accessToken;
+    if (!accessToken) {
+      const e = new Error("Access Token이 없습니다.");
+      e.name = "Unauthorized";
+      throw e;
+    }
+    //Access token 검증 로직
+    const jwtPayload = verifyAccessToken(accessToken);
+    req.userId = jwtPayload.userId;
+    next();
+  } catch (err: any) {
+    if (err instanceof TokenExpiredError || err.name === "Unauthorized") {
+      try {
+        const cookies = req.cookies;
+        const refresh_tokens = cookies.refreshToken;
+        if (err.name === "Unauthorized") {
+          if (!refresh_tokens) {
+            return next();
+          }
+        }
+
+        //Refresh token 검증 로직
+        const jwtPayload = await verifyRefreshToken(refresh_tokens);
+        const userId = jwtPayload.userId;
+
+        //새로운 access token 발급
+        const newAccessToken = makeAccessToken(userId);
+        res.cookie("accessToken", newAccessToken, {
+          httpOnly: true,
+          secure: true,
+        });
+
+        next();
+      } catch (err: any) {
+        res.clearCookie("accessToken");
+        res.clearCookie("refreshToken");
+        next(err);
+      }
+    } else {
+      res.clearCookie("accessToken");
+      res.clearCookie("refreshToken");
+      next(err);
+    }
+  }
+};
+
+export const requireLogin = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  req.userId ? next() : next(ServerError.unauthorized("로그인이 필요합니다."));
+};

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -27,15 +27,15 @@ export const authToken = async (
     if (err instanceof TokenExpiredError || err.name === "Unauthorized") {
       try {
         const cookies = req.cookies;
-        const refresh_tokens = cookies.refreshToken;
+        const refreshToken = cookies.refreshToken;
         if (err.name === "Unauthorized") {
-          if (!refresh_tokens) {
+          if (!refreshToken) {
             return next();
           }
         }
 
         //Refresh token 검증 로직
-        const jwtPayload = await verifyRefreshToken(refresh_tokens);
+        const jwtPayload = await verifyRefreshToken(refreshToken);
         const userId = jwtPayload.userId;
 
         //새로운 access token 발급
@@ -44,7 +44,6 @@ export const authToken = async (
           httpOnly: true,
           secure: true,
         });
-
         next();
       } catch (err: any) {
         res.clearCookie("accessToken");

--- a/server/middleware/errors.ts
+++ b/server/middleware/errors.ts
@@ -1,49 +1,61 @@
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response, NextFunction } from "express";
 
-export class ServerError extends Error{
+export class ServerError extends Error {
+  code: number;
 
-    code : number;
-
-    constructor(code : number, message : string) {
-        super(message);
-        this.code = code;
-    }
-    static badRequest(message:string){
-        let errorMsg = `Bad Request: ${message}`;
-        return new ServerError(400, errorMsg);
-    }
-    static unauthorized(message:string){
-        let errorMsg = `Unauthorized: ${message}`;
-        return new ServerError(401, errorMsg);
-    }
-    static forbidden(message:string){
-        let errorMsg = `Forbidden: ${message}`;
-        return new ServerError(403, errorMsg);
-    }
-    static notFound(message:string){
-        let errorMsg = `NotFound: ${message}`;
-        return new ServerError(404, errorMsg);
-    }
-    static reference(message:string){
-        let errorMsg = `Reference Error: ${message}`;
-        return new ServerError(500, errorMsg);
-    }
-    static etcError(code:number, message:string){
-        let errorMsg = `Unknown Error: ${message}`;
-        return new ServerError(code, errorMsg);
-    }
+  constructor(code: number, message: string) {
+    super(message);
+    this.code = code;
+  }
+  static badRequest(message: string) {
+    let errorMsg = `Bad Request: ${message}`;
+    return new ServerError(400, errorMsg);
+  }
+  static unauthorized(message: string) {
+    let errorMsg = `Unauthorized: ${message}`;
+    return new ServerError(401, errorMsg);
+  }
+  static forbidden(message: string) {
+    let errorMsg = `Forbidden: ${message}`;
+    return new ServerError(403, errorMsg);
+  }
+  static notFound(message: string) {
+    let errorMsg = `NotFound: ${message}`;
+    return new ServerError(404, errorMsg);
+  }
+  static reference(message: string) {
+    let errorMsg = `Reference Error: ${message}`;
+    return new ServerError(500, errorMsg);
+  }
+  static etcError(code: number, message: string) {
+    let errorMsg = `Unknown Error: ${message}`;
+    return new ServerError(code, errorMsg);
+  }
+  static expiredToken(message: string) {
+    let errorMsg = `Expired Token: ${message}`;
+    return new ServerError(401, errorMsg);
+  }
+  static tokenError(message: string) {
+    let errorMsg = `Token Error: ${message}`;
+    return new ServerError(401, errorMsg);
+  }
 }
 
-export const errorHandler = (err : ServerError | Error, req : Request, res : Response, next : NextFunction) => {
-    let data = {
-        message : ""
-    };
+export const errorHandler = (
+  err: ServerError | Error,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  let data = {
+    message: "",
+  };
 
-    if (err instanceof ServerError){
-        data.message = err.message;
-        res.status(err.code).json(data);
-    } else {
-        data.message = "Undefined Error:" + err.name  + err.message;
-        res.status(500).json(data);
-    }
-}
+  if (err instanceof ServerError) {
+    data.message = err.message;
+    res.status(err.code).json(data);
+  } else {
+    data.message = "Undefined Error:" + err.name + err.message;
+    res.status(500).json(data);
+  }
+};

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.9",
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-validator": "^7.1.0",
@@ -17,6 +18,7 @@
     "dev": "nodemon --watch \"*.ts\" --exec \"ts-node\" --files ./app.ts"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.7",
     "@types/jsonwebtoken": "^9.0.6"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start": "node dist/app.js",
     "build": "tsc -p .",
-    "dev": "nodemon --watch \"*.ts\" --exec \"ts-node\" ./app.ts"
+    "dev": "nodemon --watch \"*.ts\" --exec \"ts-node\" --files ./app.ts"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.6"

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
-    "target": "es6", // 어떤 버전으로 컴파일할지 작성 
+    "target": "es6", // 어떤 버전으로 컴파일할지 작성
     "module": "commonjs", //어떤 모듈 방식으로 컴파일할지 설정
-    "outDir": "./dist",	//컴파일 후 js 파일들이 생성되는 곳
-    "rootDir": ".",	//루트 폴더
-    "strict": true,	//strict 옵션 활성화
-    "moduleResolution": "node",	//모듈 해석 방법 설정: 'node' (Node.js)
+    "outDir": "./dist", //컴파일 후 js 파일들이 생성되는 곳
+    "rootDir": ".", //루트 폴더
+    "strict": true, //strict 옵션 활성화
+    "moduleResolution": "node", //모듈 해석 방법 설정: 'node' (Node.js)
     "esModuleInterop": true,
-     "jsx": "react"
+    "typeRoots": ["./node_module/@types", "./types/express.d.ts"],
+    "jsx": "react"
   }
 }

--- a/server/types/express.d.ts
+++ b/server/types/express.d.ts
@@ -1,0 +1,5 @@
+declare namespace Express {
+  export interface Request {
+    userId: number;
+  }
+}

--- a/server/utils/token.ts
+++ b/server/utils/token.ts
@@ -1,8 +1,14 @@
-import jwt from "jsonwebtoken";
+import jwt, { JsonWebTokenError, TokenExpiredError } from "jsonwebtoken";
 import dotenv from "dotenv";
 import { ServerError } from "../middleware/errors";
+import { getRefreshToken } from "../db/context/token_context";
 
 dotenv.config();
+
+interface IToken extends jwt.JwtPayload {
+  userId: number;
+}
+
 export const makeAccessToken = (userId: number) => {
   const key = process.env.ACCESS_TOKEN_KEY;
   if (key) {
@@ -20,5 +26,49 @@ export const makeRefreshToken = (userId: number) => {
     return token;
   } else {
     throw ServerError.reference("키가 없습니다.");
+  }
+};
+
+export const verifyAccessToken = (token: string) => {
+  try {
+    const key = process.env.ACCESS_TOKEN_KEY;
+    if (!key) {
+      throw ServerError.reference("키가 없습니다.");
+    }
+    const verifiedToken = jwt.verify(token, key) as IToken;
+    return verifiedToken;
+  } catch (err: any) {
+    if (err instanceof TokenExpiredError) {
+      throw err;
+    } else if (err instanceof JsonWebTokenError) {
+      throw ServerError.tokenError("검증되지 않은 토큰 입니다.");
+    } else {
+      throw err;
+    }
+  }
+};
+
+export const verifyRefreshToken = async (token: string) => {
+  try {
+    const key = process.env.REFRESH_TOKEN_KEY;
+    if (key) {
+      const verifiedToken = jwt.verify(token, key) as IToken;
+      const userId = verifiedToken.userId;
+      const dbToken = await getRefreshToken(userId);
+      if (token !== dbToken) {
+        throw ServerError.tokenError("변조된 토큰 입니다.");
+      }
+      return verifiedToken;
+    } else {
+      throw ServerError.reference("키가 없습니다.");
+    }
+  } catch (err: any) {
+    if (err instanceof TokenExpiredError) {
+      throw ServerError.unauthorized("로그인이 필요합니다.");
+    } else if (err instanceof JsonWebTokenError) {
+      throw ServerError.tokenError("검증되지 않은 토큰 입니다.");
+    } else {
+      throw err;
+    }
   }
 };

--- a/server/utils/token.ts
+++ b/server/utils/token.ts
@@ -54,10 +54,7 @@ export const verifyRefreshToken = async (token: string) => {
     if (key) {
       const verifiedToken = jwt.verify(token, key) as IToken;
       const userId = verifiedToken.userId;
-      const dbToken = await getRefreshToken(userId);
-      if (token !== dbToken) {
-        throw ServerError.tokenError("변조된 토큰 입니다.");
-      }
+      await getRefreshToken(userId, token);
       return verifiedToken;
     } else {
       throw ServerError.reference("키가 없습니다.");


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#27

## 📝 작업 내용

- 로그인 하지 않았을 때(access token & refresh token 이 존재하지 않을 시)
  - 로그인이 필요한 api인 경우 -> requireLogin middleware 추가
  - 로그인이 필요하지 않은 api인 경우 -> 다음 함수 실행

- requireLogin middleware 기능
  - req.userId가 있을 경우 -> 다음 함수 실행
  - 없을 경우 -> "로그인 필요" 에러 반환

- 로그인 후 api 요청을 할 경우, access token 검증
  - 검증 성공 ->decode한 userId 정보 -> req.userId에 저장
  - 검증 실패 -> refresh token 검증
  - 에러가 expiredToken 일시 refreshtoken 검증
- refresh token 검증
  - 검증 성공 -> accress token 재발급
  - 검증 실패 -> 에러 반환
  - 에러가 expiredToken 일시 "로그인 필요" 에러 반환

## 💬 리뷰 요구사항
- error 핸들러쪽 고친게 많은거는 저희가 서로 탭 간격이 달라서 많이 수정 된 거 같습니다.
- Access 토큰 검증 후 refresh 토큰 검증하고 Access토큰 재발급 하는 부분에서 더 좋은 방법 없을까요?
- 사용했을 때 정상적으로 작동 안하면 말해주세요.
- 그 외 수정이 필요한 부분이나 다른 의견이 있으면 남겨 주세요.

## 추가 사항
- 로그인 필요한 api에는 requireLogin 미들웨어 추가하시면 됩니다.
- .env 파일에 REFRESH_TOKEN_KEY, ACCESS_TOKEN_KEY 추가 해야 됩니다. 저번 PR때 말씀 드렸어야 됐는데 죄송합니다.

