### PR TITLE
[BE] 댓글 context의 DB 쿼리 보완

### DIFF
--- a/server/db/context/comments_context.ts
+++ b/server/db/context/comments_context.ts
@@ -45,6 +45,9 @@ export const readComments = async (postId: number) => {
       WHERE
         comments.isDelete = FALSE
         AND users.isDelete = FALSE
+      ORDER BY
+        comments.created_at,
+        comments.id
     `;
     const values = [postId];
 
@@ -109,6 +112,7 @@ export const updateComment = async (commentUpdate: ICommentUpdate) => {
       WHERE
         id = ?
         AND author_id = ?
+        AND isDelete = FALSE
     `;
     const values = [content, id, author_id];
 

--- a/server/db/context/comments_context.ts
+++ b/server/db/context/comments_context.ts
@@ -1,4 +1,9 @@
-import { FieldPacket, PoolConnection, ResultSetHeader } from "mysql2/promise";
+import {
+  FieldPacket,
+  PoolConnection,
+  ResultSetHeader,
+  RowDataPacket,
+} from "mysql2/promise";
 import { ServerError } from "../../middleware/errors";
 import pool from "../connect";
 import { mapDBToComments } from "../mapper/comments_mapper";
@@ -52,7 +57,10 @@ export const readComments = async (postId: number) => {
     const values = [postId];
 
     conn = await pool.getConnection();
-    const [rows]: any[] = await conn.query(sql, values);
+    const [rows]: [RowDataPacket[], FieldPacket[]] = await conn.query(
+      sql,
+      values
+    );
     return mapDBToComments(rows);
   } catch (err) {
     throw err;
@@ -123,6 +131,10 @@ export const updateComment = async (commentUpdate: ICommentUpdate) => {
     );
 
     if (result.affectedRows === 0) {
+      // 실패하는 상황
+      // - 존재하지 않는 댓글: 댓글 ID가 일치하는 레코드가 없음
+      // - 다른 사람의 댓글: 댓글의 작성자 ID가 일치하지 않음
+      // - 이미 삭제된 댓글: isDelete 컬럼이 TRUE
       throw ServerError.reference("댓글 수정 실패");
     }
   } catch (err) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #50

## 📝 작업 내용

- [x] 댓글 목록 조회 DB 쿼리에 `created_at` 오름차순 정렬 명시 (`ORDER BY comments.created_at, comments.id`)
  - `created_at` 컬럼으로만 정렬하면 [동시에 작성된 댓글의 순서는 보장되지 않으므로](https://stackoverflow.com/questions/6662837/how-does-mysql-order-rows-with-the-same-value), `id` 순서로도 정렬해야 합니다.
- [x] 댓글 수정 DB 쿼리에 누락된 `isDeleted = FALSE` 검사 추가
  - 이 내용은 삭제된 댓글의 수정을 방지합니다.

## 💬 리뷰 요구사항

- 댓글 목록 조회에서, `id`가 작성 순서와 일치하니 `id` 순서로 정렬해도 괜찮겠다는 생각도 했으나, 의미가 좀 더 직접적인 `created_at`으로 우선 정렬하도록 작성했습니다. 다른 의견 있으면 말씀해 주세요.