### PR TITLE
fix : IPostInfo에 is_author가 추가되어 발생한 타입 오류 수정

### DIFF
--- a/client/src/page/Posts/PostInfoPage.tsx
+++ b/client/src/page/Posts/PostInfoPage.tsx
@@ -13,6 +13,7 @@ const PostInfoPage = () => {
     content: "",
     author_id : 0,
     author_nickname: "",
+    is_author : false,
     created_at: new Date(),
     updated_at : undefined,
     views: 0,


### PR DESCRIPTION
## 📝 작업 내용

IPostInfo 타입의 변수에 is_author을 추가했습니다.
