### PR TITLE
feat : server 작동 후 접속 -> client 화면 제공

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 package-lock.json
 .env
 
+dist
 test_case

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,5 +1,7 @@
-import express from "express";
+import express, { Request, Response } from "express";
 import dotenv from "dotenv";
+import path from "path";
+import cors from "cors";
 // router -----------------
 import apiRouter from "./route/route";
 // handelr ----------------
@@ -7,10 +9,18 @@ import { errorHandler } from "./middleware/errors";
 
 dotenv.config();
 const app = express();
+app.use(cors());
 
 // app 등록
 app.use("/api", apiRouter);
 app.use(errorHandler);
+
+// client 파일 제공
+app.use(express.static(`${__dirname}/../client/dist`));
+app.get(`*`, (req: Request, res: Response) => {
+  let indexPath = path.join(__dirname, "../client/dist/index.html");
+  res.sendFile(indexPath);
+});
 
 // listen
 app.listen(process.env.PORT, () => {

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.9",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-validator": "^7.1.0",
@@ -17,6 +18,7 @@
     "dev": "nodemon --watch \"*.ts\" --exec \"ts-node\" ./app.ts"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/jsonwebtoken": "^9.0.6"
   }
 }


### PR DESCRIPTION
## 📝 작업 내용

기존 : client와 server를 각각 npm run dev로 동작시키고 따로 테스트해야 했다.
개선 : 따라서 server만 구동시키면 client화면도 함께 확인할 수 있다.

세팅 방법
- client 디렉토리에서 npm run build
- server 구동
- localhost:{server_port}로 접속

작업 결과 : 서버 주소로 접속하면 client 화면을 제공한다.

### 🖼️ 스크린샷 (선택)
(표시된 주소는 서버 주소와 같다.)
<img width="500" alt="스크린샷 2024-07-11 오후 8 12 50" src="https://github.com/programmers-kdt-full-stack-3rd/community-board/assets/84065412/12ccba94-658a-4387-9882-86a62182b4a9">
## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 우선은 위와 같이 client와 server를 연결하는게 간단해서 작업했는데 혹시 nginx 같은 web server를 사용하고 싶으시면 의견주세요~
