### PR TITLE
[FE] 사이트 헤더 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,9 +13,9 @@ import { AppContainer, mainContainer } from "./App.css";
 function App() {
   return (
     <div className={AppContainer}>
-      <Header />
-      <div className={mainContainer}>
-        <BrowserRouter>
+      <BrowserRouter>
+        <Header />
+        <div className={mainContainer}>
           <Routes>
             <Route path="/" element={<Main />} />
             <Route path="/user" element={<User />} />
@@ -25,8 +25,8 @@ function App() {
             <Route path="/posts" element={<Posts />} />
             <Route path="/post/:id" element={<PostInfoPage />} />
           </Routes>
-        </BrowserRouter>
-      </div>
+        </div>
+      </BrowserRouter>
     </div>
   );
 }

--- a/client/src/api/users/crud.ts
+++ b/client/src/api/users/crud.ts
@@ -7,3 +7,7 @@ export const sendPostLoginRequest = async (body: object) => {
 export const sendPostJoinRequest = async (body: object) => {
   return await httpRequest("user/Join", HttpMethod.POST, convertToBody(body));
 };
+
+export const sendPostLogoutRequest = async () => {
+  return await httpRequest("user/logout", HttpMethod.POST);
+};

--- a/client/src/component/Header/Header.css.ts
+++ b/client/src/component/Header/Header.css.ts
@@ -5,8 +5,45 @@ export const header = style({
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
-  height: "60px",
+  height: "50px",
   marginBottom: "20px",
+  padding: "0 20px",
   backgroundColor: "#333",
   color: "#fff",
+});
+
+export const siteTitle = style({
+  fontSize: "24px",
+  fontWeight: "bold",
+  ":hover": {
+    opacity: 0.7,
+    cursor: "pointer",
+  },
+});
+
+export const userAuthPanel = style({
+  display: "flex",
+  flexDirection: "row",
+  gap: "10px",
+});
+
+export const nicknameInfo = style({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  marginRight: "30px",
+});
+
+export const iconButtonGroup = style({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  gap: "20px",
+});
+
+export const button = style({
+  ":hover": {
+    opacity: 0.7,
+    cursor: "pointer",
+  },
 });

--- a/client/src/component/Header/Header.css.ts
+++ b/client/src/component/Header/Header.css.ts
@@ -14,8 +14,10 @@ export const header = style({
 
 export const siteTitle = style({
   fontSize: "24px",
+  color: "white",
   fontWeight: "bold",
   ":hover": {
+    color: "white",
     opacity: 0.7,
     cursor: "pointer",
   },

--- a/client/src/component/Header/Header.tsx
+++ b/client/src/component/Header/Header.tsx
@@ -1,7 +1,8 @@
 import { FiLogIn, FiLogOut, FiUser, FiUserPlus } from "react-icons/fi";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { sendPostLogoutRequest } from "../../api/users/crud";
 import { useUserStore } from "../../state/store";
+import { RiAliensFill } from "react-icons/ri";
 import {
   button,
   header,
@@ -16,10 +17,6 @@ const Header = () => {
   const isLogin = useUserStore.use.isLogin();
   const nickname = useUserStore.use.nickname();
   const { setLogoutUser } = useUserStore.use.actions();
-
-  const handleTitle = () => {
-    navigate("/");
-  };
 
   const handleLogin = () => {
     const currentPath = window.location.pathname;
@@ -47,9 +44,10 @@ const Header = () => {
 
   return (
     <div className={header}>
-      <div className={siteTitle} onClick={handleTitle}>
+      <Link to="/" className={siteTitle}>
+        <RiAliensFill />
         DBDB DEEP
-      </div>
+      </Link>
       <div className={userAuthPanel}>
         {isLogin && (
           <div className={nicknameInfo}>{nickname}님 환영 합니다.</div>

--- a/client/src/component/Header/Header.tsx
+++ b/client/src/component/Header/Header.tsx
@@ -1,7 +1,85 @@
-import { header } from "./Header.css";
+import { FiLogIn, FiLogOut, FiUser, FiUserPlus } from "react-icons/fi";
+import { useNavigate } from "react-router-dom";
+import { sendPostLogoutRequest } from "../../api/users/crud";
+import { useUserStore } from "../../state/store";
+import {
+  button,
+  header,
+  iconButtonGroup,
+  nicknameInfo,
+  siteTitle,
+  userAuthPanel,
+} from "./Header.css";
 
 const Header = () => {
-  return <div className={header}>Header</div>;
+  const navigate = useNavigate();
+  const isLogin = useUserStore.use.isLogin();
+  const nickname = useUserStore.use.nickname();
+  const { setLogoutUser } = useUserStore.use.actions();
+
+  const handleTitle = () => {
+    navigate("/");
+  };
+
+  const handleLogin = () => {
+    const currentPath = window.location.pathname;
+    navigate(`/login?redirect=${currentPath}`);
+  };
+
+  const handleLogout = async () => {
+    const result = await sendPostLogoutRequest();
+    if (result.status !== 200) {
+      alert("로그아웃에 실패했습니다.");
+      console.log(result);
+      return;
+    }
+    setLogoutUser();
+  };
+
+  const handleUserInfo = () => {
+    //TODO: 유저 정보 화면 생성후 추가
+    console.log("유저정보");
+  };
+
+  const handleJoin = () => {
+    navigate("/join");
+  };
+
+  return (
+    <div className={header}>
+      <div className={siteTitle} onClick={handleTitle}>
+        DBDB DEEP
+      </div>
+      <div className={userAuthPanel}>
+        {isLogin && (
+          <div className={nicknameInfo}>{nickname}님 환영 합니다.</div>
+        )}
+        <div className={iconButtonGroup}>
+          <div
+            className={button}
+            onClick={isLogin ? handleLogout : handleLogin}
+          >
+            {isLogin ? (
+              <FiLogOut size="30" title="로그아웃" />
+            ) : (
+              <FiLogIn size="30" title="로그인" />
+            )}
+          </div>
+          <div
+            onClick={isLogin ? handleUserInfo : handleJoin}
+            className={button}
+          >
+            {isLogin ? (
+              <FiUser size="30" title="유저정보" />
+            ) : (
+              <FiUserPlus size="30" title="회원가입" />
+            )}
+          </div>
+        </div>
+        <div></div>
+      </div>
+    </div>
+  );
 };
 
 export default Header;

--- a/client/src/page/User/Login.tsx
+++ b/client/src/page/User/Login.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from "react";
 import { joinLink, loginWrapper } from "./Login.css";
 import { sendPostLoginRequest } from "../../api/users/crud";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import EmailForm from "../../component/User/EmailForm";
 import PasswordForm from "../../component/User/PasswordForm";
 import ErrorMessageForm from "../../component/User/ErrorMessageForm";
@@ -31,6 +31,8 @@ const Login: FC = () => {
   // const stateIsLogin = useUserStore.use.isLogin();
 
   const navigate = useNavigate();
+  const location = useLocation();
+
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
   };
@@ -74,8 +76,9 @@ const Login: FC = () => {
 
       setLoginUser(nickname, loginTime);
 
-      //TODO: 로그인 헤더 추가 후 로그인 버튼 누른 시점의 페이지로 이동
-      navigate("/user"); // 유저 페이지로 이동
+      const redirect =
+        new URLSearchParams(location.search).get("redirect") || "/";
+      navigate(redirect); // 이전 페이지로
     } else {
       if (result.message) {
         let message: string = result.message;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #90

## 📝 작업 내용

- [x] 로그인 후 상단에 사용자의 닉네임 출력
- [x] 로그인 여부에 따라 로그인 로그아웃 버튼 전환
- [x] 로그아웃 버튼 눌렀을 때 로그아웃 기능 추가(로그아웃 api 호출, logout action 호출)
- [x] 사이트 이름 출력 (DBDB DEEP)
- [x] 로그인 여부에 따라 회원가입, 유저정보 페이지 이동 버튼 전환  

### 스크린샷
- 로그인 안했을 시
![image](https://github.com/user-attachments/assets/c250aef1-a074-45d3-a3d1-3a7b8d69a06f)

- 로그인 했을시
![image](https://github.com/user-attachments/assets/670a3d3a-4fab-4833-8c75-15ad10a08c1c)

## 💬 리뷰 요구사항(선택)

- 버튼들을 아이콘으로 해봤는데요. 글씨로 쓰는게 나을까요 아이콘이 나을까요
- 잘못 구현된 부분이나 이상한 부분 있으면 말해주세요.
