### PR TITLE
[FE] 메인 페이지(게시글 목록) 컴포넌트 구현

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -12,7 +12,7 @@
 
 .card {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   gap : 20px;
 }
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,18 +1,18 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import "./App.css";
-import TestMain from "./component/TestMain/TestMain";
 import User from "./page/User/User";
 import Posts from "./component/Posts/Posts";
 import Tests from "./component/TestMain/Tests";
 import Login from "./page/User/Login";
 import PostInfoPage from './page/Posts/PostInfoPage';
 import Join from "./page/User/Join";
+import Main from "./page/Main/Main";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<TestMain />} />
+        <Route path="/" element={<Main />} />
         <Route path="/user" element={<User />} />
         <Route path="/login" element={<Login />} />
         <Route path="/join" element={<Join />} />

--- a/client/src/component/Posts/PostList/PostList.css.ts
+++ b/client/src/component/Posts/PostList/PostList.css.ts
@@ -1,0 +1,114 @@
+import { style } from "@vanilla-extract/css";
+
+export const postListStyle = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "stretch",
+  width: "100%",
+  borderTop: "2px solid #808080",
+  borderBottom: "2px solid #808080",
+  lineHeight: "1.3",
+});
+
+export const postListLinks = style({
+  color: "inherit",
+  fontWeight: "inherit",
+
+  ":hover": {
+    backgroundColor: "#8080800a",
+    color: "inherit",
+    fontWeight: "inherit",
+  },
+});
+
+export const postListHeaderRow = style({
+  fontSize: "0.9rem",
+  fontWeight: "bold",
+  opacity: 0.8,
+});
+
+export const sortableLink = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  columnGap: "2px",
+
+  selectors: {
+    [`&${postListLinks}:hover`]: {
+      backgroundColor: "transparent",
+    },
+  },
+});
+
+export const sortableIcon = style({
+  display: "flex",
+  alignItems: "center",
+  marginLeft: "2px",
+  color: "#808080",
+});
+
+export const notSorted = style({
+  opacity: "0.3",
+});
+
+export const postListBody = style({
+  display: "flex",
+  flexDirection: "column",
+});
+
+export const postListRow = {
+  container: style({
+    display: "flex",
+    boxSizing: "border-box",
+    columnGap: "8px",
+    alignItems: "center",
+    borderTop: "1px solid #80808040",
+    borderBottom: "1px solid #80808040",
+    padding: "4px 0 4px 8px",
+    minHeight: "48px",
+
+    ":first-child": {
+      borderTopWidth: "0",
+    },
+
+    ":last-child": {
+      borderBottomWidth: "0",
+    },
+
+    selectors: {
+      [`&${postListHeaderRow}`]: {
+        borderBottom: "2px solid #808080",
+        minHeight: "32px",
+      },
+    },
+  }),
+
+  title: style({
+    flex: "1 1",
+    textAlign: "left",
+
+    selectors: {
+      [`${postListHeaderRow} &`]: {
+        textAlign: "center",
+      },
+    },
+  }),
+
+  author: style({
+    flex: "0 0 96px",
+    fontSize: "0.9rem",
+  }),
+
+  created_at: style({
+    flex: "0 0 96px",
+    fontSize: "0.9rem",
+  }),
+
+  likes: style({
+    flex: "0 0 64px",
+  }),
+
+  views: style({
+    flex: "0 0 64px",
+  }),
+};

--- a/client/src/component/Posts/PostList/PostList.tsx
+++ b/client/src/component/Posts/PostList/PostList.tsx
@@ -1,0 +1,109 @@
+import clsx from "clsx";
+import { MouseEvent } from "react";
+import { FiArrowDown } from "react-icons/fi";
+import { Link } from "react-router-dom";
+import { IPostHeader, SortBy } from "shared";
+import { dateToStr } from "../../../utils/date-to-str";
+import {
+  notSorted,
+  postListBody,
+  postListHeaderRow,
+  postListLinks,
+  postListRow,
+  postListStyle,
+  sortableIcon,
+  sortableLink,
+} from "./PostList.css";
+
+interface IPostListProps {
+  posts: IPostHeader[];
+  sortBy: SortBy | null;
+  onSort: (sortBy: SortBy | null) => void;
+}
+
+const PostList = ({ posts, sortBy, onSort }: IPostListProps) => {
+  const handleSortableClickWith =
+    (nextSortBy: SortBy | null) => (event: MouseEvent) => {
+      event.preventDefault();
+
+      onSort(nextSortBy);
+    };
+
+  return (
+    <div className={postListStyle}>
+      <div className={clsx(postListHeaderRow, postListRow.container)}>
+        <div className={postListRow.title}>제목</div>
+        <div className={postListRow.author}>작성자</div>
+        <div className={postListRow.created_at}>
+          <a
+            className={clsx(sortableLink, postListLinks)}
+            href="#"
+            onClick={handleSortableClickWith(null)}
+          >
+            작성일시
+            <span
+              className={clsx(sortableIcon, { [notSorted]: sortBy !== null })}
+            >
+              <FiArrowDown />
+            </span>
+          </a>
+        </div>
+        <div className={postListRow.likes}>
+          <a
+            className={clsx(sortableLink, postListLinks)}
+            href="#"
+            onClick={handleSortableClickWith(SortBy.LIKES)}
+          >
+            좋아요
+            <span
+              className={clsx(sortableIcon, {
+                [notSorted]: sortBy !== SortBy.LIKES,
+              })}
+            >
+              <FiArrowDown />
+            </span>
+          </a>
+        </div>
+        <div className={postListRow.views}>
+          <a
+            className={clsx(sortableLink, postListLinks)}
+            href="#"
+            onClick={handleSortableClickWith(SortBy.VIEWS)}
+          >
+            조회
+            <span
+              className={clsx(sortableIcon, {
+                [notSorted]: sortBy !== SortBy.VIEWS,
+              })}
+            >
+              <FiArrowDown />
+            </span>
+          </a>
+        </div>
+      </div>
+
+      <div className={postListBody}>
+        {posts.map((postHeader) => (
+          <Link
+            key={postHeader.id}
+            className={clsx(postListLinks, postListRow.container)}
+            to={`/post/${postHeader.id}`}
+          >
+            <div className={postListRow.title}>{postHeader.title}</div>
+            <div className={postListRow.author}>
+              {postHeader.author_nickname}
+            </div>
+            <div className={postListRow.created_at}>
+              {dateToStr(postHeader.created_at)}
+            </div>
+            <div className={postListRow.likes}>{postHeader.likes}</div>
+            {/* TODO: 조회수 views가 인터페이스에 없음 */}
+            <div className={postListRow.views}>?</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PostList;

--- a/client/src/component/common/Pagination/Pagination.css.ts
+++ b/client/src/component/common/Pagination/Pagination.css.ts
@@ -1,0 +1,27 @@
+import { style } from "@vanilla-extract/css";
+
+export const paginationStyle = style({
+  display: "flex",
+  justifyContent: "center",
+  columnGap: "8px",
+  verticalAlign: "baseline",
+});
+
+export const pageButton = style({
+  padding: "0",
+  width: "44px",
+  height: "44px",
+});
+
+export const arrowButton = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  backgroundColor: "#80808040",
+});
+
+export const current = style({
+  backgroundColor: "#808080",
+  color: "#fff",
+  fontWeight: "bold",
+});

--- a/client/src/component/common/Pagination/Pagination.tsx
+++ b/client/src/component/common/Pagination/Pagination.tsx
@@ -1,0 +1,90 @@
+import clsx from "clsx";
+import {
+  FiChevronLeft,
+  FiChevronRight,
+  FiChevronsLeft,
+  FiChevronsRight,
+} from "react-icons/fi";
+import { clamp } from "../../../utils/clamp";
+import {
+  arrowButton,
+  current,
+  pageButton,
+  paginationStyle,
+} from "./Pagination.css";
+
+interface IPaginationProps {
+  currentPage: number;
+  totalPosts: number;
+  perPage: number;
+  onChange: (page: number) => void;
+}
+
+const Pagination = ({
+  currentPage = 1,
+  totalPosts = 1,
+  perPage = 10,
+  onChange,
+}: IPaginationProps) => {
+  const actualTotalPosts = Math.max(1, totalPosts);
+  const actualPerPage = Math.max(1, perPage);
+  const totalPages = Math.ceil(actualTotalPosts / actualPerPage);
+
+  const actualCurrentPage = clamp(1, currentPage, totalPages);
+  const currentGroupIndex = Math.floor((actualCurrentPage - 1) / 10);
+  const currentGroupFirstPage = currentGroupIndex * 10 + 1;
+  const currentGroupSize = Math.min(10, totalPages - currentGroupFirstPage + 1);
+
+  const prevGroupLastPage = Math.max(1, currentGroupFirstPage - 1);
+  const nextGroupFirstPage = Math.min(totalPages, currentGroupFirstPage + 10);
+
+  const handlePageClickWith = (page: number) => () => {
+    onChange(page);
+  };
+
+  return (
+    <div className={paginationStyle}>
+      <button
+        className={clsx(pageButton, arrowButton)}
+        onClick={handlePageClickWith(1)}
+      >
+        <FiChevronsLeft />
+      </button>
+
+      <button
+        className={clsx(pageButton, arrowButton)}
+        onClick={handlePageClickWith(prevGroupLastPage)}
+      >
+        <FiChevronLeft />
+      </button>
+
+      {Array.from({ length: currentGroupSize }, (_, index) => (
+        <button
+          key={currentGroupFirstPage + index}
+          className={clsx(pageButton, {
+            [current]: currentGroupFirstPage + index === actualCurrentPage,
+          })}
+          onClick={handlePageClickWith(currentGroupFirstPage + index)}
+        >
+          {currentGroupFirstPage + index}
+        </button>
+      ))}
+
+      <button
+        className={clsx(pageButton, arrowButton)}
+        onClick={handlePageClickWith(nextGroupFirstPage)}
+      >
+        <FiChevronRight />
+      </button>
+
+      <button
+        className={clsx(pageButton, arrowButton)}
+        onClick={handlePageClickWith(totalPages)}
+      >
+        <FiChevronsRight />
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/client/src/component/common/Pagination/Pagination.tsx
+++ b/client/src/component/common/Pagination/Pagination.tsx
@@ -21,9 +21,9 @@ interface IPaginationProps {
 }
 
 const Pagination = ({
-  currentPage = 1,
-  totalPosts = 1,
-  perPage = 10,
+  currentPage,
+  totalPosts,
+  perPage,
   onChange,
 }: IPaginationProps) => {
   const actualTotalPosts = Math.max(1, totalPosts);

--- a/client/src/component/common/SearchForm/SearchForm.css.ts
+++ b/client/src/component/common/SearchForm/SearchForm.css.ts
@@ -1,0 +1,19 @@
+import { style } from "@vanilla-extract/css";
+
+export const searchStyle = style({
+  display: "flex",
+  alignItems: "stretch",
+  justifyContent: "center",
+  columnGap: "8px",
+});
+
+export const searchInput = style({
+  boxSizing: "border-box",
+  margin: "1px 0",
+  paddingLeft: "12px",
+  paddingRight: "8px",
+  border: "1px solid #808080a0",
+  borderRadius: "8px",
+  width: "240px",
+  fontSize: "1rem",
+});

--- a/client/src/component/common/SearchForm/SearchForm.tsx
+++ b/client/src/component/common/SearchForm/SearchForm.tsx
@@ -1,0 +1,34 @@
+import { ChangeEvent, FormEvent, useState } from "react";
+import { searchInput, searchStyle } from "./SearchForm.css";
+
+interface ISearchFormProps {
+  defaultKeyword?: string;
+  onSubmit: (keyword: string) => void;
+}
+
+const SearchForm = ({ defaultKeyword = "", onSubmit }: ISearchFormProps) => {
+  const [keyword, setKeyword] = useState(defaultKeyword);
+
+  const handleSearchSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    onSubmit(keyword.trim());
+  };
+
+  const handleKeywordChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setKeyword(event.target.value);
+  };
+
+  return (
+    <form className={searchStyle} onSubmit={handleSearchSubmit}>
+      <input
+        type="text"
+        className={searchInput}
+        value={keyword}
+        onChange={handleKeywordChange}
+      />
+      <button type="submit">검색</button>
+    </form>
+  );
+};
+
+export default SearchForm;

--- a/client/src/component/common/SearchForm/SearchForm.tsx
+++ b/client/src/component/common/SearchForm/SearchForm.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useState } from "react";
+import { ChangeEvent, FormEvent, useCallback, useState } from "react";
 import { searchInput, searchStyle } from "./SearchForm.css";
 
 interface ISearchFormProps {
@@ -9,14 +9,20 @@ interface ISearchFormProps {
 const SearchForm = ({ defaultKeyword = "", onSubmit }: ISearchFormProps) => {
   const [keyword, setKeyword] = useState(defaultKeyword);
 
-  const handleSearchSubmit = (event: FormEvent) => {
-    event.preventDefault();
-    onSubmit(keyword.trim());
-  };
+  const handleSearchSubmit = useCallback(
+    (event: FormEvent) => {
+      event.preventDefault();
+      onSubmit(keyword.trim());
+    },
+    [keyword, onSubmit]
+  );
 
-  const handleKeywordChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setKeyword(event.target.value);
-  };
+  const handleKeywordChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setKeyword(event.target.value);
+    },
+    []
+  );
 
   return (
     <form className={searchStyle} onSubmit={handleSearchSubmit}>

--- a/client/src/hook/useMainPageSearchParams.ts
+++ b/client/src/hook/useMainPageSearchParams.ts
@@ -1,16 +1,22 @@
+import { useSearchParams } from "react-router-dom";
 import { SortBy } from "shared";
 import { clamp } from "../utils/clamp";
 
-const useMainPageSearchParams = (searchParams: URLSearchParams) => {
+const useMainPageSearchParams = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const sanitizedSearchParams = new URLSearchParams(searchParams);
+
   const fallbacks = {
     index: 1,
-    perPage: 15,
+    perPage: 10,
     keyword: "",
     sortBy: null,
   };
 
   const parsedIndex = parseInt(String(searchParams.get("index")), 10);
   const index = Math.max(1, isNaN(parsedIndex) ? fallbacks.index : parsedIndex);
+  sanitizedSearchParams.set("index", String(index));
 
   const parsedPerPage = parseInt(String(searchParams.get("perPage")), 10);
   const perPage = clamp(
@@ -18,6 +24,9 @@ const useMainPageSearchParams = (searchParams: URLSearchParams) => {
     isNaN(parsedPerPage) ? fallbacks.perPage : parsedPerPage,
     100
   );
+  if (perPage !== fallbacks.perPage) {
+    sanitizedSearchParams.set("perPage", String(perPage));
+  }
 
   const keyword = searchParams.get("keyword") ?? fallbacks.keyword;
 
@@ -27,10 +36,14 @@ const useMainPageSearchParams = (searchParams: URLSearchParams) => {
     : (parsedSortBy as SortBy);
 
   return {
-    index,
-    perPage,
-    keyword,
-    sortBy,
+    searchParams: sanitizedSearchParams,
+    setSearchParams,
+    parsed: {
+      index,
+      perPage,
+      keyword,
+      sortBy,
+    },
   };
 };
 

--- a/client/src/hook/useMainPageSearchParams.ts
+++ b/client/src/hook/useMainPageSearchParams.ts
@@ -1,0 +1,37 @@
+import { SortBy } from "shared";
+import { clamp } from "../utils/clamp";
+
+const useMainPageSearchParams = (searchParams: URLSearchParams) => {
+  const fallbacks = {
+    index: 1,
+    perPage: 15,
+    keyword: "",
+    sortBy: null,
+  };
+
+  const parsedIndex = parseInt(String(searchParams.get("index")), 10);
+  const index = Math.max(1, isNaN(parsedIndex) ? fallbacks.index : parsedIndex);
+
+  const parsedPerPage = parseInt(String(searchParams.get("perPage")), 10);
+  const perPage = clamp(
+    1,
+    isNaN(parsedPerPage) ? fallbacks.perPage : parsedPerPage,
+    100
+  );
+
+  const keyword = searchParams.get("keyword") ?? fallbacks.keyword;
+
+  const parsedSortBy = parseInt(String(searchParams.get("sortBy")), 10);
+  const sortBy = isNaN(parsedSortBy)
+    ? fallbacks.sortBy
+    : (parsedSortBy as SortBy);
+
+  return {
+    index,
+    perPage,
+    keyword,
+    sortBy,
+  };
+};
+
+export default useMainPageSearchParams;

--- a/client/src/page/Main/Main.css.ts
+++ b/client/src/page/Main/Main.css.ts
@@ -1,0 +1,30 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "../../App.css.ts";
+
+export const mainPageStyle = style({
+  display: "flex",
+  flexDirection: "column",
+  rowGap: "48px",
+  alignItems: "stretch",
+  width: "800px",
+});
+
+export const createPostButtonWrapper = style({
+  display: "flex",
+  justifyContent: "flex-end",
+});
+
+export const createPostButton = style({
+  color: vars.color.brightText,
+  fontWeight: "bold",
+  backgroundColor: "#000",
+  ":hover": {
+    opacity: 0.8,
+  },
+});
+
+export const postListActions = style({
+  display: "flex",
+  flexDirection: "column",
+  rowGap: "8px",
+});

--- a/client/src/page/Main/Main.tsx
+++ b/client/src/page/Main/Main.tsx
@@ -1,0 +1,112 @@
+import { useLayoutEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { IPostHeader, mapDBToPostHeaders, SortBy } from "shared";
+import { sendGetPostsRequest } from "../../api/posts/crud";
+import PostModal from "../../component/Posts/Modal/PostModal";
+import Pagination from "../../component/common/Pagination/Pagination";
+import PostList from "../../component/Posts/PostList/PostList";
+import SearchForm from "../../component/common/SearchForm/SearchForm";
+import useMainPageSearchParams from "../../hook/useMainPageSearchParams";
+import { useUserStore } from "../../state/store";
+import {
+  createPostButton,
+  createPostButtonWrapper,
+  mainPageStyle,
+  postListActions,
+} from "./Main.css";
+
+const Main = () => {
+  const isLogin = useUserStore((state) => state.isLogin);
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const [posts, setPosts] = useState<IPostHeader[]>([]);
+  const [totalPosts, setTotalPosts] = useState(0);
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const parsed = useMainPageSearchParams(searchParams);
+
+  useLayoutEffect(() => {
+    const queryString = `?${searchParams.toString()}`;
+
+    sendGetPostsRequest(queryString).then((data) => {
+      if (data?.status >= 400) {
+        // TODO: 에러 핸들링
+        return;
+      }
+
+      setPosts(mapDBToPostHeaders(data.postHeaders));
+      setTotalPosts(data?.total ?? 0);
+    });
+  }, [parsed.index, parsed.perPage, parsed.keyword, parsed.sortBy]);
+
+  const handlePostSort = (sortBy: SortBy | null) => {
+    const nextSearchParams = new URLSearchParams(searchParams);
+
+    if (sortBy === null) {
+      nextSearchParams.delete("sortBy");
+    } else {
+      nextSearchParams.set("sortBy", String(sortBy));
+    }
+
+    setSearchParams(nextSearchParams);
+  };
+
+  const handlePageChange = async (page: number) => {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.set("index", String(page));
+
+    setSearchParams(nextSearchParams);
+  };
+
+  const handleCreatePostClick = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleSearchSubmit = (keyword: string) => {
+    const nextSearchParams = new URLSearchParams(searchParams);
+
+    if (keyword) {
+      nextSearchParams.set("keyword", keyword);
+    } else {
+      nextSearchParams.delete("keyword");
+    }
+
+    setSearchParams(nextSearchParams);
+  };
+
+  return (
+    <div className={mainPageStyle}>
+      {isModalOpen ? <PostModal close={setIsModalOpen} /> : null}
+
+      <PostList posts={posts} sortBy={parsed.sortBy} onSort={handlePostSort} />
+
+      <Pagination
+        currentPage={parsed.index}
+        totalPosts={totalPosts}
+        perPage={parsed.perPage}
+        onChange={handlePageChange}
+      />
+
+      <div className={postListActions}>
+        {isLogin ? (
+          <div className={createPostButtonWrapper}>
+            <button
+              className={createPostButton}
+              onClick={handleCreatePostClick}
+            >
+              글쓰기
+            </button>
+          </div>
+        ) : null}
+
+        <SearchForm
+          defaultKeyword={parsed.keyword}
+          onSubmit={handleSearchSubmit}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Main;

--- a/client/src/page/Main/Main.tsx
+++ b/client/src/page/Main/Main.tsx
@@ -14,6 +14,7 @@ import {
   mainPageStyle,
   postListActions,
 } from "./Main.css";
+import TestMain from "../../component/TestMain/TestMain";
 
 const Main = () => {
   const isLogin = useUserStore((state) => state.isLogin);
@@ -78,6 +79,9 @@ const Main = () => {
   return (
     <div className={mainPageStyle}>
       {isModalOpen ? <PostModal close={setIsModalOpen} /> : null}
+
+      {/* TODO: 최상단 헤더 연결 후 TestMain 제거 */}
+      <TestMain />
 
       <PostList posts={posts} sortBy={parsed.sortBy} onSort={handlePostSort} />
 

--- a/client/src/page/Main/Main.tsx
+++ b/client/src/page/Main/Main.tsx
@@ -95,7 +95,7 @@ const Main = () => {
 
   return (
     <div className={mainPageStyle}>
-      {isModalOpen ? <PostModal close={setIsModalOpen} /> : null}
+      {isModalOpen && <PostModal close={setIsModalOpen} />}
 
       {/* TODO: 최상단 헤더 연결 후 TestMain 제거 */}
       <TestMain />
@@ -110,7 +110,7 @@ const Main = () => {
       />
 
       <div className={postListActions}>
-        {isLogin ? (
+        {isLogin && (
           <div className={createPostButtonWrapper}>
             <button
               className={createPostButton}
@@ -119,7 +119,7 @@ const Main = () => {
               글쓰기
             </button>
           </div>
-        ) : null}
+        )}
 
         <SearchForm
           defaultKeyword={parsed.keyword}

--- a/client/src/utils/clamp.ts
+++ b/client/src/utils/clamp.ts
@@ -1,0 +1,2 @@
+export const clamp = (min: number, value: number, max: number) =>
+  Math.min(max, Math.max(min, value));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #77
- #87

## 📝 작업 내용

- **인덱스 페이지(`/`)를 게시글 목록 페이지로 교체하고, 기존 `<TestMain>` 컴포넌트는 계속 접근 가능하도록 `<Main>` 페이지 컴포넌트 안으로 옮겼습니다.**
- [x] 게시글 목록: API로 가져온 데이터 활용
  - [x] 게시글 목록 상단에 필드명 나열(표 헤더)
    - [x] 작성일시, 좋아요, 조회수 정렬
    - 아래 2가지는 작동을 확인할 수 없는데, 서버 코드 수정이 필요합니다.
      - 조회수 표시: 게시글 목록 응답에 포함되어 있지 않아서 일단 자리만 만들어 두었습니다.
      - 조회수순 정렬: 서버에서 쿼리스트링 파싱 시 NaN 처리 문제로 확인됩니다.
  - [x] 게시글 데이터 배열을 React Node 목록으로 매핑
- [x] 페이지네이션 UI 및 동작
- [x] 글쓰기 버튼: 로그인을 했을 때만 표시
- [x] 검색 필드 UI 및 동작
- [x] 컴포넌트별 스타일 작성

### 🖼️ 스크린샷

<img width="576" alt="mainpage" src="https://github.com/user-attachments/assets/39e195bb-1809-487e-945e-1edb8ca6acda">

## 💬 리뷰 요구사항

- 잘못 구현되었거나 수정 필요한 부분 있으면 말씀해 주세요.