### PR TITLE
[FE] 댓글 작성, 수정, 삭제, 좋아요

### DIFF
--- a/client/src/api/likes/crud.ts
+++ b/client/src/api/likes/crud.ts
@@ -9,3 +9,13 @@ export const sendDeletePostLikeRequest = async (param : number) => {
     const url = `/like/post/${param}`;
     return await httpRequest(url, HttpMethod.DELETE);
 };
+
+export const sendCreateCommentLikeRequest = async (param : number) => {
+    const url = `/like/comment/${param}`;
+    return await httpRequest(url, HttpMethod.POST);
+};
+
+export const sendDeleteCommentLikeRequest = async (param : number) => {
+    const url = `/like/comment/${param}`;
+    return await httpRequest(url, HttpMethod.DELETE);
+};

--- a/client/src/component/Comments/CommentForm/CommentForm.css.ts
+++ b/client/src/component/Comments/CommentForm/CommentForm.css.ts
@@ -1,0 +1,37 @@
+import { style } from "@vanilla-extract/css";
+
+export const commentFormContainer = style({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "stretch",
+  rowGap: "8px",
+  boxSizing: "border-box",
+  width: "800px",
+});
+
+export const textArea = style({
+  boxSizing: "border-box",
+  border: "1px solid #80808080",
+  borderRadius: "8px",
+  padding: "4px 8px",
+  width: "100%",
+  minHeight: "100px",
+  resize: "vertical",
+  lineHeight: "1.5",
+  fontFamily: "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif",
+  fontSize: "16px",
+});
+
+export const footer = style({
+  display: "flex",
+  justifyContent: "flex-end",
+  alignItems: "flex-start",
+});
+
+export const submitButton = style({
+  selectors: {
+    "&[disabled]": {
+      cursor: "not-allowed",
+    },
+  },
+});

--- a/client/src/component/Comments/CommentForm/CommentForm.css.ts
+++ b/client/src/component/Comments/CommentForm/CommentForm.css.ts
@@ -6,14 +6,15 @@ export const commentFormContainer = style({
   alignItems: "stretch",
   rowGap: "8px",
   boxSizing: "border-box",
-  width: "800px",
+  width: "100%",
 });
 
 export const textArea = style({
   boxSizing: "border-box",
+  marginBottom: "",
   border: "1px solid #80808080",
   borderRadius: "8px",
-  padding: "4px 8px",
+  padding: "7px 11px",
   width: "100%",
   minHeight: "100px",
   resize: "vertical",
@@ -26,9 +27,13 @@ export const footer = style({
   display: "flex",
   justifyContent: "flex-end",
   alignItems: "flex-start",
+  columnGap: "8px",
 });
 
-export const submitButton = style({
+export const button = style({
+  height: "40px",
+  fontSize: "0.9rem",
+
   selectors: {
     "&[disabled]": {
       cursor: "not-allowed",

--- a/client/src/component/Comments/CommentForm/CommentForm.tsx
+++ b/client/src/component/Comments/CommentForm/CommentForm.tsx
@@ -1,0 +1,66 @@
+import { ChangeEvent, FormEvent, useCallback, useState } from "react";
+import { useUserStore } from "../../../state/store";
+import {
+  commentFormContainer,
+  footer,
+  submitButton,
+  textArea,
+} from "./CommentForm.css";
+
+interface ICommentFormProps {
+  defaultContent?: string;
+  onSubmit: (content: string) => Promise<boolean>;
+}
+
+const CommentForm = ({
+  defaultContent,
+  onSubmit,
+}: ICommentFormProps) => {
+  const isLogin = useUserStore((state) => state.isLogin);
+
+  const [content, setContent] = useState(defaultContent || "");
+
+  const handleFormSubmit = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault();
+
+      const trimmedContent = content.trim();
+      if (!trimmedContent) {
+        alert("댓글 내용을 입력하세요.");
+        return;
+      }
+
+      const success = await onSubmit(trimmedContent);
+      if (success) {
+        setContent("");
+      }
+    },
+    [content, onSubmit]
+  );
+
+  const handleContentChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      setContent(event.target.value);
+    },
+    []
+  );
+
+  return (
+    <form className={commentFormContainer} onSubmit={handleFormSubmit}>
+      <textarea
+        className={textArea}
+        value={isLogin ? content : "댓글을 작성하려면 로그인이 필요합니다."}
+        disabled={!isLogin}
+        onChange={handleContentChange}
+      />
+
+      <div className={footer}>
+        <button type="submit" className={submitButton} disabled={!isLogin}>
+          등록
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default CommentForm;

--- a/client/src/component/Comments/CommentForm/CommentForm.tsx
+++ b/client/src/component/Comments/CommentForm/CommentForm.tsx
@@ -1,20 +1,24 @@
 import { ChangeEvent, FormEvent, useCallback, useState } from "react";
 import { useUserStore } from "../../../state/store";
 import {
+  button,
   commentFormContainer,
   footer,
-  submitButton,
   textArea,
 } from "./CommentForm.css";
 
 interface ICommentFormProps {
   defaultContent?: string;
+  isUpdateMode?: boolean;
   onSubmit: (content: string) => Promise<boolean>;
+  onCancel?: () => void;
 }
 
 const CommentForm = ({
   defaultContent,
+  isUpdateMode,
   onSubmit,
+  onCancel,
 }: ICommentFormProps) => {
   const isLogin = useUserStore((state) => state.isLogin);
 
@@ -45,6 +49,12 @@ const CommentForm = ({
     []
   );
 
+  const handleCancelClick = useCallback(() => {
+    if (onCancel) {
+      onCancel();
+    }
+  }, [onCancel]);
+
   return (
     <form className={commentFormContainer} onSubmit={handleFormSubmit}>
       <textarea
@@ -55,9 +65,14 @@ const CommentForm = ({
       />
 
       <div className={footer}>
-        <button type="submit" className={submitButton} disabled={!isLogin}>
-          등록
+        <button type="submit" className={button} disabled={!isLogin}>
+          {isUpdateMode ? "수정" : "등록"}
         </button>
+        {isUpdateMode && (
+          <button type="button" className={button} onClick={handleCancelClick}>
+            취소
+          </button>
+        )}
       </div>
     </form>
   );

--- a/client/src/component/Comments/CommentItem/CommentItem.css.ts
+++ b/client/src/component/Comments/CommentItem/CommentItem.css.ts
@@ -47,22 +47,13 @@ export const isCommentUpdated = style({
 });
 
 export const commentBody = style({
-  boxSizing: "border-box",
-  padding: "8px 12px",
   width: "100%",
 });
 
-export const commentContent = style({});
-
-export const commentEdit = style({
+export const commentContent = style({
   boxSizing: "border-box",
-  padding: "4px 8px",
+  padding: "8px 12px",
   width: "100%",
-  minHeight: "120px",
-  resize: "vertical",
-  lineHeight: "1.5",
-  fontFamily: "Inter, system-ui, Avenir, Helvetica, Arial, sans-serif",
-  fontSize: "16px",
 });
 
 export const commentFooter = style({

--- a/client/src/component/Comments/CommentItem/CommentItem.tsx
+++ b/client/src/component/Comments/CommentItem/CommentItem.tsx
@@ -46,6 +46,13 @@ const CommentItem = ({ comment, onUpdate }: ICommentItemProps) => {
   };
 
   const handleEditionSubmit = async (content: string): Promise<boolean> => {
+    const trimmedContent = content.trim();
+
+    if (trimmedContent === comment.content) {
+      alert("댓글 내용이 이전과 동일합니다.");
+      return false;
+    }
+
     try {
       const response = await sendPatchCommentRequest({
         content,

--- a/client/src/component/Comments/CommentItem/CommentItem.tsx
+++ b/client/src/component/Comments/CommentItem/CommentItem.tsx
@@ -1,6 +1,9 @@
 import { ReactNode, useMemo, useState } from "react";
 import { IComment } from "shared";
-import { sendPatchCommentRequest } from "../../../api/comments/crud";
+import {
+  sendDeleteCommentRequest,
+  sendPatchCommentRequest,
+} from "../../../api/comments/crud";
 import { dateToStr } from "../../../utils/date-to-str";
 import CommentForm from "../CommentForm/CommentForm";
 import CommentLikeButton from "../CommentLikeButton/CommentLikeButton";
@@ -66,6 +69,36 @@ const CommentItem = ({ comment, onUpdate }: ICommentItemProps) => {
       await onUpdate();
     }
 
+    return true;
+  };
+
+  const handleDeleteClick = async () => {
+    const accepted = confirm("댓글을 정말로 삭제할까요?");
+
+    if (!accepted) {
+      return;
+    }
+
+    try {
+      const response = await sendDeleteCommentRequest(comment.id);
+
+      if (response?.status >= 400) {
+        console.error(response);
+        alert("댓글 삭제에 실패했습니다.");
+        return false;
+      }
+
+      alert("댓글을 삭제했습니다.");
+    } catch (error) {
+      console.error(error);
+      alert("댓글 삭제에 실패했습니다.");
+      return false;
+    }
+
+    if (onUpdate) {
+      await onUpdate();
+    }
+
     setIsEditMode(false);
 
     return true;
@@ -114,7 +147,7 @@ const CommentItem = ({ comment, onUpdate }: ICommentItemProps) => {
           {comment.is_author && (
             <div className={commentEditButtons}>
               <button onClick={handleEditModeToggle}>수정</button>
-              <button onClick={() => alert("댓글 삭제 요청")}>삭제</button>
+              <button onClick={handleDeleteClick}>삭제</button>
             </div>
           )}
         </div>

--- a/client/src/component/Comments/CommentItem/CommentItem.tsx
+++ b/client/src/component/Comments/CommentItem/CommentItem.tsx
@@ -147,6 +147,7 @@ const CommentItem = ({ comment, onUpdate }: ICommentItemProps) => {
       {isEditMode || (
         <div className={commentFooter}>
           <CommentLikeButton
+            commentId={comment.id}
             likes={comment.likes}
             userLiked={comment.user_liked}
           />

--- a/client/src/component/Comments/CommentItem/CommentItem.tsx
+++ b/client/src/component/Comments/CommentItem/CommentItem.tsx
@@ -1,7 +1,8 @@
-import clsx from "clsx";
 import { ReactNode, useMemo, useState } from "react";
 import { IComment } from "shared";
+import { sendPatchCommentRequest } from "../../../api/comments/crud";
 import { dateToStr } from "../../../utils/date-to-str";
+import CommentForm from "../CommentForm/CommentForm";
 import CommentLikeButton from "../CommentLikeButton/CommentLikeButton";
 import {
   commentHeader,
@@ -11,16 +12,16 @@ import {
   commentTimestamp,
   isCommentUpdated,
   commentContent,
-  commentEdit,
   commentFooter,
   commentEditButtons,
 } from "./CommentItem.css";
 
 interface ICommentItemProps {
   comment: IComment;
+  onUpdate?: () => Promise<void>;
 }
 
-const CommentItem = ({ comment }: ICommentItemProps) => {
+const CommentItem = ({ comment, onUpdate }: ICommentItemProps) => {
   const [isEditMode, setIsEditMode] = useState(false);
 
   const contentNodes = useMemo(
@@ -39,6 +40,35 @@ const CommentItem = ({ comment }: ICommentItemProps) => {
 
   const handleEditModeToggle = () => {
     setIsEditMode(!isEditMode);
+  };
+
+  const handleEditionSubmit = async (content: string): Promise<boolean> => {
+    try {
+      const response = await sendPatchCommentRequest({
+        content,
+        id: comment.id,
+      });
+
+      if (response?.status >= 400) {
+        console.error(response);
+        alert("댓글 수정에 실패했습니다.");
+        return false;
+      }
+
+      alert("댓글을 수정했습니다.");
+    } catch (error) {
+      console.error(error);
+      alert("댓글 수정에 실패했습니다.");
+      return false;
+    }
+
+    if (onUpdate) {
+      await onUpdate();
+    }
+
+    setIsEditMode(false);
+
+    return true;
   };
 
   return (
@@ -63,31 +93,32 @@ const CommentItem = ({ comment }: ICommentItemProps) => {
 
       <div className={commentBody}>
         {isEditMode ? (
-          <textarea className={commentEdit} defaultValue="수정 폼" />
+          <CommentForm
+            defaultContent={comment.content}
+            isUpdateMode={true}
+            onSubmit={handleEditionSubmit}
+            onCancel={handleEditModeToggle}
+          />
         ) : (
           <div className={commentContent}>{contentNodes}</div>
         )}
       </div>
 
-      <div className={commentFooter}>
-        <CommentLikeButton
-          likes={comment.likes}
-          userLiked={comment.user_liked}
-        />
+      {isEditMode || (
+        <div className={commentFooter}>
+          <CommentLikeButton
+            likes={comment.likes}
+            userLiked={comment.user_liked}
+          />
 
-        {comment.is_author &&
-          (isEditMode ? (
-            <div className={clsx(commentEditButtons)}>
-              <button onClick={() => alert("수정한 댓글 제출")}>완료</button>
-              <button onClick={handleEditModeToggle}>취소</button>
-            </div>
-          ) : (
-            <div className={clsx(commentEditButtons)}>
+          {comment.is_author && (
+            <div className={commentEditButtons}>
               <button onClick={handleEditModeToggle}>수정</button>
               <button onClick={() => alert("댓글 삭제 요청")}>삭제</button>
             </div>
-          ))}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/component/Comments/CommentItem/CommentItem.tsx
+++ b/client/src/component/Comments/CommentItem/CommentItem.tsx
@@ -76,6 +76,8 @@ const CommentItem = ({ comment, onUpdate }: ICommentItemProps) => {
       await onUpdate();
     }
 
+    setIsEditMode(false);
+
     return true;
   };
 

--- a/client/src/component/Comments/CommentLikeButton/CommentLikeButton.tsx
+++ b/client/src/component/Comments/CommentLikeButton/CommentLikeButton.tsx
@@ -1,15 +1,24 @@
 import { useState } from "react";
 import { AiFillLike } from "react-icons/ai";
 import { vars } from "../../../App.css";
+import {
+  sendCreateCommentLikeRequest,
+  sendDeleteCommentLikeRequest,
+} from "../../../api/likes/crud";
 import { useUserStore } from "../../../state/store";
 import { likeButton } from "./CommentLikeButton.css";
 
 interface ICommentLikeButtonProps {
+  commentId: number;
   likes: number;
   userLiked?: boolean;
 }
 
-const CommentLikeButton = ({ likes, userLiked }: ICommentLikeButtonProps) => {
+const CommentLikeButton = ({
+  commentId,
+  likes,
+  userLiked,
+}: ICommentLikeButtonProps) => {
   const isLogin = useUserStore((state) => state.isLogin);
 
   const [toggled, setToggled] = useState(false);
@@ -17,19 +26,27 @@ const CommentLikeButton = ({ likes, userLiked }: ICommentLikeButtonProps) => {
   const actualUserLiked = userLiked !== toggled; // XOR
   const diff = toggled ? (userLiked ? -1 : 1) : 0;
 
-  const handleLikeClick = () => {
+  const handleLikeClick = async () => {
     if (!isLogin) {
       alert("로그인이 필요합니다!");
       return;
     }
 
+    let response;
+
     if (actualUserLiked) {
-      // TODO: 좋아요 취소 요청 후 성공 응답 시 상태 변경
-      setToggled(!toggled);
+      response = await sendDeleteCommentLikeRequest(commentId);
     } else {
-      // TODO: 좋아요 활성화 요청 후 성공 응답 시 상태 변경
-      setToggled(!toggled);
+      response = await sendCreateCommentLikeRequest(commentId);
     }
+
+    if (response?.status >= 400) {
+      console.error(response);
+      alert(`좋아요${actualUserLiked ? " 취소" : ""} 실패`);
+      return;
+    }
+
+    setToggled(!toggled);
   };
 
   return (

--- a/client/src/component/Comments/Comments.css.ts
+++ b/client/src/component/Comments/Comments.css.ts
@@ -5,6 +5,7 @@ export const commentSection = style({
   flexDirection: "column",
   justifyContent: "flex-start",
   alignItems: "stretch",
+  rowGap: "40px",
   boxSizing: "border-box",
   margin: "40px 0",
   width: "800px",
@@ -27,5 +28,4 @@ export const commentList = style({
   display: "flex",
   flexDirection: "column",
   rowGap: "40px",
-  margin: "40px 0",
 });

--- a/client/src/component/Comments/Comments.css.ts
+++ b/client/src/component/Comments/Comments.css.ts
@@ -24,6 +24,20 @@ export const commentCount = style({
   fontSize: "0.8em",
 });
 
+export const commentWriteSection = style({
+  display: "flex",
+  flexDirection: "column",
+  rowGap: "8px",
+  boxSizing: "border-box",
+  width: "100%",
+});
+
+export const commentFormTitle = style({
+  margin: 0,
+  padding: "0 12px",
+  fontSize: "18px",
+});
+
 export const commentList = style({
   display: "flex",
   flexDirection: "column",

--- a/client/src/component/Comments/Comments.css.ts
+++ b/client/src/component/Comments/Comments.css.ts
@@ -43,3 +43,10 @@ export const commentList = style({
   flexDirection: "column",
   rowGap: "40px",
 });
+
+export const noComment = style({
+  margin: "0 0 120px",
+  textAlign: "center",
+  color: "#808080",
+  fontSize: "24px",
+});

--- a/client/src/component/Comments/Comments.tsx
+++ b/client/src/component/Comments/Comments.tsx
@@ -13,6 +13,7 @@ import {
   commentSection,
   commentSectionTitle,
   commentWriteSection,
+  noComment,
 } from "./Comments.css";
 
 interface ICommentsProps {
@@ -82,13 +83,20 @@ const Comments = ({ postId }: ICommentsProps) => {
       </div>
 
       <div className={commentList}>
-        {comments.map((comment) => (
-          <CommentItem
-            key={comment.id}
-            comment={comment}
-            onUpdate={handleCommentUpdate}
-          />
-        ))}
+        {comments.length > 0 ? (
+          comments.map((comment) => (
+            <CommentItem
+              key={comment.id}
+              comment={comment}
+              onUpdate={handleCommentUpdate}
+            />
+          ))
+        ) : (
+          <p className={noComment}>
+            아직 댓글이 없습니다.
+            <br />첫 댓글을 작성해 보세요.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/client/src/component/Comments/Comments.tsx
+++ b/client/src/component/Comments/Comments.tsx
@@ -1,7 +1,11 @@
-import { IComment, mapDBToComments } from "shared";
-import CommentItem from "./CommentItem/CommentItem";
 import { useLayoutEffect, useState } from "react";
-import { sendGetCommentsRequest } from "../../api/comments/crud";
+import { IComment, mapDBToComments } from "shared";
+import {
+  sendGetCommentsRequest,
+  sendPostCommentRequest,
+} from "../../api/comments/crud";
+import CommentForm from "./CommentForm/CommentForm";
+import CommentItem from "./CommentItem/CommentItem";
 import {
   commentCount,
   commentList,
@@ -14,6 +18,7 @@ interface ICommentsProps {
 }
 
 const Comments = ({ postId }: ICommentsProps) => {
+  const [submissionTime, setSubmissionTime] = useState(0);
   const [comments, setComments] = useState<IComment[]>([]);
 
   useLayoutEffect(() => {
@@ -30,13 +35,38 @@ const Comments = ({ postId }: ICommentsProps) => {
 
       setComments(mapDBToComments(data.comments));
     });
-  }, [postId]);
+  }, [postId, submissionTime]);
+
+  const handleCommentCreate = async (content: string): Promise<boolean> => {
+    try {
+      const response = await sendPostCommentRequest({
+        content,
+        post_id: postId,
+      });
+
+      if (response?.status >= 400) {
+        alert("댓글 작성에 실패했습니다.");
+        return false;
+      }
+
+      setSubmissionTime(Date.now());
+      alert("댓글을 작성했습니다.");
+    } catch (error) {
+      console.error(error);
+      alert("댓글 작성에 실패했습니다.");
+      return false;
+    }
+
+    return true;
+  };
 
   return (
     <div className={commentSection}>
       <h2 className={commentSectionTitle}>
         댓글<span className={commentCount}> ({comments.length}개)</span>
       </h2>
+
+      <CommentForm onSubmit={handleCommentCreate} />
 
       <div className={commentList}>
         {comments.map((comment) => (


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #91
- #101

## 📝 작업 내용

PR #101 에 이어서, 클라이언트에서의 댓글 작성, 수정, 삭제와 댓글 좋아요/취소를 구현합니다.

- [x] 댓글 작성 폼
  - [x] 로그아웃 상태에서는 작성 및 제출 불가
- 댓글 항목 컴포넌트
  - 댓글 좋아요 컴포넌트
    - [x] 댓글 좋아요/취소 요청 전송
  - 댓글 수정 폼
    - [x] 컴포넌트로 추출: 댓글 작성 폼과 같은 컴포넌트를 사용하며, `isUpdateMode` prop으로 수정/신규를 구분합니다. 수정 모드에서는 취소 버튼이 추가로 표시됩니다.
    - [x] 댓글 수정 제출
    - [x] 댓글 수정 성공 시 댓글 목록 업데이트
  - 댓글 삭제
    - [x] 댓글 삭제: 사용자의 의사를 확인하고 진행. 일단 `window.confirm()`으로 작성했습니다.
    - [x] 댓글 삭제 성공 시 댓글 목록 업데이트
- 댓글 목록 컴포넌트
  - [x] 댓글 없음 표시

### 🖼️ 스크린샷

다른 UI 부분은 #101 과 유사합니다.

#### 🖼️ 댓글 수정

![comment-modify](https://github.com/user-attachments/assets/a583eae7-fcdb-45c6-95c9-2edb509c71a3)

#### 🖼️ 댓글이 없는 게시글, 비로그인 상태

![no-comment](https://github.com/user-attachments/assets/63d448cd-b8cf-4b37-b80a-033c757dd486)

## 💬 리뷰 요구사항

- 잘못 구현된 부분이나 수정이 필요한 부분 있으면 말씀해 주세요.