### PR TITLE
[FE] 게시글 생성/수정 모달

### DIFF
--- a/client/src/App.css.ts
+++ b/client/src/App.css.ts
@@ -15,7 +15,8 @@ export const vars = createGlobalTheme(":root", {
         secondaryDarkTextHover : "rgb(218,219,225)",
         selectedTab : "rgb(137,176,173)",
         updatedButton : "rgb(237,180,88)",
-        deleteButton : "rgb(237,51,88)"
+        deleteButton : "rgb(237,51,88)",
+        successButton : "#36B700"
     },
     fontSizing : {
         T1:"32px",

--- a/client/src/api/posts/crud.ts
+++ b/client/src/api/posts/crud.ts
@@ -1,4 +1,4 @@
-import { HttpMethod, httpRequest } from "../api"
+import { HttpMethod, convertToBody, httpRequest } from "../api"
 
 export const sendGetPostsRequest = async (query? : string) => {
     const url = query ? `post${query}` : `post`;
@@ -9,4 +9,15 @@ export const sendGetPostsRequest = async (query? : string) => {
 export const sendGetPostRequest = async (param : string) => {
     const url = `post/${param}`
     return await httpRequest(url, HttpMethod.GET);
+}
+
+export const sendCreatePostRequest = async (body : object) => {
+    const requestBody = convertToBody(body);
+    return await httpRequest(`post`, HttpMethod.POST, requestBody);
+}
+
+export const sendUpdatePostRequest = async (postId: number, body : object) => {
+    const url = `post/${postId}`
+    const requestBody = convertToBody(body);
+    return await httpRequest(url, HttpMethod.PATCH, requestBody);
 }

--- a/client/src/component/Posts/Modal/PostModal.css.ts
+++ b/client/src/component/Posts/Modal/PostModal.css.ts
@@ -1,0 +1,89 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "../../../App.css.ts";
+
+export const ModalContainer = style({
+    position : "absolute",
+    top : "50%",
+    left : "50%",
+    transform : "translate(-50%, -50%)",
+    width : "600px",
+    height : "600px",
+    background : vars.color.task,
+    borderRadius : "5px",
+    textAlign : "center"
+});
+
+export const ModalHeader = style({
+    display : 'flex',
+    justifyContent : "space-between",
+    flexDirection : "row",
+    height : "fit-content",
+    flexWrap : "wrap",
+    margin : 15
+});
+
+export const ModalBody = style({
+    display : 'flex',
+    flexDirection : "column",
+    alignItems : "center",
+    flexWrap : "wrap",
+    width : "fit",
+    height : "100%",
+    rowGap : 15,
+    margin : "20px"
+});
+
+export const PostHeaderTitle = style({
+    display : 'flex',
+    justifyContent : "center",
+    alignItems : "center",
+    color : vars.color.darkText,
+    fontWeight : "bold"
+});
+
+export const PostBtn = style({
+    backgroundColor : vars.color.successButton,
+    color : vars.color.brightText
+});
+
+export const CloseBtn = style({
+    backgroundColor : vars.color.brightText,
+    borderColor : vars.color.deleteButton,
+    color : vars.color.deleteButton
+});
+
+export const InputContainer = style({
+    display : 'flex',
+    flexDirection : "column",
+    width : "100%"
+});
+
+export const InputIndex = style({
+    display : 'flex',
+    alignItems : "center",
+    fontWeight : "bolder",
+    color : vars.color.darkText,
+    marginLeft : 10,
+    marginBottom : 10,
+    "::placeholder" : {
+    }
+});
+
+export const TitleInput = style({
+    backgroundColor : vars.color.brightText,
+    color : vars.color.darkText,
+    resize : "none",
+    borderRadius : 5,
+    padding : 10,
+    border : `1px solid ${vars.color.secondaryDarkText}`,
+    boxShadow : "none"
+});
+
+export const ContentTextArea = style({
+    backgroundColor : vars.color.brightText,
+    color : vars.color.darkText,
+    height : "350px",
+    resize : "none",
+    borderRadius : 5,
+    padding : 10
+});

--- a/client/src/component/Posts/Modal/PostModal.tsx
+++ b/client/src/component/Posts/Modal/PostModal.tsx
@@ -1,0 +1,40 @@
+import { SetStateAction, useState } from 'react'
+import { CloseBtn, ContentTextArea, InputContainer, InputIndex, ModalBody, ModalContainer, ModalHeader, PostBtn, PostHeaderTitle, TitleInput } from './PostModal.css'
+
+interface PostModalProps {
+    close : React.Dispatch<SetStateAction<boolean>>;
+}
+
+const PostModal : React.FC<PostModalProps> = ({ close }) => {
+    const [title, setTitle] = useState("");
+    const [content, setContent] = useState("");
+
+
+    return (
+        <div className={ModalContainer}>
+            <div className={ModalHeader}>
+                <button className={PostBtn} onClick={()=>close(false)}>생성</button>
+                <div className={PostHeaderTitle}>게시글 생성</div>
+                <button className={CloseBtn} onClick={()=>close(false)}>취소</button>
+            </div>
+            <div className={ModalBody}>
+                <div className={InputContainer}>
+                    <div className={InputIndex}>제목</div>
+                    <input className={TitleInput}
+                        value={title}
+                        onChange={(e)=>setTitle(e.target.value)}
+                        placeholder='제목을 입력해주세요'></input>
+                </div>
+                <div className={InputContainer}>
+                    <div className={InputIndex}>내용</div>
+                    <textarea className={ContentTextArea}
+                        value={content}
+                        onChange={(e)=>setContent(e.target.value)}
+                        placeholder='내용을 입력해주세요'></textarea>
+                </div>
+            </div> 
+        </div>
+    );
+}
+
+export default PostModal

--- a/client/src/component/Posts/Modal/PostModal.tsx
+++ b/client/src/component/Posts/Modal/PostModal.tsx
@@ -1,20 +1,66 @@
 import { SetStateAction, useState } from 'react'
 import { CloseBtn, ContentTextArea, InputContainer, InputIndex, ModalBody, ModalContainer, ModalHeader, PostBtn, PostHeaderTitle, TitleInput } from './PostModal.css'
+import { sendCreatePostRequest, sendUpdatePostRequest } from '../../../api/posts/crud';
+
+export interface PostData {
+    id : number;
+    title : string;
+    content : string;
+}
 
 interface PostModalProps {
     close : React.Dispatch<SetStateAction<boolean>>;
+    originalPostData? : PostData
 }
 
-const PostModal : React.FC<PostModalProps> = ({ close }) => {
-    const [title, setTitle] = useState("");
-    const [content, setContent] = useState("");
+const PostModal : React.FC<PostModalProps> = ({ close, originalPostData }) => {
+    const isUpdateMode = originalPostData !== undefined;
 
+    const modalTitle = isUpdateMode ? "수정" : "생성";
+
+    const [title, setTitle] = useState(isUpdateMode ? originalPostData.title : "");
+    const [content, setContent] = useState(isUpdateMode ? originalPostData.content : "");
+
+    const createPost = () => {
+        const body = {
+            title,
+            content
+        };
+
+        sendCreatePostRequest(body).then((res)=>{
+            console.log(res);
+        })
+    };
+
+    const updatePost = () => {
+        if (!originalPostData){
+            return;
+        }
+
+        const body = {
+            title,
+            content
+        };
+
+        const postId : number = originalPostData.id;
+
+        sendUpdatePostRequest(postId, body).then((res)=>{
+            console.log(res);
+        })
+    };
 
     return (
         <div className={ModalContainer}>
             <div className={ModalHeader}>
-                <button className={PostBtn} onClick={()=>close(false)}>생성</button>
-                <div className={PostHeaderTitle}>게시글 생성</div>
+                <button className={PostBtn}
+                        onClick={()=>{
+                            if(isUpdateMode){
+                                updatePost();
+                            } else {
+                                createPost();
+                            }
+                        }}>생성</button>
+                <div className={PostHeaderTitle}>게시글 {modalTitle}</div>
                 <button className={CloseBtn} onClick={()=>close(false)}>취소</button>
             </div>
             <div className={ModalBody}>

--- a/client/src/component/Posts/Modal/PostModal.tsx
+++ b/client/src/component/Posts/Modal/PostModal.tsx
@@ -16,7 +16,7 @@ interface PostModalProps {
 const PostModal : React.FC<PostModalProps> = ({ close, originalPostData }) => {
     const isUpdateMode = originalPostData !== undefined;
 
-    const modalTitle = isUpdateMode ? "수정" : "생성";
+    const modalMode = isUpdateMode ? "수정" : "생성";
 
     const [title, setTitle] = useState(isUpdateMode ? originalPostData.title : "");
     const [content, setContent] = useState(isUpdateMode ? originalPostData.content : "");
@@ -59,8 +59,9 @@ const PostModal : React.FC<PostModalProps> = ({ close, originalPostData }) => {
                             } else {
                                 createPost();
                             }
-                        }}>생성</button>
-                <div className={PostHeaderTitle}>게시글 {modalTitle}</div>
+                            close(false);
+                        }}>{modalMode}</button>
+                <div className={PostHeaderTitle}>게시글 {modalMode}</div>
                 <button className={CloseBtn} onClick={()=>close(false)}>취소</button>
             </div>
             <div className={ModalBody}>

--- a/client/src/component/Posts/Modal/PostModal.tsx
+++ b/client/src/component/Posts/Modal/PostModal.tsx
@@ -2,18 +2,18 @@ import { SetStateAction, useState } from 'react'
 import { CloseBtn, ContentTextArea, InputContainer, InputIndex, ModalBody, ModalContainer, ModalHeader, PostBtn, PostHeaderTitle, TitleInput } from './PostModal.css'
 import { sendCreatePostRequest, sendUpdatePostRequest } from '../../../api/posts/crud';
 
-export interface PostData {
+interface IPostData {
     id : number;
     title : string;
     content : string;
 }
 
-interface PostModalProps {
+interface IPostModalProps {
     close : React.Dispatch<SetStateAction<boolean>>;
-    originalPostData? : PostData
+    originalPostData? : IPostData
 }
 
-const PostModal : React.FC<PostModalProps> = ({ close, originalPostData }) => {
+const PostModal : React.FC<IPostModalProps> = ({ close, originalPostData }) => {
     const isUpdateMode = originalPostData !== undefined;
 
     const modalMode = isUpdateMode ? "수정" : "생성";

--- a/client/src/component/Posts/Posts.tsx
+++ b/client/src/component/Posts/Posts.tsx
@@ -5,6 +5,8 @@ import PostModal from "./Modal/PostModal";
 
 const Posts = () => {
   const [openModal, setOpenModal] = useState<boolean>(false);
+  const [openUpdateModal, setOpenUpdateModal] = useState<boolean>(false);
+
 
   const getPosts = () => {
     const query = `?index=1&perPage=5&sortBy=`+SortBy.LIKES;
@@ -20,10 +22,18 @@ const Posts = () => {
     });
   };
 
+  const testPostData = {
+    id : 1,
+    title : "히히",
+    content : "길낄"
+  }
+
   return (
     <div>
       {openModal ? <PostModal close={setOpenModal}/> : null}
-      <button onClick={()=>setOpenModal(true)}>모달 띄우기</button>
+      {openUpdateModal ? <PostModal close={setOpenUpdateModal} originalPostData={testPostData}/> : null}
+      <button onClick={()=>setOpenModal(true)}>생성 모달 띄우기</button>
+      <button onClick={()=>setOpenUpdateModal(true)}>수정 모달 띄우기</button>
       <button onClick={getPosts}>게시글 목록 불러오기</button>
       <button onClick={getPost}>게시글 내용 보기</button>
     </div>

--- a/client/src/component/Posts/Posts.tsx
+++ b/client/src/component/Posts/Posts.tsx
@@ -1,7 +1,10 @@
 import { SortBy } from "shared";
 import { sendGetPostRequest, sendGetPostsRequest } from "../../api/posts/crud";
+import { useState } from "react";
+import PostModal from "./Modal/PostModal";
 
 const Posts = () => {
+  const [openModal, setOpenModal] = useState<boolean>(false);
 
   const getPosts = () => {
     const query = `?index=1&perPage=5&sortBy=`+SortBy.LIKES;
@@ -19,6 +22,8 @@ const Posts = () => {
 
   return (
     <div>
+      {openModal ? <PostModal close={setOpenModal}/> : null}
+      <button onClick={()=>setOpenModal(true)}>모달 띄우기</button>
       <button onClick={getPosts}>게시글 목록 불러오기</button>
       <button onClick={getPost}>게시글 내용 보기</button>
     </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#68 

## 📝 작업 내용

- request 함수 추가
    - [x] 게시글 생성
    - [x] 게시글 수정

- 게시글 생성/수정 modal
   - [x] 게시글 기존 data 여부에 따라 생성/수정 기능 바뀜
   - [x] 제목, 내용을 입력/수정할 수 있음
   - [x] 스타일 적용 (화면 가운데 absolute)

### 🖼️ 스크린샷 (선택)
<img width="300" height="300" alt="스크린샷 2024-07-14 오후 9 05 47" src="https://github.com/user-attachments/assets/add70102-a3be-4a08-8358-6acde1b61f40">

<img width="300" height="300" alt="스크린샷 2024-07-14 오후 9 15 47" src="https://github.com/user-attachments/assets/42e3b7fd-3ffe-4f9a-8ba4-4848697ac82a">


## 💬 리뷰 요구사항(선택)

- 게시글 수정 기능을 생성 모달에 추가할지, 게시글 내용 페이지에 추가할지 고민하다가 우선은 수정 기능에 추가했습니다.
혹시, 게시글 내용을 보는 페이지에서 수정 기능이 동작하는게 더 나을까요?