### PR TITLE
[BE] 회원 탈퇴 API 구현

### DIFF
--- a/server/controller/users_controller.ts
+++ b/server/controller/users_controller.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import {
   addUser,
   authUser,
+  deleteUser,
   getUserById,
   updateUser,
 } from "../db/context/users_context";
@@ -118,6 +119,23 @@ export const handleCheckPassword = async (
     res.cookie("tempToken", tempToken, { maxAge: 1000 * 60 * 60 }); // 유효 기간 1시간
 
     res.status(200).json({ message: "비밀번호 확인 성공" });
+  } catch (err: any) {
+    next(err);
+  }
+};
+
+export const handleDeleteUser = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const userId = req.userId;
+    await deleteUser(userId);
+
+    res.clearCookie("accessToken");
+    res.clearCookie("refreshToken");
+    res.status(200).json({ message: "회원탈퇴 성공" });
   } catch (err: any) {
     next(err);
   }

--- a/server/controller/users_controller.ts
+++ b/server/controller/users_controller.ts
@@ -135,6 +135,7 @@ export const handleDeleteUser = async (
 
     res.clearCookie("accessToken");
     res.clearCookie("refreshToken");
+    await deleteRefreshToken(userId);
     res.status(200).json({ message: "회원탈퇴 성공" });
   } catch (err: any) {
     next(err);

--- a/server/db/context/token_context.ts
+++ b/server/db/context/token_context.ts
@@ -64,13 +64,18 @@ export const getRefreshToken = async (user_id: number, token: string) => {
 
 export const deleteRefreshToken = async (
   user_id: number,
-  refreshToken: string
+  refreshToken?: string
 ) => {
   let conn: PoolConnection | null = null;
 
   try {
-    const sql = `DELETE FROM refresh_tokens WHERE user_id = ? AND token = ?`;
-    const value = [user_id, refreshToken];
+    let sql = `DELETE FROM refresh_tokens WHERE user_id = ?`;
+    const value: [number, string?] = [user_id];
+
+    if (refreshToken) {
+      sql += ` AND token = ?`;
+      value.push(refreshToken);
+    }
 
     conn = await pool.getConnection();
     const [rows]: [ResultSetHeader, FieldPacket[]] = await conn.query(

--- a/server/db/context/users_context.ts
+++ b/server/db/context/users_context.ts
@@ -73,7 +73,7 @@ export const addUser = async (userData: IUserRegData) => {
 export const authUser = async (userData: IUserAuthData) => {
   let conn: PoolConnection | null = null;
   try {
-    const sql = `SELECT * FROM users WHERE email = ? AND isDelete=FALSE`;
+    const sql = `SELECT * FROM users WHERE email = ?`;
     const value = [userData.email];
 
     let accessToken: string;
@@ -90,6 +90,10 @@ export const authUser = async (userData: IUserAuthData) => {
     }
 
     const user: IUserAuthResult = rows[0];
+
+    if (user.isDelete) {
+      throw ServerError.badRequest("탈퇴한 회원입니다.");
+    }
 
     const hashedPassword: string = await makeHashedPassword(
       userData.password,

--- a/server/db/context/users_context.ts
+++ b/server/db/context/users_context.ts
@@ -157,3 +157,25 @@ export const getUserById = async (userId: number) => {
     if (conn) conn.release();
   }
 };
+
+export const deleteUser = async (userId: number) => {
+  let conn: PoolConnection | null = null;
+  try {
+    const sql = `UPDATE users SET isDelete=TRUE WHERE id=? AND isDelete=FALSE`;
+    const value = [userId];
+
+    conn = await pool.getConnection();
+    const [rows]: [ResultSetHeader, FieldPacket[]] = await conn.query(
+      sql,
+      value
+    );
+
+    if (rows.affectedRows === 0) {
+      throw ServerError.badRequest("회원 탈퇴 실패");
+    }
+  } catch (err: any) {
+    throw err;
+  } finally {
+    if (conn) conn.release();
+  }
+};

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -7,6 +7,7 @@ import {
 } from "../utils/token";
 import { TokenExpiredError } from "jsonwebtoken";
 import { ServerError } from "./errors";
+import { getUserById, isUserDeleted } from "../db/context/users_context";
 
 export const authToken = async (
   req: Request,
@@ -22,6 +23,10 @@ export const authToken = async (
     }
     //Access token 검증 로직
     const jwtPayload = verifyAccessToken(accessToken);
+
+    if (await isUserDeleted({ userId: jwtPayload.userId })) {
+      throw ServerError.badRequest("탈퇴한 회원입니다.");
+    }
     req.userId = jwtPayload.userId;
     next();
   } catch (err: any) {

--- a/server/route/users_router.ts
+++ b/server/route/users_router.ts
@@ -5,6 +5,7 @@ import {
   handleJoinUser,
   handleUpdateUser,
   handleCheckPassword,
+  handleDeleteUser,
 } from "../controller/users_controller";
 import { body } from "express-validator";
 import { validate } from "../middleware/validate";
@@ -104,5 +105,6 @@ router.post(
   requireLogin,
   handleCheckPassword
 );
+router.delete("/", requireLogin, requirePassword, handleDeleteUser);
 
 export default router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #42

## 📝 작업 내용

- [x] `DELETE : /api/user` 엔드포인트 생성
- [x] 비밀번호 확인 절차 거치기
- [x] 회원 정보 DB에 isDelete 수정
- [x] 성공 response 반환

## 💬 리뷰 요구사항
- 회원가입시 이미 탈퇴한 회원의 이메일 인 경우 일단 에러 처리 해놨는데요. 이 경우에 다른 처리 방법에 대한 아이디어 있을까요?

