### PR TITLE
[BE] 댓글 API URL 변경 및 유효성 검사 리팩터링

### DIFF
--- a/server/controller/comments_controller.ts
+++ b/server/controller/comments_controller.ts
@@ -29,7 +29,7 @@ export const handleCommentCreate = async (
 ) => {
   try {
     await createComment({
-      post_id: parseInt(req.body.post_id, 10),
+      post_id: req.body.post_id,
       author_id: req.userId,
       content: req.body.content,
     });
@@ -47,7 +47,7 @@ export const handleCommentUpdate = async (
 ) => {
   try {
     await updateComment({
-      id: parseInt(req.body.id, 10),
+      id: req.body.id,
       author_id: req.userId,
       content: req.body.content,
     });

--- a/server/controller/comments_controller.ts
+++ b/server/controller/comments_controller.ts
@@ -12,7 +12,7 @@ export const handleCommentsRead = async (
   next: NextFunction
 ) => {
   try {
-    const postId = parseInt(req.params.post_id, 10);
+    const postId = parseInt(String(req.query.post_id), 10);
 
     const comments = await readComments(postId);
 
@@ -65,7 +65,7 @@ export const handleCommentDelete = async (
 ) => {
   try {
     await deleteComment({
-      id: parseInt(req.body.id, 10),
+      id: parseInt(req.params.comment_id, 10),
       author_id: req.userId,
     });
 

--- a/server/route/comments_router.ts
+++ b/server/route/comments_router.ts
@@ -1,5 +1,4 @@
 import express from "express";
-import { body, param, query } from "express-validator";
 import {
   handleCommentCreate,
   handleCommentDelete,
@@ -7,64 +6,17 @@ import {
   handleCommentUpdate,
 } from "../controller/comments_controller";
 import { requireLogin } from "../middleware/auth";
-import { validate } from "../middleware/validate";
-
-const getCommentValidation = [
-  query("post_id")
-    .notEmpty()
-    .withMessage("게시글 ID를 입력해 주십시오.")
-    .bail()
-    .isInt({ min: 1 })
-    .withMessage("게시글 ID가 양의 정수가 아닙니다."),
-  validate,
-];
-
-const postCommentValidation = [
-  body("content")
-    .notEmpty()
-    .withMessage("본문을 입력해 주십시오.")
-    .bail()
-    .isString()
-    .withMessage("본문이 문자열이 아닙니다."),
-  body("post_id")
-    .notEmpty()
-    .withMessage("게시글 ID를 입력해 주십시오.")
-    .bail()
-    .isInt({ min: 1 })
-    .withMessage("게시글 ID가 양의 정수가 아닙니다."),
-  validate,
-];
-
-const patchCommentValidation = [
-  body("id")
-    .notEmpty()
-    .withMessage("댓글 ID를 입력해 주십시오.")
-    .bail()
-    .isInt({ min: 1 })
-    .withMessage("댓글 ID가 양의 정수가 아닙니다."),
-  body("content")
-    .notEmpty()
-    .withMessage("본문을 입력해 주십시오.")
-    .bail()
-    .isString()
-    .withMessage("본문이 문자열이 아닙니다."),
-  validate,
-];
-
-const deleteCommentValidation = [
-  param("comment_id")
-    .notEmpty()
-    .withMessage("댓글 ID를 입력해 주십시오.")
-    .bail()
-    .isInt({ min: 1 })
-    .withMessage("댓글 ID가 양의 정수가 아닙니다."),
-  validate,
-];
+import {
+  deleteCommentValidation,
+  getCommentsValidation,
+  patchCommentValidation,
+  postCommentValidation,
+} from "../utils/validations/comments/comment";
 
 const router = express.Router();
 router.use(express.json());
 
-router.get("/", getCommentValidation, handleCommentsRead);
+router.get("/", getCommentsValidation, handleCommentsRead);
 router.post("/", requireLogin, postCommentValidation, handleCommentCreate);
 router.patch("/", requireLogin, patchCommentValidation, handleCommentUpdate);
 router.delete(

--- a/server/route/comments_router.ts
+++ b/server/route/comments_router.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { body, param } from "express-validator";
+import { body, param, query } from "express-validator";
 import {
   handleCommentCreate,
   handleCommentDelete,
@@ -10,7 +10,7 @@ import { requireLogin } from "../middleware/auth";
 import { validate } from "../middleware/validate";
 
 const getCommentValidation = [
-  param("post_id")
+  query("post_id")
     .notEmpty()
     .withMessage("게시글 ID를 입력해 주십시오.")
     .bail()
@@ -52,7 +52,7 @@ const patchCommentValidation = [
 ];
 
 const deleteCommentValidation = [
-  body("id")
+  param("comment_id")
     .notEmpty()
     .withMessage("댓글 ID를 입력해 주십시오.")
     .bail()
@@ -64,9 +64,14 @@ const deleteCommentValidation = [
 const router = express.Router();
 router.use(express.json());
 
-router.get("/:post_id", getCommentValidation, handleCommentsRead);
+router.get("/", getCommentValidation, handleCommentsRead);
 router.post("/", requireLogin, postCommentValidation, handleCommentCreate);
 router.patch("/", requireLogin, patchCommentValidation, handleCommentUpdate);
-router.delete("/", requireLogin, deleteCommentValidation, handleCommentDelete);
+router.delete(
+  "/:comment_id",
+  requireLogin,
+  deleteCommentValidation,
+  handleCommentDelete
+);
 
 export default router;

--- a/server/utils/validations/comments/comment.ts
+++ b/server/utils/validations/comments/comment.ts
@@ -1,14 +1,15 @@
 import { body, check, param, query } from "express-validator";
 import { validate } from "../../../middleware/validate";
+import { ERROR_MESSAGES } from "./constants";
 
 /** Request body의 댓글 본문 유효성 검사 */
 const bodyContentValidator = () =>
   body("content")
     .notEmpty()
-    .withMessage("본문을 입력해 주십시오.")
+    .withMessage(ERROR_MESSAGES.CONTENT_REQUIRED)
     .bail()
     .isString()
-    .withMessage("본문이 문자열이 아닙니다.");
+    .withMessage(ERROR_MESSAGES.INVALID_CONTENT);
 
 /**
  * 게시글 ID 유효성 검사
@@ -21,10 +22,10 @@ const postIdValidator = (
 ) =>
   checkFunction(name)
     .notEmpty()
-    .withMessage("게시글 ID를 입력해 주십시오.")
+    .withMessage(ERROR_MESSAGES.POST_ID_REQUIRED)
     .bail()
     .isInt({ min: 1 })
-    .withMessage("게시글 ID가 양의 정수가 아닙니다.");
+    .withMessage(ERROR_MESSAGES.INVALID_POST_ID);
 
 /**
  * 댓글 ID 유효성 검사
@@ -37,10 +38,10 @@ const commentIdValidator = (
 ) =>
   checkFunction(name)
     .notEmpty()
-    .withMessage("댓글 ID를 입력해 주십시오.")
+    .withMessage(ERROR_MESSAGES.COMMENT_ID_REQUIRED)
     .bail()
     .isInt({ min: 1 })
-    .withMessage("댓글 ID가 양의 정수가 아닙니다.");
+    .withMessage(ERROR_MESSAGES.INVALID_COMMENT_ID);
 
 /** 댓글 목록 조회 API 유효성 검사 */
 export const getCommentsValidation = [postIdValidator(query), validate];

--- a/server/utils/validations/comments/comment.ts
+++ b/server/utils/validations/comments/comment.ts
@@ -1,0 +1,63 @@
+import { body, check, param, query } from "express-validator";
+import { validate } from "../../../middleware/validate";
+
+/** Request body의 댓글 본문 유효성 검사 */
+const bodyContentValidator = () =>
+  body("content")
+    .notEmpty()
+    .withMessage("본문을 입력해 주십시오.")
+    .bail()
+    .isString()
+    .withMessage("본문이 문자열이 아닙니다.");
+
+/**
+ * 게시글 ID 유효성 검사
+ * @param checkFunction - 유효성 검사 함수 (`body`, `param`, `query`, ...)
+ * @param name - 필드명 (기본값: `"post_id"`)
+ */
+const postIdValidator = (
+  checkFunction: typeof check,
+  name: string = "post_id"
+) =>
+  checkFunction(name)
+    .notEmpty()
+    .withMessage("게시글 ID를 입력해 주십시오.")
+    .bail()
+    .isInt({ min: 1 })
+    .withMessage("게시글 ID가 양의 정수가 아닙니다.");
+
+/**
+ * 댓글 ID 유효성 검사
+ * @param checkFunction - 유효성 검사 함수 (`body`, `param`, `query`, ...)
+ * @param name 필드명 (기본값: `"comment_id"`)
+ */
+const commentIdValidator = (
+  checkFunction: typeof check,
+  name: string = "comment_id"
+) =>
+  checkFunction(name)
+    .notEmpty()
+    .withMessage("댓글 ID를 입력해 주십시오.")
+    .bail()
+    .isInt({ min: 1 })
+    .withMessage("댓글 ID가 양의 정수가 아닙니다.");
+
+/** 댓글 목록 조회 API 유효성 검사 */
+export const getCommentsValidation = [postIdValidator(query), validate];
+
+/** 댓글 등록 API 유효성 검사 */
+export const postCommentValidation = [
+  bodyContentValidator(),
+  postIdValidator(body),
+  validate,
+];
+
+/** 댓글 수정 API 유효성 검사 */
+export const patchCommentValidation = [
+  commentIdValidator(body, "id"),
+  bodyContentValidator(),
+  validate,
+];
+
+/** 댓글 삭제 API 유효성 검사 */
+export const deleteCommentValidation = [commentIdValidator(param), validate];

--- a/server/utils/validations/comments/constants.ts
+++ b/server/utils/validations/comments/constants.ts
@@ -1,0 +1,8 @@
+export const ERROR_MESSAGES = {
+  CONTENT_REQUIRED: "본문을 입력해 주십시오.",
+  INVALID_CONTENT: "본문이 문자열이 아닙니다.",
+  POST_ID_REQUIRED: "게시글 ID를 입력해 주십시오.",
+  INVALID_POST_ID: "게시글 ID가 양의 정수가 아닙니다.",
+  COMMENT_ID_REQUIRED: "댓글 ID를 입력해 주십시오.",
+  INVALID_COMMENT_ID: "댓글 ID가 양의 정수가 아닙니다.",
+} as const;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #55

## 📝 작업 내용

- 댓글 API URL 변경
  - **(1) 조회** → `GET /api/comment?post_id={}` ... `post_id`를 param에서 query로 옮김
  - ~~(2) 등록 → `POST /api/comment` ... 현재 구현 유지~~
  - ~~(3) 수정 → `PATCH /api/comment` ... 현재 구현 유지~~
  - **(4) 삭제** → `DELETE /api/comment/{comment_id}` ... `comment_id`를 body에서 param으로 옮김
- 댓글 API 유효성 검사를 router에서 추출
  - #56 과 같은 구조로 옮겼습니다.

## 💬 리뷰 요구사항

- 잘못되었거나 기타 수정이 필요한 부분 있으면 말씀해 주세요.