### PR TITLE
[BE] 게시글, 댓글 좋아요 API

### DIFF
--- a/server/controller/comments_controller.ts
+++ b/server/controller/comments_controller.ts
@@ -14,7 +14,7 @@ export const handleCommentsRead = async (
   try {
     const postId = parseInt(String(req.query.post_id), 10);
 
-    const comments = await readComments(postId);
+    const comments = await readComments(postId, req.userId);
 
     res.status(200).json({ comments });
   } catch (err) {

--- a/server/controller/likes_controller.ts
+++ b/server/controller/likes_controller.ts
@@ -2,22 +2,6 @@ import { Request, Response, NextFunction } from "express";
 import { createLike, deleteLike, readLikes } from "../db/context/likes_context";
 import { TLikeTarget } from "../db/model/likes";
 
-export const handleLikesReadWith =
-  <T extends TLikeTarget>(targetType: T) =>
-  async (req: Request, res: Response, next: NextFunction) => {
-    try {
-      const targetId = parseInt(req.params[`${targetType}_id`], 10);
-
-      const likes = await readLikes(targetType, targetId, req.userId);
-
-      res.status(200).json({
-        [`${targetType}_likes`]: likes,
-      });
-    } catch (err) {
-      next(err);
-    }
-  };
-
 export const handleLikeCreateWith =
   <T extends TLikeTarget>(targetType: T) =>
   async (req: Request, res: Response, next: NextFunction) => {
@@ -25,8 +9,11 @@ export const handleLikeCreateWith =
       const targetId = parseInt(req.params[`${targetType}_id`], 10);
 
       await createLike(targetType, targetId, req.userId);
+      const likes = await readLikes(targetType, targetId, req.userId);
 
-      res.status(201).end();
+      res.status(201).json({
+        [`${targetType}_likes`]: likes,
+      });
     } catch (err) {
       next(err);
     }
@@ -39,8 +26,11 @@ export const handleLikeDeleteWith =
       const targetId = parseInt(req.params[`${targetType}_id`], 10);
 
       await deleteLike(targetType, targetId, req.userId);
+      const likes = await readLikes(targetType, targetId, req.userId);
 
-      res.status(200).end();
+      res.status(200).json({
+        [`${targetType}_likes`]: likes,
+      });
     } catch (err) {
       next(err);
     }

--- a/server/controller/likes_controller.ts
+++ b/server/controller/likes_controller.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction } from "express";
+import { createLike, deleteLike, readLikes } from "../db/context/likes_context";
+import { TLikeTarget } from "../db/model/likes";
+
+export const handleLikesReadWith =
+  <T extends TLikeTarget>(targetType: T) =>
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const targetId = parseInt(req.params[`${targetType}_id`], 10);
+
+      const likes = await readLikes(targetType, targetId, req.userId);
+
+      res.status(200).json({
+        [`${targetType}_likes`]: likes,
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
+
+export const handleLikeCreateWith =
+  <T extends TLikeTarget>(targetType: T) =>
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const targetId = parseInt(req.params[`${targetType}_id`], 10);
+
+      await createLike(targetType, targetId, req.userId);
+
+      res.status(201).end();
+    } catch (err) {
+      next(err);
+    }
+  };
+
+export const handleLikeDeleteWith =
+  <T extends TLikeTarget>(targetType: T) =>
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const targetId = parseInt(req.params[`${targetType}_id`], 10);
+
+      await deleteLike(targetType, targetId, req.userId);
+
+      res.status(200).end();
+    } catch (err) {
+      next(err);
+    }
+  };

--- a/server/controller/likes_controller.ts
+++ b/server/controller/likes_controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { createLike, deleteLike, readLikes } from "../db/context/likes_context";
+import { createLike, deleteLike } from "../db/context/likes_context";
 import { TLikeTarget } from "../db/model/likes";
 
 export const handleLikeCreateWith =
@@ -9,11 +9,8 @@ export const handleLikeCreateWith =
       const targetId = parseInt(req.params[`${targetType}_id`], 10);
 
       await createLike(targetType, targetId, req.userId);
-      const likes = await readLikes(targetType, targetId, req.userId);
 
-      res.status(201).json({
-        [`${targetType}_likes`]: likes,
-      });
+      res.status(201).end();
     } catch (err) {
       next(err);
     }
@@ -26,11 +23,8 @@ export const handleLikeDeleteWith =
       const targetId = parseInt(req.params[`${targetType}_id`], 10);
 
       await deleteLike(targetType, targetId, req.userId);
-      const likes = await readLikes(targetType, targetId, req.userId);
 
-      res.status(200).json({
-        [`${targetType}_likes`]: likes,
-      });
+      res.status(200).end();
     } catch (err) {
       next(err);
     }

--- a/server/controller/posts_controller.ts
+++ b/server/controller/posts_controller.ts
@@ -47,7 +47,7 @@ export const handlePostRead = async (req : Request, res : Response, next : NextF
         if (isNaN(post_id)) {
             throw ServerError.badRequest("Invalid post ID");
         }
-        const post = await getPostInfo(post_id);
+        const post = await getPostInfo(post_id, req.userId);
         res.status(200).json({ post : post });
     } catch (err) {
         next(err);

--- a/server/db/context/comments_context.ts
+++ b/server/db/context/comments_context.ts
@@ -37,11 +37,7 @@ export const readComments = async (postId: number, userId?: number) => {
         users.nickname as author_nickname,
         comments.created_at as created_at,
         comments.updated_at as updated_at,
-        (
-          SELECT COUNT(DISTINCT comment_likes.user_id)
-          FROM comment_likes
-          WHERE comment_id = comments.id
-        ) AS likes,
+        (SELECT COUNT(*) FROM comment_likes WHERE comment_id = comments.id) AS likes,
         EXISTS(
           SELECT *
           FROM comment_likes

--- a/server/db/context/comments_context.ts
+++ b/server/db/context/comments_context.ts
@@ -37,7 +37,11 @@ export const readComments = async (postId: number) => {
         users.nickname as author_nickname,
         comments.created_at as created_at,
         comments.updated_at as updated_at,
-        (SELECT COUNT(*) FROM comment_likes WHERE comment_id = comments.id) AS likes
+        (
+          SELECT COUNT(DISTINCT comment_likes.user_id)
+          FROM comment_likes
+          WHERE comment_id = comments.id
+        ) AS likes
       FROM
         comments
       INNER JOIN

--- a/server/db/context/likes_context.ts
+++ b/server/db/context/likes_context.ts
@@ -1,0 +1,124 @@
+import {
+  FieldPacket,
+  PoolConnection,
+  ResultSetHeader,
+  RowDataPacket,
+} from "mysql2/promise";
+import { ServerError } from "../../middleware/errors";
+import pool from "../connect";
+import { likeTargetToName, mapDBToLikes } from "../mapper/likes_mapper";
+import { TLikeTarget } from "../model/likes";
+
+export const readLikes = async <T extends TLikeTarget>(
+  targetType: T,
+  targetId: number,
+  userId?: number
+) => {
+  let conn: PoolConnection | null = null;
+
+  try {
+    const sql = `
+      SELECT
+        COUNT(DISTINCT user_id) AS likes,
+        EXISTS(
+          SELECT *
+          FROM ${targetType}_likes
+          WHERE ${targetType}_id = ? AND user_id = ?
+        ) AS user_liked
+      FROM
+        ${targetType}_likes
+      WHERE
+        ${targetType}_id = ?
+    `;
+    const values = [targetId, userId, targetId];
+
+    conn = await pool.getConnection();
+    const [rows]: [RowDataPacket[], FieldPacket[]] = await conn.query(
+      sql,
+      values
+    );
+    return mapDBToLikes(targetType, targetId, rows[0]);
+  } catch (err) {
+    throw err;
+  } finally {
+    if (conn) conn.release();
+  }
+};
+
+export const createLike = async <T extends TLikeTarget>(
+  targetType: T,
+  targetId: number,
+  userId: number
+) => {
+  const targetTypeName = likeTargetToName[targetType];
+  let conn: PoolConnection | null = null;
+
+  try {
+    const sql = `
+      INSERT INTO
+        ${targetType}_likes (${targetType}_id, user_id)
+      VALUES
+        (?, ?)
+    `;
+    const values = [targetId, userId];
+
+    conn = await pool.getConnection();
+    const [result]: [ResultSetHeader, FieldPacket[]] = await conn.query(
+      sql,
+      values
+    );
+
+    if (result.affectedRows === 0) {
+      throw ServerError.etcError(500, `${targetTypeName} 좋아요 실패`);
+    }
+  } catch (err: any) {
+    if (
+      err?.code === "ER_NO_REFERENCED_ROW_2" &&
+      err?.sqlMessage?.includes(`${targetType}_id`)
+    ) {
+      throw ServerError.notFound(`${targetTypeName} ID가 존재하지 않습니다.`);
+    }
+
+    throw err;
+  } finally {
+    if (conn) conn.release();
+  }
+};
+
+export const deleteLike = async <T extends TLikeTarget>(
+  targetType: T,
+  targetId: number,
+  userId: number
+) => {
+  const targetTypeName = likeTargetToName[targetType];
+  let conn: PoolConnection | null = null;
+
+  try {
+    const sql = `
+      DELETE
+      FROM
+        ${targetType}_likes
+      WHERE
+        ${targetType}_id = ?
+        AND user_id = ?
+    `;
+    const values = [targetId, userId];
+
+    conn = await pool.getConnection();
+    const [result]: [ResultSetHeader, FieldPacket[]] = await conn.query(
+      sql,
+      values
+    );
+
+    if (result.affectedRows === 0) {
+      // 실패하는 상황
+      // - 존재하지 않는 target: target ID가 일치하는 레코드가 없음
+      // - target에 좋아요를 하지 않은 상태
+      throw ServerError.reference(`${targetTypeName} 좋아요 취소 실패`);
+    }
+  } catch (err) {
+    throw err;
+  } finally {
+    if (conn) conn.release();
+  }
+};

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -73,7 +73,7 @@ export const getPostHeaders = async ( queryString : IReadPostRequest ) => {
     }
 };
 
-export const getPostInfo = async (post_id : number) => {
+export const getPostInfo = async (post_id : number, user_id? : number) => {
     let conn : PoolConnection | null = null;
 
     try {
@@ -89,8 +89,13 @@ export const getPostInfo = async (post_id : number) => {
                         (
                             SELECT COUNT(DISTINCT pl.user_id)
                             FROM post_likes as pl
-                            WHERE post_id = p.id
-                        ) AS likes
+                            WHERE pl.post_id = p.id
+                        ) AS likes,
+                        EXISTS(
+                            SELECT *
+                            FROM post_likes AS pl
+                            WHERE pl.post_id = p.id AND pl.user_id = ?
+                        ) AS user_liked
                 FROM posts as p
                 LEFT JOIN users as u
                 ON p.author_id = u.id
@@ -100,7 +105,7 @@ export const getPostInfo = async (post_id : number) => {
         `;
 
         conn = await pool.getConnection();
-        const [rows] : any[] = await conn.query(sql, [post_id]);
+        const [rows] : any[] = await conn.query(sql, [user_id, post_id]);
 
         if(rows.length === 0) {
             throw ServerError.notFound("존재하지 않는 게시글입니다.");

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -22,7 +22,11 @@ export const getPostHeaders = async ( queryString : IReadPostRequest ) => {
                             p.title as title,
                             u.nickname as author_nickname,
                             p.created_at as created_at,
-                            (SELECT COUNT(*) FROM post_likes WHERE post_id = p.id) AS likes ${sharedSql}`; 
+                            (
+                                SELECT COUNT(DISTINCT pl.user_id)
+                                FROM post_likes as pl
+                                WHERE post_id = p.id
+                            ) AS likes ${sharedSql}`; 
 
         let countSql = `SELECT COUNT(*) as total ${sharedSql}`;
         
@@ -82,7 +86,11 @@ export const getPostInfo = async (post_id : number) => {
                         p.created_at,
                         p.updated_at,
                         p.views,
-                        (SELECT COUNT(*) FROM post_likes WHERE post_id = p.id) AS likes
+                        (
+                            SELECT COUNT(DISTINCT pl.user_id)
+                            FROM post_likes as pl
+                            WHERE post_id = p.id
+                        ) AS likes
                 FROM posts as p
                 LEFT JOIN users as u
                 ON p.author_id = u.id

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -22,11 +22,7 @@ export const getPostHeaders = async ( queryString : IReadPostRequest ) => {
                             p.title as title,
                             u.nickname as author_nickname,
                             p.created_at as created_at,
-                            (
-                                SELECT COUNT(DISTINCT pl.user_id)
-                                FROM post_likes as pl
-                                WHERE post_id = p.id
-                            ) AS likes ${sharedSql}`; 
+                            (SELECT COUNT(*) FROM post_likes WHERE post_id = p.id) AS likes ${sharedSql}`; 
 
         let countSql = `SELECT COUNT(*) as total ${sharedSql}`;
         
@@ -86,11 +82,7 @@ export const getPostInfo = async (post_id : number, user_id? : number) => {
                         p.created_at,
                         p.updated_at,
                         p.views,
-                        (
-                            SELECT COUNT(DISTINCT pl.user_id)
-                            FROM post_likes as pl
-                            WHERE pl.post_id = p.id
-                        ) AS likes,
+                        (SELECT COUNT(*) FROM post_likes WHERE post_id = p.id) AS likes,
                         EXISTS(
                             SELECT *
                             FROM post_likes AS pl

--- a/server/db/mapper/comments_mapper.ts
+++ b/server/db/mapper/comments_mapper.ts
@@ -8,6 +8,7 @@ export const mapDBToComments = (data: any[]): IComment[] => {
     author_nickname: item.author_nickname,
     created_at: new Date(item.created_at),
     updated_at: item.updated_at ? new Date(item.updated_at) : null,
-    likes: item.likes
+    likes: item.likes,
+    user_liked: !!item.user_liked,
   }));
 };

--- a/server/db/mapper/likes_mapper.ts
+++ b/server/db/mapper/likes_mapper.ts
@@ -1,16 +1,4 @@
-import { TLikes, TLikeTarget } from "../model/likes";
-
-export const mapDBToLikes = <T extends TLikeTarget = TLikeTarget>(
-  targetType: T,
-  targetId: number,
-  data: any
-): TLikes<T> => {
-  return {
-    [`${targetType}_id`]: targetId,
-    likes: data.likes,
-    user_liked: !!data.user_liked,
-  };
-};
+import { TLikeTarget } from "../model/likes";
 
 export const likeTargetToName: { [key in TLikeTarget]: string } = {
   post: "게시글",

--- a/server/db/mapper/likes_mapper.ts
+++ b/server/db/mapper/likes_mapper.ts
@@ -1,0 +1,18 @@
+import { TLikes, TLikeTarget } from "../model/likes";
+
+export const mapDBToLikes = <T extends TLikeTarget = TLikeTarget>(
+  targetType: T,
+  targetId: number,
+  data: any
+): TLikes<T> => {
+  return {
+    [`${targetType}_id`]: targetId,
+    likes: data.likes,
+    user_liked: !!data.user_liked,
+  };
+};
+
+export const likeTargetToName: { [key in TLikeTarget]: string } = {
+  post: "게시글",
+  comment: "댓글",
+};

--- a/server/db/mapper/posts_mapper.ts
+++ b/server/db/mapper/posts_mapper.ts
@@ -10,7 +10,8 @@ export const mapDBToPostInfo = (data : any) : IPostInfo => {
         created_at : new Date(data.created_at),
         updated_at : data.updated_at? new Date(data.updated_at) : null,
         views : data.views,
-        likes : data.likes
+        likes : data.likes,
+        user_liked : !!data.user_liked,
     };
 };
 

--- a/server/db/model/comments.ts
+++ b/server/db/model/comments.ts
@@ -6,4 +6,5 @@ export interface IComment {
   created_at: Date;
   updated_at?: Date | null;
   likes: number;
+  user_liked: boolean;
 }

--- a/server/db/model/likes.ts
+++ b/server/db/model/likes.ts
@@ -1,14 +1,1 @@
 export type TLikeTarget = "post" | "comment";
-
-interface ILikesSummary {
-  likes: number;
-  user_liked: boolean;
-}
-
-type TLikeTargetIdWrapper<T extends TLikeTarget> = {
-  [key in `${T}_id`]: number;
-};
-
-export type TLikes<T extends TLikeTarget> =
-  | ILikesSummary
-  | TLikeTargetIdWrapper<T>;

--- a/server/db/model/likes.ts
+++ b/server/db/model/likes.ts
@@ -1,0 +1,14 @@
+export type TLikeTarget = "post" | "comment";
+
+interface ILikesSummary {
+  likes: number;
+  user_liked: boolean;
+}
+
+type TLikeTargetIdWrapper<T extends TLikeTarget> = {
+  [key in `${T}_id`]: number;
+};
+
+export type TLikes<T extends TLikeTarget> =
+  | ILikesSummary
+  | TLikeTargetIdWrapper<T>;

--- a/server/db/model/posts.ts
+++ b/server/db/model/posts.ts
@@ -8,6 +8,7 @@ export interface IPostInfo {
     updated_at : Date | null;
     views : number;
     likes : number;
+    user_liked : boolean;
 }
 
 export interface IPostHeader {

--- a/server/db/sql/comments.sql
+++ b/server/db/sql/comments.sql
@@ -16,5 +16,6 @@ CREATE TABLE IF NOT EXISTS comment_likes (
     user_id INT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     FOREIGN KEY (comment_id) REFERENCES comments(id),
-    FOREIGN KEY (user_id) REFERENCES users(id)
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    UNIQUE KEY (comment_id, user_id)
 );

--- a/server/db/sql/posts.sql
+++ b/server/db/sql/posts.sql
@@ -16,5 +16,6 @@ CREATE TABLE IF NOT EXISTS post_likes (
     user_id INT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     FOREIGN KEY (post_id) REFERENCES posts(id),
-    FOREIGN KEY (user_id) REFERENCES users(id)
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    UNIQUE KEY (post_id, user_id)
 );

--- a/server/route/likes_router.ts
+++ b/server/route/likes_router.ts
@@ -3,7 +3,6 @@ import { requireLogin } from "../middleware/auth";
 import {
   handleLikeCreateWith,
   handleLikeDeleteWith,
-  handleLikesReadWith,
 } from "../controller/likes_controller";
 import { likeValidationWith } from "../utils/validations/likes/like";
 
@@ -12,7 +11,6 @@ router.use(express.json());
 
 router
   .route("/post/:post_id")
-  .get(likeValidationWith("post"), handleLikesReadWith("post"))
   .post(requireLogin, likeValidationWith("post"), handleLikeCreateWith("post"))
   .delete(
     requireLogin,
@@ -22,7 +20,6 @@ router
 
 router
   .route("/comment/:comment_id")
-  .get(likeValidationWith("comment"), handleLikesReadWith("comment"))
   .post(
     requireLogin,
     likeValidationWith("comment"),

--- a/server/route/likes_router.ts
+++ b/server/route/likes_router.ts
@@ -1,0 +1,37 @@
+import express from "express";
+import { requireLogin } from "../middleware/auth";
+import {
+  handleLikeCreateWith,
+  handleLikeDeleteWith,
+  handleLikesReadWith,
+} from "../controller/likes_controller";
+import { likeValidationWith } from "../utils/validations/likes/like";
+
+const router = express.Router();
+router.use(express.json());
+
+router
+  .route("/post/:post_id")
+  .get(likeValidationWith("post"), handleLikesReadWith("post"))
+  .post(requireLogin, likeValidationWith("post"), handleLikeCreateWith("post"))
+  .delete(
+    requireLogin,
+    likeValidationWith("post"),
+    handleLikeDeleteWith("post")
+  );
+
+router
+  .route("/comment/:comment_id")
+  .get(likeValidationWith("comment"), handleLikesReadWith("comment"))
+  .post(
+    requireLogin,
+    likeValidationWith("comment"),
+    handleLikeCreateWith("comment")
+  )
+  .delete(
+    requireLogin,
+    likeValidationWith("comment"),
+    handleLikeDeleteWith("comment")
+  );
+
+export default router;

--- a/server/route/route.ts
+++ b/server/route/route.ts
@@ -3,7 +3,7 @@ import { doTest, doTest2 } from "../controller/testController";
 import postRouter from "./posts_router";
 import userRouter from "./users_router";
 import commentRouter from "./comments_router";
-
+import likeRouter from "./likes_router";
 
 const router = express.Router();
 router.use(express.json());
@@ -12,6 +12,7 @@ router.use(express.json());
 router.use("/post", postRouter);
 router.use("/comment", commentRouter);
 router.use("/user", userRouter);
+router.use("/like", likeRouter);
 
 // 테스팅 api -> 추후 삭제
 router.get("/test", doTest);

--- a/server/utils/validations/likes/constants.ts
+++ b/server/utils/validations/likes/constants.ts
@@ -1,0 +1,9 @@
+import { likeTargetToName } from "../../../db/mapper/likes_mapper";
+import { TLikeTarget } from "../../../db/model/likes";
+
+export const ERROR_MESSAGES = {
+  TARGET_ID_REQUIRED: (targetType: TLikeTarget) =>
+    `${likeTargetToName[targetType]} ID를 입력해 주십시오.`,
+  INVALID_TARGET_ID: (targetType: TLikeTarget) =>
+    `${likeTargetToName[targetType]} ID가 양의 정수가 아닙니다.`,
+} as const;

--- a/server/utils/validations/likes/like.ts
+++ b/server/utils/validations/likes/like.ts
@@ -1,0 +1,14 @@
+import { param } from "express-validator";
+import { validate } from "../../../middleware/validate";
+import { TLikeTarget } from "../../../db/model/likes";
+import { ERROR_MESSAGES } from "./constants";
+
+export const likeValidationWith = (targetType: TLikeTarget) => [
+  param(`${targetType}_id`)
+    .notEmpty()
+    .withMessage(ERROR_MESSAGES.TARGET_ID_REQUIRED(targetType))
+    .bail()
+    .isInt({ min: 1 })
+    .withMessage(ERROR_MESSAGES.INVALID_TARGET_ID(targetType)),
+  validate,
+];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #62

## 📝 작업 내용

- [x] API 명세 결정
- [x] 응답 모델 정의
- [x] 매퍼 구현
- [x] 게시글 좋아요 DB context 작성 (좋아요 개수 조회, 활성화, 취소)
- [x] DB context 함수 일반화 (댓글 좋아요까지 확장)
  - 게시글 좋아요와 댓글 좋아요의 테이블 구조가 동일하여 컬럼명만 바꾸면 그대로 사용할 수 있습니다.
- [x] 좋아요 controller 작성
- [x] 좋아요 API 라우팅 및 유효성 검사 등록
- [x] **게시글, 댓글 API의 context에서 좋아요 중복 카운트 해소**

### 💡 참고: 게시글·댓글 좋아요 API 명세

> - 게시글 좋아요
>   - ~~조회: `GET /api/like/post/{post_id}`~~
>   - 활성화: `POST /api/like/post/{post_id}`
>   - 취소: `DELETE /api/like/post/{post_id}`
>   - 응답 본문
>     ```typescript
>     {
>       post_id: number,
>       likes: number,
>       user_liked: boolean // 비로그인 시 항상 false
>     }
>     ```
> - 댓글 좋아요
>   - ~~조회: `GET /api/like/comment/{comment_id}`~~
>   - 활성화: `POST /api/like/comment/{comment_id}`
>   - 취소: `DELETE /api/like/comment/{comment_id}`
>   - 응답 본문
>     ```typescript
>     {
>       comment_id: number,
>       likes: number,
>       user_liked: boolean // 비로그인 시 항상 false
>     }
>     ```
> - 모두 로그인 필요

## 💬 리뷰 요구사항

- 게시글과 댓글 좋아요 테이블이 테이블명(`*_likes`)과 컬럼명 하나(`*_id`) 제외하고는 동일하고 규칙적이어서, 코드 중복을 줄이기 위해 일반화를 했습니다.
  - 더 나은(더 간결하거나 읽기 좋은) 구현 방법이 있다면 제안 부탁드립니다.
- 잘못되었거나 기타 수정이 필요한 부분 있으면 말씀해 주세요.
- 질문: 좋아요 활성화/취소 응답 본문을 안 넣었는데, 동작 이후에 좋아요를 새로 조회한 결과를 실어서 보낼까요?
