### PR TITLE
[FE] 댓글 목록 컴포넌트 기본 구조, 댓글 목록 읽기

### DIFF
--- a/client/src/api/comments/crud.ts
+++ b/client/src/api/comments/crud.ts
@@ -1,0 +1,21 @@
+import { HttpMethod, convertToBody, httpRequest } from "../api";
+
+export const sendGetCommentsRequest = async (postId: number) => {
+  const url = `comment?post_id=${postId}`;
+  return await httpRequest(url, HttpMethod.GET);
+};
+
+export const sendPostCommentRequest = async (body: object) => {
+  const requestBody = convertToBody(body);
+  return await httpRequest("comment", HttpMethod.POST, requestBody);
+};
+
+export const sendPatchCommentRequest = async (body: object) => {
+  const requestBody = convertToBody(body);
+  return await httpRequest("comment", HttpMethod.PATCH, requestBody);
+};
+
+export const sendDeleteCommentRequest = async (commentId: number) => {
+  const url = `comment/${commentId}`;
+  return await httpRequest(url, HttpMethod.DELETE);
+};

--- a/client/src/component/Comments/CommentItem/CommentItem.css.ts
+++ b/client/src/component/Comments/CommentItem/CommentItem.css.ts
@@ -38,6 +38,12 @@ export const commentTimestamp = style({
 export const isCommentUpdated = style({
   fontSize: "0.9em",
   opacity: 0.7,
+  cursor: "help",
+
+  ":hover": {
+    opacity: 1,
+    textDecoration: "underline dotted",
+  },
 });
 
 export const commentBody = style({

--- a/client/src/component/Comments/CommentItem/CommentItem.css.ts
+++ b/client/src/component/Comments/CommentItem/CommentItem.css.ts
@@ -1,0 +1,74 @@
+import { style } from "@vanilla-extract/css";
+
+export const commentContainer = style({
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  alignItems: "stretch",
+  boxSizing: "border-box",
+  width: "800px",
+  textAlign: "left",
+
+  ":first-child": {
+    marginTop: "0",
+  },
+});
+
+export const commentHeader = style({
+  display: "flex",
+  justifyContent: "flex-start",
+  alignItems: "baseline",
+  columnGap: "16px",
+  boxSizing: "border-box",
+  borderBottom: "1px solid #80808040",
+  padding: "0 12px 8px",
+  width: "100%",
+  fontSize: "0.95em",
+});
+
+export const commentAuthor = style({
+  fontWeight: "bold",
+});
+
+export const commentTimestamp = style({
+  color: "#808080",
+  fontSize: "0.9em",
+});
+
+export const isCommentUpdated = style({
+  fontSize: "0.9em",
+  opacity: 0.7,
+});
+
+export const commentBody = style({
+  boxSizing: "border-box",
+  padding: "8px 12px",
+  width: "100%",
+});
+
+export const commentContent = style({});
+
+export const commentEdit = style({
+  boxSizing: "border-box",
+  padding: "4px 8px",
+  width: "100%",
+  minHeight: "120px",
+  resize: "vertical",
+  lineHeight: "1.5",
+  fontFamily: "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif",
+  fontSize: "16px",
+});
+
+export const commentFooter = style({
+  display: "flex",
+  justifyContent: "space-between",
+  boxSizing: "border-box",
+  padding: "0 12px",
+  width: "100%",
+  fontSize: "0.9rem",
+});
+
+export const commentEditButtons = style({
+  display: "flex",
+  columnGap: "8px",
+});

--- a/client/src/component/Comments/CommentItem/CommentItem.tsx
+++ b/client/src/component/Comments/CommentItem/CommentItem.tsx
@@ -1,0 +1,87 @@
+import clsx from "clsx";
+import { ReactNode, useMemo, useState } from "react";
+import { IComment } from "shared";
+import { dateToStr } from "../../../utils/date-to-str";
+import CommentLikeButton from "../CommentLikeButton/CommentLikeButton";
+import {
+  commentHeader,
+  commentContainer,
+  commentBody,
+  commentAuthor,
+  commentTimestamp,
+  isCommentUpdated,
+  commentContent,
+  commentEdit,
+  commentFooter,
+  commentEditButtons,
+} from "./CommentItem.css";
+
+interface ICommentItemProps {
+  comment: IComment;
+}
+
+const CommentItem = ({ comment }: ICommentItemProps) => {
+  const [isEditMode, setIsEditMode] = useState(false);
+
+  const contentNodes = useMemo(
+    () =>
+      comment.content
+        .split("\n")
+        .reduce<ReactNode[]>((acc, paragraph, index) => {
+          if (index !== 0) {
+            acc.push(<br key={index} />);
+          }
+          acc.push(paragraph);
+          return acc;
+        }, []),
+    [comment.content]
+  );
+
+  const handleEditModeToggle = () => {
+    setIsEditMode(!isEditMode);
+  };
+
+  return (
+    <div className={commentContainer}>
+      <div className={commentHeader}>
+        <div className={commentAuthor}>{comment.author_nickname}</div>
+        <div className={commentTimestamp}>
+          {dateToStr(comment.created_at)}
+          {comment.updated_at ? (
+            <span className={isCommentUpdated}> (수정됨)</span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className={commentBody}>
+        {isEditMode ? (
+          <textarea className={commentEdit} defaultValue="수정 폼" />
+        ) : (
+          <div className={commentContent}>{contentNodes}</div>
+        )}
+      </div>
+
+      <div className={commentFooter}>
+        <CommentLikeButton
+          likes={comment.likes}
+          userLiked={comment.user_liked}
+        />
+
+        {comment.is_author &&
+          (isEditMode ? (
+            <div className={clsx(commentEditButtons)}>
+              <button onClick={() => alert("수정한 댓글 제출")}>완료</button>
+              <button onClick={handleEditModeToggle}>취소</button>
+            </div>
+          ) : (
+            <div className={clsx(commentEditButtons)}>
+              <button onClick={handleEditModeToggle}>수정</button>
+              <button onClick={() => alert("댓글 삭제 요청")}>삭제</button>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+};
+
+export default CommentItem;

--- a/client/src/component/Comments/CommentItem/CommentItem.tsx
+++ b/client/src/component/Comments/CommentItem/CommentItem.tsx
@@ -48,7 +48,15 @@ const CommentItem = ({ comment }: ICommentItemProps) => {
         <div className={commentTimestamp}>
           {dateToStr(comment.created_at)}
           {comment.updated_at ? (
-            <span className={isCommentUpdated}> (수정됨)</span>
+            <>
+              {" "}
+              <span
+                className={isCommentUpdated}
+                title={`최종 수정: ${dateToStr(comment.updated_at)}`}
+              >
+                (수정됨)
+              </span>
+            </>
           ) : null}
         </div>
       </div>

--- a/client/src/component/Comments/CommentLikeButton/CommentLikeButton.css.ts
+++ b/client/src/component/Comments/CommentLikeButton/CommentLikeButton.css.ts
@@ -1,0 +1,11 @@
+import { style } from "@vanilla-extract/css";
+
+export const likeButton = style({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  columnGap: "4px",
+  boxSizing: "border-box",
+  padding: "0 12px",
+  height: "40px",
+});

--- a/client/src/component/Comments/CommentLikeButton/CommentLikeButton.tsx
+++ b/client/src/component/Comments/CommentLikeButton/CommentLikeButton.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { AiFillLike } from "react-icons/ai";
+import { vars } from "../../../App.css";
+import { useUserStore } from "../../../state/store";
+import { likeButton } from "./CommentLikeButton.css";
+
+interface ICommentLikeButtonProps {
+  likes: number;
+  userLiked?: boolean;
+}
+
+const CommentLikeButton = ({ likes, userLiked }: ICommentLikeButtonProps) => {
+  const isLogin = useUserStore((state) => state.isLogin);
+
+  const [toggled, setToggled] = useState(false);
+
+  const actualUserLiked = userLiked !== toggled; // XOR
+  const diff = toggled ? (userLiked ? -1 : 1) : 0;
+
+  const handleLikeClick = () => {
+    if (!isLogin) {
+      alert("로그인이 필요합니다!");
+      return;
+    }
+
+    if (actualUserLiked) {
+      // TODO: 좋아요 취소 요청 후 성공 응답 시 상태 변경
+      setToggled(!toggled);
+    } else {
+      // TODO: 좋아요 활성화 요청 후 성공 응답 시 상태 변경
+      setToggled(!toggled);
+    }
+  };
+
+  return (
+    <button className={likeButton} onClick={handleLikeClick}>
+      <AiFillLike
+        color={actualUserLiked ? vars.color.successButton : "#808080"}
+      />
+      {likes + diff}
+    </button>
+  );
+};
+
+export default CommentLikeButton;

--- a/client/src/component/Comments/Comments.css.ts
+++ b/client/src/component/Comments/Comments.css.ts
@@ -1,0 +1,31 @@
+import { style } from "@vanilla-extract/css";
+
+export const commentSection = style({
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  alignItems: "stretch",
+  boxSizing: "border-box",
+  margin: "40px 0",
+  width: "800px",
+  textAlign: "left",
+});
+
+export const commentSectionTitle = style({
+  boxSizing: "border-box",
+  margin: 0,
+  borderBottom: "1px solid black",
+  padding: "0 12px 8px",
+  fontSize: "20px",
+});
+
+export const commentCount = style({
+  fontSize: "0.8em",
+});
+
+export const commentList = style({
+  display: "flex",
+  flexDirection: "column",
+  rowGap: "40px",
+  margin: "40px 0",
+});

--- a/client/src/component/Comments/Comments.tsx
+++ b/client/src/component/Comments/Comments.tsx
@@ -1,0 +1,46 @@
+import { IComment, mapDBToComments } from "shared";
+import CommentItem from "./CommentItem/CommentItem";
+import { useLayoutEffect, useState } from "react";
+import { sendGetCommentsRequest } from "../../api/comments/crud";
+import {
+  commentCount,
+  commentList,
+  commentSection,
+  commentSectionTitle,
+} from "./Comments.css";
+
+interface ICommentsProps {
+  postId: number;
+}
+
+const Comments = ({ postId }: ICommentsProps) => {
+  const [comments, setComments] = useState<IComment[]>([]);
+
+  useLayoutEffect(() => {
+    sendGetCommentsRequest(postId).then((data) => {
+      if (data.status >= 400) {
+        // TODO: 에러 핸들링
+        console.log(data);
+        return;
+      }
+
+      setComments(mapDBToComments(data.comments));
+    });
+  }, [postId]);
+
+  return (
+    <div className={commentSection}>
+      <h2 className={commentSectionTitle}>
+        댓글<span className={commentCount}> ({comments.length}개)</span>
+      </h2>
+
+      <div className={commentList}>
+        {comments.map((comment) => (
+          <CommentItem key={comment.id} comment={comment} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Comments;

--- a/client/src/component/Comments/Comments.tsx
+++ b/client/src/component/Comments/Comments.tsx
@@ -17,6 +17,10 @@ const Comments = ({ postId }: ICommentsProps) => {
   const [comments, setComments] = useState<IComment[]>([]);
 
   useLayoutEffect(() => {
+    if (postId < 1) {
+      return;
+    }
+
     sendGetCommentsRequest(postId).then((data) => {
       if (data.status >= 400) {
         // TODO: 에러 핸들링

--- a/client/src/page/Posts/PostInfoPage.tsx
+++ b/client/src/page/Posts/PostInfoPage.tsx
@@ -40,7 +40,7 @@ const PostInfoPage = () => {
   return (
     <div className={PostInfoPageStyle}>
       <PostInfo postInfo={postInfo} />
-      <Comments postId={postInfo.id} />
+      <Comments postId={postInfo.id || parseInt(id ?? "0", 10) || 0} />
     </div>
   );
 };

--- a/client/src/page/Posts/PostInfoPage.tsx
+++ b/client/src/page/Posts/PostInfoPage.tsx
@@ -4,6 +4,7 @@ import { PostInfoPageStyle } from "./PostInfoPage.css";
 import { useParams } from 'react-router-dom';
 import { IPostInfo, mapDBToPostInfo } from "shared";
 import { sendGetPostRequest } from "../../api/posts/crud";
+import Comments from "../../component/Comments/Comments";
 
 const PostInfoPage = () => {
   const { id } = useParams();
@@ -38,9 +39,10 @@ const PostInfoPage = () => {
 
   return (
     <div className={PostInfoPageStyle}>
-        <PostInfo postInfo={postInfo}/>
+      <PostInfo postInfo={postInfo} />
+      <Comments postId={postInfo.id} />
     </div>
-  )
-}
+  );
+};
 
-export default PostInfoPage
+export default PostInfoPage;

--- a/server/db/context/comments_context.ts
+++ b/server/db/context/comments_context.ts
@@ -1,3 +1,4 @@
+import { mapDBToComments } from "shared";
 import {
   FieldPacket,
   PoolConnection,
@@ -6,7 +7,6 @@ import {
 } from "mysql2/promise";
 import { ServerError } from "../../middleware/errors";
 import pool from "../connect";
-import { mapDBToComments } from "../mapper/comments_mapper";
 
 interface ICommentInsertion {
   post_id: number;

--- a/shared/comments/mappers.ts
+++ b/shared/comments/mappers.ts
@@ -1,4 +1,4 @@
-import { IComment } from "../model/comments";
+import { IComment } from "./models";
 
 export const mapDBToComments = (data: any[]): IComment[] => {
   return data.map((item) => ({
@@ -6,7 +6,7 @@ export const mapDBToComments = (data: any[]): IComment[] => {
     content: item.content,
     author_id: item.author_id,
     author_nickname: item.author_nickname,
-    is_author : !!item.is_author,
+    is_author: !!item.is_author,
     created_at: new Date(item.created_at),
     updated_at: item.updated_at ? new Date(item.updated_at) : null,
     likes: item.likes,

--- a/shared/comments/models.ts
+++ b/shared/comments/models.ts
@@ -3,7 +3,7 @@ export interface IComment {
   content: string;
   author_id: number;
   author_nickname: string;
-  is_author : boolean;
+  is_author: boolean;
   created_at: Date;
   updated_at?: Date | null;
   likes: number;

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,3 +1,5 @@
 export * from './posts/enums';
 export * from './posts/mappers';
 export * from './posts/models';
+export * from './comments/mappers';
+export * from './comments/models';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #91 : 작업이 길어져서 기본적인 부분(읽기) 먼저 반영하고자 합니다.

## 📝 작업 내용

- 댓글 항목 컴포넌트
  - [x] 기본 항목 표시 (author_nickname, content, updated_at, created_at, likes)
  - 댓글 좋아요 컴포넌트
    - [x] 좋아요 개수 출력
    - [x] 로그인 상태에서 클릭 시, 좋아요 토글
    - [ ] 댓글 좋아요 활성화/취소 요청 전송
  - 댓글 수정·삭제 버튼
    - [x] 자신의 댓글에만 표시
    - [x] 댓글 수정: 댓글 수정 상태 토글
    - [ ] 댓글 삭제: 사용자의 의사를 확인하고 진행
  - 댓글 수정 폼
    - [x] 댓글 본문 자리에 `<textarea>`, 취소 버튼, 제출 버튼 표시
    - [ ] 컴포넌트로 추출
    - [ ] 댓글 수정 제출
- 댓글 목록 컴포넌트
  - [x] 댓글 목록 조회를 요청하여 가져온 데이터를 댓글 항목 컴포넌트의 배열로 매핑
  - [x] `<PostInfoPage>` 페이지 컴포넌트에 연결

### 🖼️ 스크린샷

<details><summary>🖼️ 댓글 렌더 예시 + 좋아요 유무 비교 (아래가 좋아요 누른 상태)</summary>

> <img width="600" alt="comment_comparison" src="https://github.com/user-attachments/assets/9371c7e9-88d3-4dd1-92b2-2ae5715a3a86">

</details>

<details><summary>🖼️ 회원 본인의 댓글에는 수정, 삭제 버튼을 표시</summary>

> <img width="600" alt="comment_mine" src="https://github.com/user-attachments/assets/fcb35656-505f-48d6-a68f-9e5a5f822f1d">

</details>

<details><summary>🖼️ 댓글 수정 토글: 댓글 수정 모드</summary>

> <img width="600" alt="comment_edit" src="https://github.com/user-attachments/assets/efbe7ce8-0f38-4176-a5c2-2a246841e149">

</details>

## 💬 리뷰 요구사항

- 저의 우선순위 설정 미숙으로 작업이 늘어져서, 일단 기본적인 부분(읽기) 먼저 반영하고자 합니다.
- 잘못된 부분이나 수정 필요한 부분 있으면 말씀해 주세요.
