### PR TITLE
[BE] 댓글 수정 API 구현 및 댓글 API 일관성 향상

### DIFF
--- a/server/controller/comments_controller.ts
+++ b/server/controller/comments_controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
-import { createComment, getComments } from "../db/context/comment_context";
+import { createComment, readComments } from "../db/context/comments_context";
 
-export const getCommentsByPostId = async (
+export const handleCommentsRead = async (
   req: Request,
   res: Response,
   next: NextFunction
@@ -9,7 +9,7 @@ export const getCommentsByPostId = async (
   try {
     const postId = parseInt(req.params.post_id, 10);
 
-    const comments = await getComments(postId);
+    const comments = await readComments(postId);
 
     res.status(200).json({ comments });
   } catch (err) {
@@ -17,17 +17,15 @@ export const getCommentsByPostId = async (
   }
 };
 
-export const createCommentByPostId = async (
+export const handleCommentCreate = async (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
   try {
-    const postId = parseInt(req.params.post_id, 10);
-
     await createComment({
-      post_id: postId,
-      author_id: req.body.author_id,
+      post_id: parseInt(req.body.post_id, 10),
+      author_id: parseInt(req.body.author_id, 10), // TODO: 토큰 미들웨어 도입 시 req 객체에서 가져오기
       content: req.body.content,
     });
 

--- a/server/controller/comments_controller.ts
+++ b/server/controller/comments_controller.ts
@@ -1,5 +1,9 @@
 import { Request, Response, NextFunction } from "express";
-import { createComment, readComments } from "../db/context/comments_context";
+import {
+  createComment,
+  readComments,
+  updateComment,
+} from "../db/context/comments_context";
 
 export const handleCommentsRead = async (
   req: Request,
@@ -30,6 +34,24 @@ export const handleCommentCreate = async (
     });
 
     res.status(201).end();
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const handleCommentUpdate = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    await updateComment({
+      id: parseInt(req.body.id, 10),
+      author_id: parseInt(req.body.author_id, 10), // TODO: 토큰 미들웨어 도입 시 req 객체에서 가져오기
+      content: req.body.content,
+    });
+
+    res.status(200).end();
   } catch (err) {
     next(err);
   }

--- a/server/db/context/comments_context.ts
+++ b/server/db/context/comments_context.ts
@@ -9,6 +9,12 @@ interface ICommentInsertion {
   content: string;
 }
 
+interface ICommentUpdate {
+  id: number;
+  author_id: number;
+  content: string;
+}
+
 export const readComments = async (postId: number) => {
   let conn: PoolConnection | null = null;
 
@@ -96,6 +102,39 @@ export const createComment = async (commentInsertion: ICommentInsertion) => {
       throw ServerError.badRequest("작성자 ID의 자료형은 number이어야 합니다.");
     }
 
+    throw err;
+  } finally {
+    if (conn) conn.release();
+  }
+};
+
+export const updateComment = async (commentUpdate: ICommentUpdate) => {
+  let conn: PoolConnection | null = null;
+
+  const { id, author_id, content } = commentUpdate;
+
+  try {
+    const sql = `
+      UPDATE
+        comments
+      SET
+        content = ?
+      WHERE
+        id = ?
+        AND author_id = ?
+    `;
+    const values = [content, id, author_id];
+
+    conn = await pool.getConnection();
+    const [result]: [ResultSetHeader, FieldPacket[]] = await conn.query(
+      sql,
+      values
+    );
+
+    if (result.affectedRows === 0) {
+      throw ServerError.reference("댓글 수정 실패");
+    }
+  } catch (err) {
     throw err;
   } finally {
     if (conn) conn.release();

--- a/server/db/context/comments_context.ts
+++ b/server/db/context/comments_context.ts
@@ -9,7 +9,7 @@ interface ICommentInsertion {
   content: string;
 }
 
-export const getComments = async (postId: number) => {
+export const readComments = async (postId: number) => {
   let conn: PoolConnection | null = null;
 
   try {

--- a/server/route/comments_router.ts
+++ b/server/route/comments_router.ts
@@ -3,6 +3,7 @@ import { body, param } from "express-validator";
 import {
   handleCommentCreate,
   handleCommentsRead,
+  handleCommentUpdate,
 } from "../controller/comments_controller";
 import { validate } from "../middleware/validate";
 
@@ -32,10 +33,27 @@ const postCommentValidation = [
   validate,
 ];
 
+const patchCommentValidation = [
+  body("id")
+    .notEmpty()
+    .withMessage("댓글 ID를 입력해 주십시오.")
+    .bail()
+    .isInt({ min: 1 })
+    .withMessage("댓글 ID가 양의 정수가 아닙니다."),
+  body("content")
+    .notEmpty()
+    .withMessage("본문을 입력해 주십시오.")
+    .bail()
+    .isString()
+    .withMessage("본문이 문자열이 아닙니다."),
+  validate,
+];
+
 const router = express.Router();
 router.use(express.json());
 
 router.get("/:post_id", getCommentValidation, handleCommentsRead);
 router.post("/", postCommentValidation, handleCommentCreate);
+router.patch("/", patchCommentValidation, handleCommentUpdate);
 
 export default router;

--- a/server/route/comments_router.ts
+++ b/server/route/comments_router.ts
@@ -1,8 +1,8 @@
 import express from "express";
 import { body, param } from "express-validator";
 import {
-  createCommentByPostId,
-  getCommentsByPostId,
+  handleCommentCreate,
+  handleCommentsRead,
 } from "../controller/comments_controller";
 import { validate } from "../middleware/validate";
 
@@ -23,7 +23,7 @@ const postCommentValidation = [
     .bail()
     .isString()
     .withMessage("본문이 문자열이 아닙니다."),
-  param("post_id")
+  body("post_id")
     .notEmpty()
     .withMessage("게시글 ID를 입력해 주십시오.")
     .bail()
@@ -35,7 +35,7 @@ const postCommentValidation = [
 const router = express.Router();
 router.use(express.json());
 
-router.get("/:post_id", getCommentValidation, getCommentsByPostId);
-router.post("/:post_id", postCommentValidation, createCommentByPostId);
+router.get("/:post_id", getCommentValidation, handleCommentsRead);
+router.post("/", postCommentValidation, handleCommentCreate);
 
 export default router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#33

## 📝 작업 내용

일관성을 향상하는 작업은 댓글 API 구현 완료 후에 진행하려 했으나, 작업 시 혼동을 유발하여 먼저 작업했습니다.

- 댓글 수정 API 구현
  - [x] context: DB `comments` 테이블에서 `id`, `author_id` 컬럼이 주어진 값과 일치하는 레코드를 찾아서 댓글의 새 내용으로 갱신
  - [x] controller: 댓글 수정 요청 API 핸들러 작성: 성공 시 response 응답 (200 OK)
  - [x] router: `PATCH /api/comment` 엔드포인트 생성 및 request body 유효성 검사
    ```jsonc
    {
      id: number, // 양의 정수
      content: string, // 비어 있지 않은 문자열

      // 임시 필드: 토큰 검증 미들웨어 구현 후 제거 작업 필요
      author_id: number // 양의 정수
    }
    ```
- 댓글 API 일관성 향상
  - [x] 파일명 변경: `server/db/context/comment_context.ts` → <code>comment<mark>**s**</mark>_context.ts</code>
  - [x] API를 원래 명세대로 변경: `POST /api/comment/:post_id` → `POST /api/comment`
    - [x] `post_id` param을 body 객체의 필드로 이동
  - [x] 댓글 관련 controller, context의 함수 이름 정리

## 💬 리뷰 요구사항

- 잘못 구현된 부분 등, 이상한 부분이 있다면 말씀해 주세요.
- 더 나은 처리 방법, 함수명, request body 구성 등이 있다면 말씀해 주세요.