### PR TITLE
[BE] 게시글, 댓글 조회 API 응답에 is_author 필드 추가

### DIFF
--- a/server/db/context/comments_context.ts
+++ b/server/db/context/comments_context.ts
@@ -35,6 +35,7 @@ export const readComments = async (postId: number, userId?: number) => {
         comments.content as content,
         comments.author_id as author_id,
         users.nickname as author_nickname,
+        (comments.author_id = ?) AS is_author,
         comments.created_at as created_at,
         comments.updated_at as updated_at,
         (SELECT COUNT(*) FROM comment_likes WHERE comment_id = comments.id) AS likes,
@@ -60,7 +61,7 @@ export const readComments = async (postId: number, userId?: number) => {
         comments.created_at,
         comments.id
     `;
-    const values = [userId, postId];
+    const values = [userId, userId, postId];
 
     conn = await pool.getConnection();
     const [rows]: [RowDataPacket[], FieldPacket[]] = await conn.query(

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -79,6 +79,7 @@ export const getPostInfo = async (post_id : number, user_id? : number) => {
                         p.content,
                         p.author_id,
                         u.nickname as author_nickname,
+                        (p.author_id = ?) AS is_author,
                         p.created_at,
                         p.updated_at,
                         p.views,
@@ -97,7 +98,7 @@ export const getPostInfo = async (post_id : number, user_id? : number) => {
         `;
 
         conn = await pool.getConnection();
-        const [rows] : any[] = await conn.query(sql, [user_id, post_id]);
+        const [rows] : any[] = await conn.query(sql, [user_id, user_id, post_id]);
 
         if(rows.length === 0) {
             throw ServerError.notFound("존재하지 않는 게시글입니다.");

--- a/server/db/mapper/comments_mapper.ts
+++ b/server/db/mapper/comments_mapper.ts
@@ -6,6 +6,7 @@ export const mapDBToComments = (data: any[]): IComment[] => {
     content: item.content,
     author_id: item.author_id,
     author_nickname: item.author_nickname,
+    is_author : !!item.is_author,
     created_at: new Date(item.created_at),
     updated_at: item.updated_at ? new Date(item.updated_at) : null,
     likes: item.likes,

--- a/server/db/mapper/posts_mapper.ts
+++ b/server/db/mapper/posts_mapper.ts
@@ -7,6 +7,7 @@ export const mapDBToPostInfo = (data : any) : IPostInfo => {
         content : data.content,
         author_id : data.author_id,
         author_nickname : data.author_nickname,
+        is_author : !!data.is_author,
         created_at : new Date(data.created_at),
         updated_at : data.updated_at? new Date(data.updated_at) : null,
         views : data.views,

--- a/server/db/model/comments.ts
+++ b/server/db/model/comments.ts
@@ -3,6 +3,7 @@ export interface IComment {
   content: string;
   author_id: number;
   author_nickname: string;
+  is_author : boolean;
   created_at: Date;
   updated_at?: Date | null;
   likes: number;

--- a/server/db/model/posts.ts
+++ b/server/db/model/posts.ts
@@ -4,6 +4,7 @@ export interface IPostInfo {
     content : string;
     author_id : number;
     author_nickname : string;
+    is_author : boolean;
     created_at : Date;
     updated_at : Date | null;
     views : number;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #69

## 📝 작업 내용

게시글 내용, 댓글 목록 조회 API의 응답에, 해당 게시글, 댓글을 회원이 작성했는지 여부를 boolean으로 나타내는 필드(`is_author`)를 추가합니다. 이 필드는 게시글 내용 페이지에서 게시글과 댓글에 수정, 삭제 버튼을 노출할지 결정하는 데 필요합니다.

- 게시글 내용 조회 API
  - [x] 게시글 내용 model에 `is_author` 필드 추가
  - [x] 게시글 내용 context의 SQL에서 `is_author`를 함께 조회
- 댓글 목록 조회 API
  - [x] 댓글 model에 `is_author` 필드 추가
  - [x] 댓글 목록 context의 SQL에서 `is_author`를 함께 조회

## 💬 리뷰 요구사항

- 구현 방법이 잘못되었거나 수정이 필요한 부분, 수정했으면 하는 부분 있으면 말씀해 주세요.