### PR TITLE
[BE] 댓글 작성, 수정, 삭제 API에 `requireLogin` 미들웨어 반영

### DIFF
--- a/server/controller/comments_controller.ts
+++ b/server/controller/comments_controller.ts
@@ -30,7 +30,7 @@ export const handleCommentCreate = async (
   try {
     await createComment({
       post_id: parseInt(req.body.post_id, 10),
-      author_id: parseInt(req.body.author_id, 10), // TODO: 토큰 미들웨어 도입 시 req 객체에서 가져오기
+      author_id: req.userId,
       content: req.body.content,
     });
 
@@ -48,7 +48,7 @@ export const handleCommentUpdate = async (
   try {
     await updateComment({
       id: parseInt(req.body.id, 10),
-      author_id: parseInt(req.body.author_id, 10), // TODO: 토큰 미들웨어 도입 시 req 객체에서 가져오기
+      author_id: req.userId,
       content: req.body.content,
     });
 
@@ -66,7 +66,7 @@ export const handleCommentDelete = async (
   try {
     await deleteComment({
       id: parseInt(req.body.id, 10),
-      author_id: parseInt(req.body.author_id, 10), // TODO: 토큰 미들웨어 도입 시 req 객체에서 가져오기
+      author_id: req.userId,
     });
 
     res.status(200).end();

--- a/server/db/context/comments_context.ts
+++ b/server/db/context/comments_context.ts
@@ -82,29 +82,11 @@ export const createComment = async (commentInsertion: ICommentInsertion) => {
       throw ServerError.etcError(500, "댓글을 등록하지 못했습니다.");
     }
   } catch (err: any) {
-    if (err?.code === "ER_NO_REFERENCED_ROW_2") {
-      const notFoundFields = [
-        { fieldDesc: "작성자 ID", columnName: "author_id" },
-        { fieldDesc: "게시글 ID", columnName: "post_id" },
-      ];
-
-      for (const field of notFoundFields) {
-        if (err?.sqlMessage?.includes(field.columnName)) {
-          throw ServerError.notFound(
-            `${field.fieldDesc} ${field.columnName}이(가) 존재하지 않습니다.`
-          );
-        }
-      }
-    } else if (
-      err?.code === "ER_BAD_NULL_ERROR" &&
-      (author_id === undefined || author_id === null)
+    if (
+      err?.code === "ER_NO_REFERENCED_ROW_2" &&
+      err?.sqlMessage?.includes("post_id")
     ) {
-      throw ServerError.badRequest("작성자 ID가 필요합니다.");
-    } else if (
-      err?.code === "ER_TRUNCATED_WRONG_VALUE_FOR_FIELD" &&
-      typeof author_id !== "number"
-    ) {
-      throw ServerError.badRequest("작성자 ID의 자료형은 number이어야 합니다.");
+      throw ServerError.notFound("게시글 ID가 존재하지 않습니다.");
     }
 
     throw err;

--- a/server/route/comments_router.ts
+++ b/server/route/comments_router.ts
@@ -6,6 +6,7 @@ import {
   handleCommentsRead,
   handleCommentUpdate,
 } from "../controller/comments_controller";
+import { requireLogin } from "../middleware/auth";
 import { validate } from "../middleware/validate";
 
 const getCommentValidation = [
@@ -64,8 +65,8 @@ const router = express.Router();
 router.use(express.json());
 
 router.get("/:post_id", getCommentValidation, handleCommentsRead);
-router.post("/", postCommentValidation, handleCommentCreate);
-router.patch("/", patchCommentValidation, handleCommentUpdate);
-router.delete("/", deleteCommentValidation, handleCommentDelete);
+router.post("/", requireLogin, postCommentValidation, handleCommentCreate);
+router.patch("/", requireLogin, patchCommentValidation, handleCommentUpdate);
+router.delete("/", requireLogin, deleteCommentValidation, handleCommentDelete);
 
 export default router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #45
- #34
- https://github.com/programmers-kdt-full-stack-3rd/community-board/pull/44#discussion_r1673454286

## 📝 작업 내용

- [x] 댓글 router에서 아래 라우팅의 유효성 검사 앞에 `requireLogin` 미들웨어 추가
  - `POST /api/comment`: 댓글 작성
  - `PATCH /api/comment`: 댓글 수정
  - `DELETE /api/comment`: 댓글 삭제
- [x] 댓글 controller의 아래 함수 본문에서, `author_id`를 request body 대신 `req.userId`에서 가져오기
  - `handleCommentCreate`: 댓글 작성
  - `handleCommentUpdate`: 댓글 수정
  - `handleCommentDelete`: 댓글 삭제
- [x] 댓글 context의 `createComment`에서 사용자 ID 관련 에러 메시지 정리

## 💬 리뷰 요구사항

- 로그인 여부의 우선순위가 다른 유효성 검사보다 더 먼저라고 판단해서 `requireLogin` 미들웨어를 유효성 검사보다 앞에 배치했습니다. 다른 의견 있으면 말씀해 주세요.
  - 이렇게 하면 클라이언트에서 다른 문제가 함께 발생했더라도(예: 댓글 작성 시 본문 누락) Unauthorized 에러 메시지를 우선적으로 받을 수 있습니다.
- 댓글 context의 `createComment` 함수에서 사용자 ID 관련 에러 처리가 지나치게 많이 삭제되었다면, 어느 부분을 되살리면 좋을지 의견 부탁드립니다.