### PR TITLE
Feature/pagenation api

### DIFF
--- a/server/controller/posts_controller.ts
+++ b/server/controller/posts_controller.ts
@@ -34,7 +34,8 @@ export const handlePostsRead = async (req : Request, res : Response, next : Next
         console.log(values);
 
         const posts = await getPostHeaders(values);
-        res.json({ posts });
+        
+        res.json({ total : posts.total, postHeaders : posts.postHeaders });
     }catch(err){
         next(err);
     }

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -9,41 +9,57 @@ export const getPostHeaders = async ( queryString : IReadPostRequest ) => {
     let conn: PoolConnection | null = null;
 
     try {
-        let values : (number | string)[] = [];
+        let dataValues : (number | string)[] = [];
+        let countValues : (number | string)[] = [];
 
-        let sql = `SELECT p.id as id, 
-                            p.title as title,
-                            u.nickname as author_nickname,
-                            p.created_at as created_at,
-                            (SELECT COUNT(*) FROM post_likes WHERE post_id = p.id) AS likes
-                        FROM posts as p
+        let sharedSql = ` FROM posts as p
                         LEFT JOIN users as u
                         ON p.author_id = u.id
                         WHERE p.isDelete = FALSE
                         AND u.isDelete = FALSE`;
         
+        let dataSql = `SELECT p.id as id, 
+                            p.title as title,
+                            u.nickname as author_nickname,
+                            p.created_at as created_at,
+                            (SELECT COUNT(*) FROM post_likes WHERE post_id = p.id) AS likes ${sharedSql}`; 
+
+        let countSql = `SELECT COUNT(*) as total ${sharedSql}`;
+        
         if (queryString.keyword){
-            values.push(`%${queryString.keyword}%`);
-            sql += ` AND p.content LIKE ?`
+            dataValues.push(`%${queryString.keyword}%`);
+            countValues.push(`%${queryString.keyword}%`);
+            dataSql += ` AND p.content LIKE ?`;
+            countSql += ` AND p.content LIKE ?`;
         }
 
         if (queryString.sortBy === SortBy.LIKES) {
-            sql += ` ORDER BY likes DESC`
+            dataSql += ` ORDER BY likes DESC`;
         } else if (queryString.sortBy === SortBy.VIEWS) {
-            sql += ` ORDER BY views DESC`
+            dataSql += ` ORDER BY views DESC`;
         } else {
-            sql += ` ORDER BY created_at DESC`;
+            dataSql += ` ORDER BY created_at DESC`;
         }
 
-        sql+= `, u.id ASC`
+        dataSql += `, u.id ASC`
 
-        sql += ' LIMIT ? OFFSET ?';
-        values.push(queryString.perPage);
-        values.push(queryString.index * queryString.perPage);
+        dataSql += ' LIMIT ? OFFSET ?';
+        dataValues.push(queryString.perPage);
+        dataValues.push(queryString.index * queryString.perPage);
 
+        // pagenation
         conn = await pool.getConnection();
-        const [rows] : any[] = await conn.query(sql, values);
-        return mapDBToPostHeaders(rows);
+
+        const [countRows]: any[] = await conn.query(countSql, countValues);
+        const total = countRows[0].total;
+
+        const [dataRows] : any[] = await conn.query(dataSql, dataValues);
+        const postHeaders = mapDBToPostHeaders(dataRows);
+        
+        return {
+            total,
+            postHeaders
+        }
     } catch (err) {
         console.log(err);
         throw err;

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -27,10 +27,11 @@ export const getPostHeaders = async ( queryString : IReadPostRequest ) => {
         let countSql = `SELECT COUNT(*) as total ${sharedSql}`;
         
         if (queryString.keyword){
-            dataValues.push(`%${queryString.keyword}%`);
-            countValues.push(`%${queryString.keyword}%`);
-            dataSql += ` AND p.content LIKE ?`;
-            countSql += ` AND p.content LIKE ?`;
+            const keyword = `%${queryString.keyword.trim()}%`;
+            dataValues.push(keyword);
+            countValues.push(keyword);
+            dataSql += ` AND p.title LIKE ?`;
+            countSql += ` AND p.title LIKE ?`;
         }
 
         if (queryString.sortBy === SortBy.LIKES) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#65 

## 📝 작업 내용

- [x] postHeaders를 가져오던 api의 response에 total (총 page 수) 추가
- [x] postHeaders context에 페이지 수를 세는 count sql 추가
- 기존 게시글 목록 불러오는 sql에서 keyword를 게시글 내용과 비교했던 논리적 오류가 있었음
    - 게시글 목록에서는 게시글 제목만 볼 수 있기 때문에 default로 게시글 제목과 title을 비교하도록 변경  

## 💬 리뷰 요구사항(선택)

기존에 있던 api에 sql을 추가하는 방식으로 구현했는데 혹시 다른 추천 방식이 있을까요?
api를 2개로 나누지 않은 이유는 게시글 목록을 불러올 때마다 api 요청을 2번씩 보내는게 비효율적이라고 판단해서 입니다.
