### PR TITLE
[FE] 게시글 정보 컴포넌트

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.2.1",
-    "react-router-dom": "^6.24.0",
+    "react-router-dom": "^6.24.1",
     "shared": "1.0.0"
   },
   "devDependencies": {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import TestMain from './component/TestMain/TestMain'
 import User from './component/User/User'
 import Posts from './component/Posts/Posts'
 import Tests from './component/TestMain/Tests'
+import PostInfoPage from './page/Posts/PostInfoPage'
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
         <Route path="/user" element={<User/>}/>
         <Route path="/test" element={<Tests/>}/>
         <Route path="/posts" element={<Posts/>}/>
+        <Route path="/post/:id" element={<PostInfoPage />}/>
       </Routes>
     </BrowserRouter>
   )

--- a/client/src/component/Posts/PostInfo.css.ts
+++ b/client/src/component/Posts/PostInfo.css.ts
@@ -1,5 +1,4 @@
 import { style } from "@vanilla-extract/css";
-import { vars } from "../../App.css.ts";
 
 export const PostHeader = style({
     display : "flex",
@@ -36,13 +35,18 @@ export const PostBody = style({
     display : "flex",
     flexDirection : "column",
     textAlign : "start",
-    backgroundColor : vars.color.brightText,
-    color : vars.color.darkText,
     width : "780px",
-    height : "350px",
+    height : "100%",
     resize : "none",
     borderRadius : 5,
     padding : 10
 });
 
-export const Buttons = style({});
+export const Buttons = style({
+    display : "flex",
+    justifyContent : "space-between",
+    paddingTop : "20px",
+    paddingBottom : "20px",
+    paddingLeft : "10px",
+    paddingRight : "10px"
+});

--- a/client/src/component/Posts/PostInfo.css.ts
+++ b/client/src/component/Posts/PostInfo.css.ts
@@ -1,0 +1,48 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "../../App.css.ts";
+
+export const PostHeader = style({
+    display : "flex",
+    flexDirection : "column",
+    width : "800px",
+    paddingTop : "10px",
+    paddingBottom : "10px"
+});
+
+export const Title = style({
+    display : "flex",
+    justifyContent : "start",
+    borderBottom : "1px solid black",
+    padding : "5px",
+    fontSize : "30px",
+    fontWeight : "bold"
+});
+
+export const EtcInfo = style({
+    display : "flex",
+    flexDirection : "row",
+    justifyContent : "space-between",
+    padding : "5px"
+});
+
+export const EtcInfoItem = style({
+    display : "flex",
+    flexDirection : "row",
+    justifyContent : "space-between",
+    gap : "10px"
+});
+
+export const PostBody = style({
+    display : "flex",
+    flexDirection : "column",
+    textAlign : "start",
+    backgroundColor : vars.color.brightText,
+    color : vars.color.darkText,
+    width : "780px",
+    height : "350px",
+    resize : "none",
+    borderRadius : 5,
+    padding : 10
+});
+
+export const Buttons = style({});

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -42,10 +42,12 @@ const PostInfo : React.FC<IPostInfoProps> = ({ postInfo }) => {
         <div className={PostBody}>
             {content}
         </div>
-        <div className={Buttons}></div>
+        <div className={Buttons}>
+          {/* TODO : 로그인 여부에 따라 버튼 숨기기 */}
           {<button>수정</button>}
           <button>좋아요</button>
           {<button>삭제</button>}
+        </div>
     </div>
   )
 }

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -1,0 +1,53 @@
+import { Buttons, EtcInfo, EtcInfoItem, PostBody, PostHeader, Title } from "./PostInfo.css";
+import { dateToStr } from "../../utils/date-to-str";
+import { IPostInfo } from "shared";
+
+interface IPostInfoProps {
+  postInfo : IPostInfo
+}
+
+const PostInfo : React.FC<IPostInfoProps> = ({ postInfo }) => {
+  const time = postInfo.updated_at ?
+              new Date(postInfo.updated_at):
+              new Date(postInfo.created_at);
+
+  const updateTxt = postInfo.updated_at ? " (수정됨)" : "";
+
+  const content = postInfo.content.split('\n').map((line, index) => (
+    <span key={index}>
+      {line}
+      <br />
+    </span>
+  ));
+
+  return (
+    <div>
+        <div className={PostHeader}>
+            {/* flex col */}
+            <div className={Title}>{postInfo.title}</div>
+            <div className={EtcInfo}>
+              {/* flex between */}
+              <div className={EtcInfoItem}>
+                {/* 왼쪽 flex row */}
+                <div>{postInfo.author_nickname}</div>
+                <div>{dateToStr(time) + updateTxt}</div>
+              </div>
+              <div className={EtcInfoItem}>
+                {/* 오른쪽 flex row */}
+                <div>{"조회 " + postInfo.views}</div>
+                <div>{"좋아요 " + postInfo.likes}</div>
+              </div>
+            </div>
+        </div>
+        <div className={PostBody}>
+            {content}
+        </div>
+        <div className={Buttons}></div>
+          {<button>수정</button>}
+          <button>좋아요</button>
+          {<button>삭제</button>}
+    </div>
+  )
+}
+
+export default PostInfo

--- a/client/src/component/Posts/Posts.tsx
+++ b/client/src/component/Posts/Posts.tsx
@@ -1,12 +1,13 @@
 import { SortBy } from "shared";
-import { sendGetPostRequest, sendGetPostsRequest } from "../../api/posts/crud";
+import { sendGetPostsRequest } from "../../api/posts/crud";
 import { useState } from "react";
 import PostModal from "./Modal/PostModal";
+import { useNavigate } from "react-router-dom";
 
 const Posts = () => {
+  const navigate = useNavigate();
   const [openModal, setOpenModal] = useState<boolean>(false);
   const [openUpdateModal, setOpenUpdateModal] = useState<boolean>(false);
-
 
   const getPosts = () => {
     const query = `?index=1&perPage=5&sortBy=`+SortBy.LIKES;
@@ -16,10 +17,7 @@ const Posts = () => {
   };
 
   const getPost = () => {
-    const post_id = '1';
-    sendGetPostRequest(post_id).then((res)=>{
-      console.log(res);
-    });
+    navigate("/post/9");
   };
 
   const testPostData = {

--- a/client/src/page/Posts/PostInfoPage.css.ts
+++ b/client/src/page/Posts/PostInfoPage.css.ts
@@ -4,7 +4,6 @@ export const PostInfoPageStyle = style({
     display : "flex",
     flexDirection : "column",
     alignItems : "center",
-    padding : "20px",
     width : "100%",
     height : "fit-content"
 });

--- a/client/src/page/Posts/PostInfoPage.css.ts
+++ b/client/src/page/Posts/PostInfoPage.css.ts
@@ -1,0 +1,10 @@
+import { style } from "@vanilla-extract/css";
+
+export const PostInfoPageStyle = style({
+    display : "flex",
+    flexDirection : "column",
+    alignItems : "center",
+    padding : "20px",
+    width : "100%",
+    height : "fit-content"
+});

--- a/client/src/page/Posts/PostInfoPage.tsx
+++ b/client/src/page/Posts/PostInfoPage.tsx
@@ -1,0 +1,45 @@
+import { useLayoutEffect, useState } from "react";
+import PostInfo from "../../component/Posts/PostInfo";
+import { PostInfoPageStyle } from "./PostInfoPage.css";
+import { useParams } from 'react-router-dom';
+import { IPostInfo, mapDBToPostInfo } from "shared";
+import { sendGetPostRequest } from "../../api/posts/crud";
+
+const PostInfoPage = () => {
+  const { id } = useParams();
+  const [postInfo, setPostInfo] = useState<IPostInfo>({
+    id: 0,
+    title: "",
+    content: "",
+    author_id : 0,
+    author_nickname: "",
+    created_at: new Date(),
+    updated_at : undefined,
+    views: 0,
+    likes: 0,
+    user_liked : false
+  });
+
+  useLayoutEffect(() => {
+    if(!id) {
+      {/* TODO : 에러 핸들링하기 */}
+      return;
+    }
+
+    sendGetPostRequest(id).then((res)=>{
+      if(res.status >= 400){
+        console.log(res);
+        return;
+      }
+      setPostInfo(mapDBToPostInfo(res.post));
+    });
+  }, []);
+
+  return (
+    <div className={PostInfoPageStyle}>
+        <PostInfo postInfo={postInfo}/>
+    </div>
+  )
+}
+
+export default PostInfoPage

--- a/client/src/utils/date-to-str.tsx
+++ b/client/src/utils/date-to-str.tsx
@@ -1,0 +1,11 @@
+export const dateToStr = (date : Date) => {
+    
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    const seconds = String(date.getSeconds()).padStart(2, '0');
+
+    return `${year}.${month}.${day} ${hours}:${minutes}:${seconds}`;
+}

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -1,7 +1,7 @@
 import { PoolConnection } from "mysql2/promise";
 import { ICreatePostRequest, IReadPostRequest, IUpdatePostRequest } from '../../controller/posts_controller';
 import pool from '../connect';
-import { mapDBToPostHeaders, mapDBToPostInfo } from '../mapper/posts_mapper';
+import { mapDBToPostHeaders, mapDBToPostInfo } from 'shared';
 import { ServerError } from '../../middleware/errors';
 import { SortBy } from "shared";
 

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,1 +1,3 @@
 export * from './posts/enums';
+export * from './posts/mappers';
+export * from './posts/models';

--- a/shared/posts/mappers.ts
+++ b/shared/posts/mappers.ts
@@ -1,4 +1,4 @@
-import { IPostInfo, IPostHeader } from "../model/posts";
+import { IPostHeader, IPostInfo } from "./models";
 
 export const mapDBToPostInfo = (data : any) : IPostInfo => {
     return {
@@ -8,7 +8,7 @@ export const mapDBToPostInfo = (data : any) : IPostInfo => {
         author_id : data.author_id,
         author_nickname : data.author_nickname,
         created_at : new Date(data.created_at),
-        updated_at : data.updated_at? new Date(data.updated_at) : null,
+        updated_at : data.updated_at? new Date(data.updated_at) : undefined,
         views : data.views,
         likes : data.likes,
         user_liked : !!data.user_liked,

--- a/shared/posts/models.ts
+++ b/shared/posts/models.ts
@@ -5,7 +5,7 @@ export interface IPostInfo {
     author_id : number;
     author_nickname : string;
     created_at : Date;
-    updated_at : Date | null;
+    updated_at? : Date;
     views : number;
     likes : number;
     user_liked : boolean;


### PR DESCRIPTION
## 📝 작업 내용

게시글 정보 컴포넌트 하나 완성하는데 너무 많은 변경이 필요해 보여서 한 번 끊어서 올립니다.

- [x] 기존 sercer/db/model, mapper에 있던 post관련 코드 -> shared로 이동
- 게시글 정보 컴포넌트 추가
    - [x] App.tsx에 라우팅 추가하기
    - [x] PostInfoPage에서 param값으로 게시글 정보 불러오기 request 보내기
        - 게시글 목록에서 게시글을 클릭 -> navigate("post/:id")만 동작하면 되도록 구현함.
        - 따라서 param = id
    - [x] resposne data로 PostInfo component 채우기
    - [x] PostInfo css 임시로 설정
    - [x] context -> 개행 문자로 split하고 JSX emelemt로 반환 -> 개행 구현
    - [x] Date타입을 "yyyy.mm.dd hh:mm:ss" 형식의 string으로 바꾸는 util 함수 추가

- 해야할 일
    - [ ] 수정 버튼 -> 수정 모달 띄우기
    - [ ] 삭제 버튼 -> 삭제 요청 보내기
    - [ ] 좋아요 버튼 -> 좋아요 요청
    - [ ] 좋아요 여부에 따라 좋아요 버튼 기능 + css 변경

## 🖼️ 스크린샷 (선택)
<img width="926" alt="스크린샷 2024-07-15 오후 4 29 28" src="https://github.com/user-attachments/assets/0c5c99df-645a-43d4-bb0b-938c12846479">

## 💬 리뷰 요구사항(선택)

- 컨벤션을 잘 못 지킨 부분이 있을까요?
- 혹시 구현 상, 미흡한 부분이 있다면 알려주세요!

