### PR TITLE
[BE] 댓글 삭제 API 구현

### DIFF
--- a/server/controller/comments_controller.ts
+++ b/server/controller/comments_controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import {
   createComment,
+  deleteComment,
   readComments,
   updateComment,
 } from "../db/context/comments_context";
@@ -49,6 +50,23 @@ export const handleCommentUpdate = async (
       id: parseInt(req.body.id, 10),
       author_id: parseInt(req.body.author_id, 10), // TODO: 토큰 미들웨어 도입 시 req 객체에서 가져오기
       content: req.body.content,
+    });
+
+    res.status(200).end();
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const handleCommentDelete = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    await deleteComment({
+      id: parseInt(req.body.id, 10),
+      author_id: parseInt(req.body.author_id, 10), // TODO: 토큰 미들웨어 도입 시 req 객체에서 가져오기
     });
 
     res.status(200).end();

--- a/server/route/comments_router.ts
+++ b/server/route/comments_router.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { body, param } from "express-validator";
 import {
   handleCommentCreate,
+  handleCommentDelete,
   handleCommentsRead,
   handleCommentUpdate,
 } from "../controller/comments_controller";
@@ -49,11 +50,22 @@ const patchCommentValidation = [
   validate,
 ];
 
+const deleteCommentValidation = [
+  body("id")
+    .notEmpty()
+    .withMessage("댓글 ID를 입력해 주십시오.")
+    .bail()
+    .isInt({ min: 1 })
+    .withMessage("댓글 ID가 양의 정수가 아닙니다."),
+  validate,
+];
+
 const router = express.Router();
 router.use(express.json());
 
 router.get("/:post_id", getCommentValidation, handleCommentsRead);
 router.post("/", postCommentValidation, handleCommentCreate);
 router.patch("/", patchCommentValidation, handleCommentUpdate);
+router.delete("/", deleteCommentValidation, handleCommentDelete);
 
 export default router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#39

## 📝 작업 내용

- 댓글 삭제 API 구현
  - [x] context: DB `comments` 테이블에서 `id`, `author_id` 컬럼이 주어진 값과 일치하고 `isDelete = FALSE`인 레코드를 찾아서 `isDelete` 컬럼을 `TRUE`로 변경
  - [x] controller: 댓글 삭제 요청 API 핸들러 작성: 성공 시 response 응답 (200 OK)
  - [x] router: `DELETE /api/comment` 엔드포인트 생성 및 request body 유효성 검사
    ```jsonc
    {
      id: number, // 양의 정수
      author_id: number // 양의 정수 (임시 필드: 토큰 검증 미들웨어 구현 후 제거 작업 필요)
    }
    ```

## 💬 리뷰 요구사항

잘못 구현된 부분, 이상한(이상해 보이는) 부분, 더 나은 처리 방법이나 명명법 등이 있다면 말씀해 주세요.