### PR TITLE
[FE] 회원정보 수정 페이지 추가

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import Main from "./page/Main/Main";
 import Header from "./component/Header/Header";
 import { AppContainer, mainContainer } from "./App.css";
 import CheckPassword from "./page/User/CheckPassword";
+import ProfileUpdate from "./page/User/ProfileUpdate";
 
 function App() {
   return (
@@ -23,6 +24,7 @@ function App() {
             <Route path="/login" element={<Login />} />
             <Route path="/join" element={<Join />} />
             <Route path="/checkPassword" element={<CheckPassword />} />
+            <Route path="/profileUpdate" element={<ProfileUpdate />} />
             <Route path="/test" element={<Tests />} />
             <Route path="/posts" element={<Posts />} />
             <Route path="/post/:id" element={<PostInfoPage />} />

--- a/client/src/api/users/crud.ts
+++ b/client/src/api/users/crud.ts
@@ -19,3 +19,7 @@ export const sendPOSTCheckPasswordRequest = async (body: object) => {
 export const sendPostLogoutRequest = async () => {
   return await httpRequest("user/logout", HttpMethod.POST);
 };
+
+export const sendPutUpdateUserRequest = async (body: object) => {
+  return await httpRequest("user", HttpMethod.PUT, convertToBody(body));
+};

--- a/client/src/page/User/ProfileUpdate.css.ts
+++ b/client/src/page/User/ProfileUpdate.css.ts
@@ -13,3 +13,25 @@ export const profileUpdateWrapper = style({
   padding: "24px",
   gap: "10px",
 });
+
+export const buttonsWrapper = style({
+  width: "100%",
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "space-between",
+  gap: "10px",
+});
+
+export const cancleButton = style({
+  width: "100%",
+  height: "50px",
+  padding: "0px",
+  borderRadius: "4px",
+  backgroundColor: "gray",
+  color: "#fff",
+
+  ":hover": {
+    filter: "brightness(0.8)",
+    cursor: "pointer",
+  },
+});

--- a/client/src/page/User/ProfileUpdate.css.ts
+++ b/client/src/page/User/ProfileUpdate.css.ts
@@ -1,0 +1,15 @@
+import { style } from "@vanilla-extract/css";
+
+export const profileUpdateWrapper = style({
+  position: "relative",
+  width: "460px",
+  height: "100%",
+  boxSizing: "border-box",
+  border: "1px solid #ccc",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: "24px",
+  gap: "10px",
+});

--- a/client/src/page/User/ProfileUpdate.tsx
+++ b/client/src/page/User/ProfileUpdate.tsx
@@ -1,0 +1,154 @@
+import { ChangeEvent, FC, useState } from "react";
+import NicknameForm from "../../component/User/NicknameForm";
+import PasswordForm from "../../component/User/PasswordForm";
+import { profileUpdateWrapper } from "./ProfileUpdate.css";
+import SubmitButton from "../../component/User/SubmitButton";
+import { REGEX } from "./constants/constants";
+import ErrorMessageForm from "../../component/User/ErrorMessageForm";
+import { sendPutUpdateUserRequest } from "../../api/users/crud";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useUserStore } from "../../state/store";
+
+interface IProfileUpdateResult {
+  status: number;
+  message: string;
+}
+
+const ProfileUpdate: FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const searchParams = new URLSearchParams(location.search);
+  const final = searchParams.get("final");
+
+  const [nickname, setNickname] = useState("");
+  const [password, setPassword] = useState("");
+  const [requiredPassword, setRequiredPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const { setNickName: storeSetNickName } = useUserStore.use.actions();
+
+  const storeNickName = useUserStore.use.nickname();
+
+  const validateProfileUpdate = (
+    nickname: string,
+    password: string,
+    requiredPassword: string
+  ): boolean => {
+    if (!nickname) {
+      setErrorMessage("닉네임을 입력하세요.");
+      return false;
+    }
+
+    if (nickname === storeNickName) {
+      setErrorMessage("기존 닉네임과 동일합니다.");
+      return false;
+    }
+
+    if (!password) {
+      setErrorMessage("비밀번호를 입력하세요.");
+      return false;
+    }
+    if (!requiredPassword) {
+      setErrorMessage("비밀번호가 서로 다릅니다.");
+      return false;
+    }
+    if (password !== requiredPassword) {
+      setErrorMessage("비밀번호가 일치하지 않습니다.");
+      return false;
+    }
+
+    if (REGEX.PASSWORD.test(password) === false) {
+      setErrorMessage(
+        "비밀번호: 10자 이상의 영문 대/소문자, 숫자를 사용해 주세요."
+      );
+      return false;
+    }
+    return true;
+  };
+
+  const handleError = (result: IProfileUpdateResult) => {
+    if (result.status === 400) {
+      let message: string = result.message;
+      message = message.replace("Bad Request: ", "");
+      setErrorMessage(message);
+      return true;
+    }
+
+    if (
+      result.status === 401 &&
+      result.message === "Unauthorized: 로그인이 필요합니다."
+    ) {
+      alert("로그인이 필요합니다.");
+      navigate("/login");
+      return true;
+    }
+
+    if (result.status !== 200) {
+      alert("검증되지 않은 유저 입니다.");
+      navigate(`/checkPassword?next=profileUpdate&final=${final}`);
+      return true;
+    }
+
+    return false;
+  };
+
+  const handleNicknameChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+  };
+
+  const handlePasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  const handleRequiredPasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setRequiredPassword(e.target.value);
+  };
+
+  const handleSubmit = async () => {
+    if (!validateProfileUpdate(nickname, password, requiredPassword)) {
+      return;
+    }
+
+    const result: IProfileUpdateResult = await sendPutUpdateUserRequest({
+      nickname,
+      password,
+    });
+
+    if (handleError(result)) {
+      return;
+    }
+
+    navigate(final || "/");
+
+    storeSetNickName(nickname);
+
+    alert("유저 정보가 변경되었습니다.");
+  };
+  return (
+    <div className={profileUpdateWrapper}>
+      <h1>유저 정보 수정</h1>
+      <NicknameForm
+        labelText="변경할 닉네임"
+        nickname={nickname}
+        onChange={handleNicknameChange}
+      />
+      <PasswordForm
+        labelText={"변경할 비밀번호"}
+        password={password}
+        onChange={handlePasswordChange}
+      />
+      <PasswordForm
+        labelText={"비밀번호 확인"}
+        id="requiredPassword"
+        password={requiredPassword}
+        onChange={handleRequiredPasswordChange}
+      />
+      <SubmitButton onClick={handleSubmit}>유저 정보 변경</SubmitButton>
+
+      {errorMessage && <ErrorMessageForm>{errorMessage}</ErrorMessageForm>}
+    </div>
+  );
+};
+
+export default ProfileUpdate;

--- a/client/src/page/User/ProfileUpdate.tsx
+++ b/client/src/page/User/ProfileUpdate.tsx
@@ -1,7 +1,11 @@
 import { ChangeEvent, FC, useState } from "react";
 import NicknameForm from "../../component/User/NicknameForm";
 import PasswordForm from "../../component/User/PasswordForm";
-import { profileUpdateWrapper } from "./ProfileUpdate.css";
+import {
+  buttonsWrapper,
+  cancleButton,
+  profileUpdateWrapper,
+} from "./ProfileUpdate.css";
 import SubmitButton from "../../component/User/SubmitButton";
 import { REGEX } from "./constants/constants";
 import ErrorMessageForm from "../../component/User/ErrorMessageForm";
@@ -125,6 +129,10 @@ const ProfileUpdate: FC = () => {
 
     alert("유저 정보가 변경되었습니다.");
   };
+
+  const handleCancle = () => {
+    navigate(final || "/");
+  };
   return (
     <div className={profileUpdateWrapper}>
       <h1>유저 정보 수정</h1>
@@ -144,9 +152,13 @@ const ProfileUpdate: FC = () => {
         password={requiredPassword}
         onChange={handleRequiredPasswordChange}
       />
-      <SubmitButton onClick={handleSubmit}>유저 정보 변경</SubmitButton>
-
       {errorMessage && <ErrorMessageForm>{errorMessage}</ErrorMessageForm>}
+      <div className={buttonsWrapper}>
+        <button className={cancleButton} onClick={handleCancle}>
+          취소
+        </button>
+        <SubmitButton onClick={handleSubmit}>유저 정보 변경</SubmitButton>
+      </div>
     </div>
   );
 };

--- a/client/src/page/User/User.tsx
+++ b/client/src/page/User/User.tsx
@@ -9,6 +9,9 @@ const User = () => {
       <button onClick={() => navigate("/checkPassword")}>
         비밀번호 확인 화면
       </button>
+      <button onClick={() => navigate("/profileUpdate")}>
+        회원정보 수정 화면
+      </button>
     </div>
   );
 };

--- a/server/controller/users_controller.ts
+++ b/server/controller/users_controller.ts
@@ -111,6 +111,7 @@ export const handleUpdateUser = async (
   }
 };
 
+// TODO: 비밀번호가 기존 비밀번호와 같은지 확인 작업 필요
 export const handleCheckPassword = async (
   req: Request,
   res: Response,

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -74,6 +74,7 @@ export const requireLogin = (
   req.userId ? next() : next(ServerError.unauthorized("로그인이 필요합니다."));
 };
 
+// TODO: 기존 유저의 userId와 tenpToken의 userId가 일치하는지 확인하는 로직 추가
 export const requirePassword = (
   req: Request,
   res: Response,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #97 
## 📝 작업 내용

- [x] 회원정보 수정 페이지 추가
- [x] 비밀번호 확인후 회원정보 수정페이지 이동
- [x] 취소 버튼 추가

### 🖼️ 스크린샷
![image](https://github.com/user-attachments/assets/f1b03fb1-c5c9-44f9-8c44-43b412e41b3f)

## 💬 리뷰 요구사항

- 원래 계획은 버튼눌렀을때 회원정보가 보이고 수정버튼 눌러서 변경하게끔 할 계획이었지만 저희가 받은정보가 이메일이랑 닉네임 2개에 바꿀 수 있는거는 닉네임 뿐이라 구성 상 별로라고 느껴져서 해당 이미지처럼 변경했습니다. 다른 아이디어 있으시면 말씀해주세요.

- 잘못 구현된 부분이나 이상한 부분 있으면 말해주세요.
