### PR TITLE
fix : 조회수 기준 정렬 버그 + post_header field에 views 추가

### DIFF
--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -22,6 +22,7 @@ export const getPostHeaders = async ( queryString : IReadPostRequest ) => {
                             p.title as title,
                             u.nickname as author_nickname,
                             p.created_at as created_at,
+                            p.views as views,
                             (SELECT COUNT(*) FROM post_likes WHERE post_id = p.id) AS likes ${sharedSql}`; 
 
         let countSql = `SELECT COUNT(*) as total ${sharedSql}`;

--- a/shared/posts/enums.ts
+++ b/shared/posts/enums.ts
@@ -1,4 +1,4 @@
 export enum SortBy {
-    VIEWS,
-    LIKES
+    VIEWS=1,
+    LIKES=2
 }

--- a/shared/posts/mappers.ts
+++ b/shared/posts/mappers.ts
@@ -23,7 +23,8 @@ export const mapDBToPostHeaders = (datas : any[]) : IPostHeader[] => {
             title : data.title,
             author_nickname : data.author_nickname,
             created_at : new Date(data.created_at),
-            likes : data.likes
+            likes : data.likes,
+            views : data.views
         };
     });
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#87

## 📝 작업 내용

- SortBy의 기본값을 아래와 같이 수정했습니다.
    - 기존 : VIEWS = 0, LIKES = 1
    - 수정 : VIEWS = 1, LIKES = 2
- PostHeader의 field에 조회수(views)를 추가했습니다.

### 🖼️ 스크린샷 (선택)
<img width="270" alt="스크린샷 2024-07-16 오전 10 03 06" src="https://github.com/user-attachments/assets/5f3cc7a2-a67d-4b16-8877-61e181bfa2eb">

