### PR TITLE
[FE] 로그인 화면 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,21 +1,23 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
-import './App.css'
-import TestMain from './component/TestMain/TestMain'
-import User from './component/User/User'
-import Posts from './component/Posts/Posts'
-import Tests from './component/TestMain/Tests'
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import "./App.css";
+import TestMain from "./component/TestMain/TestMain";
+import User from "./page/User/User";
+import Posts from "./component/Posts/Posts";
+import Tests from "./component/TestMain/Tests";
+import Login from "./page/User/Login";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<TestMain />}/>
-        <Route path="/user" element={<User/>}/>
-        <Route path="/test" element={<Tests/>}/>
-        <Route path="/posts" element={<Posts/>}/>
+        <Route path="/" element={<TestMain />} />
+        <Route path="/user" element={<User />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/test" element={<Tests />} />
+        <Route path="/posts" element={<Posts />} />
       </Routes>
     </BrowserRouter>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/client/src/api/users/crud.ts
+++ b/client/src/api/users/crud.ts
@@ -1,0 +1,5 @@
+import { HttpMethod, convertToBody, httpRequest } from "../api";
+
+export const sendPostLoginRequest = async (body: object) => {
+  return await httpRequest("user/login", HttpMethod.POST, convertToBody(body));
+};

--- a/client/src/component/User/User.tsx
+++ b/client/src/component/User/User.tsx
@@ -1,7 +1,0 @@
-const User = () => {
-  return (
-    <div>User</div>
-  )
-}
-
-export default User

--- a/client/src/page/User/Login.css.ts
+++ b/client/src/page/User/Login.css.ts
@@ -1,0 +1,76 @@
+import { style } from "@vanilla-extract/css";
+
+export const loginWrapper = style({
+  position: "relative",
+  width: "460px",
+  height: "100%",
+  boxSizing: "border-box",
+  border: "1px solid #ccc",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "24px",
+  gap: "10px",
+});
+
+export const loginForm = style({
+  display: "flex",
+  width: "100%",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "24px",
+  gap: "24px",
+});
+
+export const inputBox = style({
+  display: "flex",
+  width: "100%",
+  flexDirection: "column",
+  textAlign: "left",
+  gap: "4px",
+});
+
+export const label = style({
+  width: "100%",
+  fontSize: "20px",
+  fontWeight: "bold",
+});
+
+export const input = style({
+  width: "100%",
+  height: "40px",
+  padding: "0px",
+  fontSize: "20px",
+  border: "1px solid #ccc",
+  borderRadius: "4px",
+});
+
+export const errorMessageStyle = style({
+  color: "red",
+});
+
+export const loginButton = style({
+  width: "100%",
+  height: "50px",
+  padding: "0px",
+  border: "1px solid #ccc",
+  borderRadius: "4px",
+  backgroundColor: "#000",
+  color: "#fff",
+  cursor: "pointer",
+  ":hover": {
+    opacity: 0.8,
+  },
+});
+
+export const joinButton = style({
+  width: "100%",
+  padding: "0px",
+  cursor: "pointer",
+  ":hover": {
+    textDecoration: "underline",
+    color: "blue",
+  },
+});

--- a/client/src/page/User/Login.tsx
+++ b/client/src/page/User/Login.tsx
@@ -1,0 +1,121 @@
+import { FC, useState } from "react";
+import {
+  input,
+  inputBox,
+  joinButton as joinLink,
+  label,
+  loginButton,
+  loginForm,
+  loginWrapper,
+  errorMessageStyle,
+} from "./Login.css";
+import { sendPostLoginRequest } from "../../api/users/crud";
+import { useNavigate } from "react-router-dom";
+
+const Login: FC = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const navigate = useNavigate();
+
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+  };
+
+  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  const handleLoginButton = async () => {
+    const body = {
+      email,
+      password,
+    };
+
+    // 이메일 정규표현식
+    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,3}$/;
+    //비밀번호 정규표현식(영대소문자 각각 1개 이상, 숫자 1개이상, 10자리 이상)
+    const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{10,}$/;
+
+    if (!email) {
+      setErrorMessage("이메일을 입력하세요.");
+      return;
+    }
+
+    if (!password) {
+      setErrorMessage("비밀번호를 입력하세요.");
+      return;
+    }
+
+    if (!emailRegex.test(email) || !passwordRegex.test(password)) {
+      setErrorMessage("이메일 또는 비밀번호가 틀렸습니다.");
+      return;
+    }
+
+    const result = await sendPostLoginRequest(body);
+    if (result.status !== 200) {
+      if (result.message) {
+        let message: string = result.message;
+        message = message.replace("Bad Request: ", "");
+        setErrorMessage(message);
+      }
+    } else {
+      // 로그인 성공
+      console.log("로그인 성공");
+
+      //TODO: 로그인 헤더 추가 후 로그인 버튼 누른 시점의 페이지로 이동
+      navigate("/user"); // 유저 페이지로 이동
+
+      //TODO: 로그인 성공시 Zustand추가 후 처리 추가
+    }
+  };
+
+  return (
+    <div className={loginWrapper}>
+      <h1>로그인</h1>
+      <div className={loginForm}>
+        <div className={inputBox}>
+          <label className={label} htmlFor="email">
+            이메일
+          </label>
+          <input
+            className={input}
+            type="email"
+            id="email"
+            onChange={handleEmailChange}
+            value={email}
+            placeholder="이메일을 입력하세요."
+          />
+        </div>
+        <div className={inputBox}>
+          <label className={label} htmlFor="password">
+            비밀번호
+          </label>
+          <input
+            className={input}
+            type="password"
+            id="password"
+            onChange={handlePasswordChange}
+            value={password}
+            placeholder="비밀번호를 입력하세요."
+          />
+          {errorMessage && (
+            <div className={errorMessageStyle}>{errorMessage}</div>
+          )}
+        </div>
+        <button
+          className={loginButton}
+          onClick={handleLoginButton}
+          type="submit"
+        >
+          로그인
+        </button>
+        {/* TODO: 회원가입 페이지 만든 이후 클릭시 페이지 이동 기능 추가 */}
+        <div className={joinLink}>회원가입</div>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/client/src/page/User/User.tsx
+++ b/client/src/page/User/User.tsx
@@ -1,0 +1,5 @@
+const User = () => {
+  return <div>User</div>;
+};
+
+export default User;

--- a/client/src/page/User/User.tsx
+++ b/client/src/page/User/User.tsx
@@ -1,5 +1,12 @@
+import { useNavigate } from "react-router-dom";
+
 const User = () => {
-  return <div>User</div>;
+  const navigate = useNavigate();
+  return (
+    <div>
+      <button onClick={() => navigate("/login")}>로그인 화면</button>
+    </div>
+  );
 };
 
 export default User;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #71

## 📝 작업 내용

- [x] 사용자 이메일과 비밀번호 입력 폼 생성
- [x] 로그인 버튼 구현 및 클릭 이벤트 처리
- [x] 로그인 성공시 유저 페이지로 리다이렉트
- [x] 로그인 실패 시 에러 메시지 표시

## 향후 추가 사항
 - [ ] Zustand 세팅 후 로그인 성공 시 Zustand 저장소에 다음 정보 저장:
     - 사용자 닉네임
     - 로그인 시간
     - 로그인 여부(boolean)
 - [ ] 로그인 헤더 추가 후 로그인 버튼 누른 시점의 페이지로 이동

### 🖼️ 스크린샷
![image](https://github.com/user-attachments/assets/80ada513-e787-442e-baa2-8bada333342b)


## 💬 리뷰 요구사항(선택)

잘못 구현된 부분이나 이상한 부분 있으면 말해주세요.
