### PR TITLE
[BE] 비밀번호 확인 API 구현

### DIFF
--- a/server/db/context/users_context.ts
+++ b/server/db/context/users_context.ts
@@ -133,3 +133,27 @@ export const updateUser = async (userData: IUpdateUserInfo) => {
     if (conn) conn.release();
   }
 };
+
+export const getUserById = async (userId: number) => {
+  let conn: PoolConnection | null = null;
+  try {
+    const sql = `SELECT * FROM users WHERE id = ? AND isDelete=FALSE`;
+    const value = [userId];
+
+    conn = await pool.getConnection();
+    const [rows]: [IUserAuthResult[], FieldPacket[]] = await conn.query(
+      sql,
+      value
+    );
+
+    if (rows.length === 0) {
+      throw ServerError.badRequest("존재하지 않은 회원 입니다.");
+    }
+
+    return rows[0];
+  } catch (err: any) {
+    throw err;
+  } finally {
+    if (conn) conn.release();
+  }
+};

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -3,6 +3,7 @@ import {
   makeAccessToken,
   verifyAccessToken,
   verifyRefreshToken,
+  verifyTempToken,
 } from "../utils/token";
 import { TokenExpiredError } from "jsonwebtoken";
 import { ServerError } from "./errors";
@@ -66,4 +67,19 @@ export const requireLogin = (
   next: NextFunction
 ) => {
   req.userId ? next() : next(ServerError.unauthorized("로그인이 필요합니다."));
+};
+
+export const requirePassword = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const tempToken = req.cookies.tempToken;
+  if (!tempToken) {
+    throw ServerError.unauthorized("비밀번호 확인이 필요합니다.");
+  }
+  verifyTempToken(tempToken);
+
+  res.clearCookie("tempToken");
+  next();
 };

--- a/server/route/users_router.ts
+++ b/server/route/users_router.ts
@@ -4,10 +4,11 @@ import {
   handleLogoutUser,
   handleJoinUser,
   handleUpdateUser,
+  handleCheckPassword,
 } from "../controller/users_controller";
 import { body } from "express-validator";
 import { validate } from "../middleware/validate";
-import { requireLogin } from "../middleware/auth";
+import { requireLogin, requirePassword } from "../middleware/auth";
 
 // Request body 유효성 검사
 const joinValidation = [
@@ -70,12 +71,38 @@ const updateUserInfoValidation = [
   validate,
 ];
 
+const checkPasswordValidation = [
+  body("password")
+    .notEmpty()
+    .withMessage("비밀번호를 입력해주십시오.")
+    .isStrongPassword({
+      minLength: 10,
+      minLowercase: 1,
+      minUppercase: 1,
+      minNumbers: 1,
+      minSymbols: 0,
+    })
+    .withMessage("비밀번호가 틀렸습니다."),
+];
+
 const router = express.Router();
 router.use(express.json());
 
 router.post("/join", joinValidation, handleJoinUser);
 router.post("/login", loginValidation, handleLoginUser);
 router.post("/logout", requireLogin, handleLogoutUser);
-router.put("/", updateUserInfoValidation, requireLogin, handleUpdateUser);
+router.put(
+  "/",
+  updateUserInfoValidation,
+  requireLogin,
+  requirePassword,
+  handleUpdateUser
+);
+router.post(
+  "/checkPassword",
+  checkPasswordValidation,
+  requireLogin,
+  handleCheckPassword
+);
 
 export default router;

--- a/server/route/users_router.ts
+++ b/server/route/users_router.ts
@@ -99,7 +99,7 @@ router.put(
   handleUpdateUser
 );
 router.post(
-  "/checkPassword",
+  "/check-password",
   checkPasswordValidation,
   requireLogin,
   handleCheckPassword


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #43
- #46 

## 📝 작업 내용

- [x] `POST /api/user/checkPassword` 엔드포인트 생성
- [x] Request body 유효성 검사
- [x] 비밀번호 검증
- [x] cookie에 tempToken 발행 (jwt 토큰)
- [x] tempToken 확인 미들웨어 구현


## 💬 리뷰 요구사항

- 토큰 발행하는 방식보다 더 적절한 방식 있을까요? 
- 잘못 구현된 부분이나 이상한 부분 있으면 말해주세요.