### PR TITLE
[FE] 메인 페이지의 게시글 목록 정보 보충

### DIFF
--- a/client/src/component/Posts/PostList/EmptyPostListBody.tsx
+++ b/client/src/component/Posts/PostList/EmptyPostListBody.tsx
@@ -1,0 +1,28 @@
+interface IEmptyPostListBody {
+  className?: string;
+  isFetchFailed: boolean;
+  keyword?: string;
+}
+
+const EmptyPostListBody = ({
+  className,
+  isFetchFailed,
+  keyword,
+}: IEmptyPostListBody) => {
+  return (
+    <p className={className}>
+      {isFetchFailed ? (
+        "게시글을 불러오지 못했습니다."
+      ) : keyword ? (
+        <>“{keyword}”에 대한 검색 결과가 없습니다.</>
+      ) : (
+        <>
+          아직 게시글이 없습니다.
+          <br />첫 게시글을 작성해 보세요.
+        </>
+      )}
+    </p>
+  );
+};
+
+export default EmptyPostListBody;

--- a/client/src/component/Posts/PostList/PostList.css.ts
+++ b/client/src/component/Posts/PostList/PostList.css.ts
@@ -112,3 +112,10 @@ export const postListRow = {
     flex: "0 0 64px",
   }),
 };
+
+export const noPost = style({
+  margin: "120px 0",
+  textAlign: "center",
+  color: "#808080",
+  fontSize: "24px",
+});

--- a/client/src/component/Posts/PostList/PostList.tsx
+++ b/client/src/component/Posts/PostList/PostList.tsx
@@ -4,6 +4,7 @@ import { FiArrowDown } from "react-icons/fi";
 import { Link } from "react-router-dom";
 import { IPostHeader, SortBy } from "shared";
 import { dateToStr } from "../../../utils/date-to-str";
+import EmptyPostListBody from "./EmptyPostListBody";
 import {
   noPost,
   notSorted,
@@ -17,7 +18,7 @@ import {
 } from "./PostList.css";
 
 interface IPostListProps {
-  posts: IPostHeader[];
+  posts: IPostHeader[] | null;
   keyword?: string;
   sortBy: SortBy | null;
   onSort: (sortBy: SortBy | null) => void;
@@ -30,6 +31,11 @@ const PostList = ({ posts, keyword, sortBy, onSort }: IPostListProps) => {
 
       onSort(nextSortBy);
     };
+
+  const isFetchFailed = posts === null;
+  const isPostsEmpty = isFetchFailed || posts.length === 0;
+
+  console.log(isFetchFailed, posts);
 
   return (
     <div className={postListStyle}>
@@ -85,7 +91,13 @@ const PostList = ({ posts, keyword, sortBy, onSort }: IPostListProps) => {
       </div>
 
       <div className={postListBody}>
-        {posts.length > 0 ? (
+        {isPostsEmpty ? (
+          <EmptyPostListBody
+            className={noPost}
+            isFetchFailed={isFetchFailed}
+            keyword={keyword}
+          />
+        ) : (
           posts.map((postHeader) => (
             <Link
               key={postHeader.id}
@@ -103,17 +115,6 @@ const PostList = ({ posts, keyword, sortBy, onSort }: IPostListProps) => {
               <div className={postListRow.views}>{postHeader.views}</div>
             </Link>
           ))
-        ) : (
-          <p className={noPost}>
-            {keyword ? (
-              <>“{keyword}”에 대한 검색 결과가 없습니다.</>
-            ) : (
-              <>
-                아직 게시글이 없습니다.
-                <br />첫 게시글을 작성해 보세요.
-              </>
-            )}
-          </p>
         )}
       </div>
     </div>

--- a/client/src/component/Posts/PostList/PostList.tsx
+++ b/client/src/component/Posts/PostList/PostList.tsx
@@ -97,8 +97,7 @@ const PostList = ({ posts, sortBy, onSort }: IPostListProps) => {
               {dateToStr(postHeader.created_at)}
             </div>
             <div className={postListRow.likes}>{postHeader.likes}</div>
-            {/* TODO: 조회수 views가 인터페이스에 없음 */}
-            <div className={postListRow.views}>?</div>
+            <div className={postListRow.views}>{postHeader.views}</div>
           </Link>
         ))}
       </div>

--- a/client/src/component/Posts/PostList/PostList.tsx
+++ b/client/src/component/Posts/PostList/PostList.tsx
@@ -109,7 +109,7 @@ const PostList = ({ posts, keyword, sortBy, onSort }: IPostListProps) => {
                 {postHeader.author_nickname}
               </div>
               <div className={postListRow.created_at}>
-                {dateToStr(postHeader.created_at)}
+                {dateToStr(postHeader.created_at, true)}
               </div>
               <div className={postListRow.likes}>{postHeader.likes}</div>
               <div className={postListRow.views}>{postHeader.views}</div>

--- a/client/src/component/Posts/PostList/PostList.tsx
+++ b/client/src/component/Posts/PostList/PostList.tsx
@@ -35,8 +35,6 @@ const PostList = ({ posts, keyword, sortBy, onSort }: IPostListProps) => {
   const isFetchFailed = posts === null;
   const isPostsEmpty = isFetchFailed || posts.length === 0;
 
-  console.log(isFetchFailed, posts);
-
   return (
     <div className={postListStyle}>
       <div className={clsx(postListHeaderRow, postListRow.container)}>

--- a/client/src/component/Posts/PostList/PostList.tsx
+++ b/client/src/component/Posts/PostList/PostList.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { IPostHeader, SortBy } from "shared";
 import { dateToStr } from "../../../utils/date-to-str";
 import {
+  noPost,
   notSorted,
   postListBody,
   postListHeaderRow,
@@ -17,11 +18,12 @@ import {
 
 interface IPostListProps {
   posts: IPostHeader[];
+  keyword?: string;
   sortBy: SortBy | null;
   onSort: (sortBy: SortBy | null) => void;
 }
 
-const PostList = ({ posts, sortBy, onSort }: IPostListProps) => {
+const PostList = ({ posts, keyword, sortBy, onSort }: IPostListProps) => {
   const handleSortableClickWith =
     (nextSortBy: SortBy | null) => (event: MouseEvent) => {
       event.preventDefault();
@@ -83,23 +85,36 @@ const PostList = ({ posts, sortBy, onSort }: IPostListProps) => {
       </div>
 
       <div className={postListBody}>
-        {posts.map((postHeader) => (
-          <Link
-            key={postHeader.id}
-            className={clsx(postListLinks, postListRow.container)}
-            to={`/post/${postHeader.id}`}
-          >
-            <div className={postListRow.title}>{postHeader.title}</div>
-            <div className={postListRow.author}>
-              {postHeader.author_nickname}
-            </div>
-            <div className={postListRow.created_at}>
-              {dateToStr(postHeader.created_at)}
-            </div>
-            <div className={postListRow.likes}>{postHeader.likes}</div>
-            <div className={postListRow.views}>{postHeader.views}</div>
-          </Link>
-        ))}
+        {posts.length > 0 ? (
+          posts.map((postHeader) => (
+            <Link
+              key={postHeader.id}
+              className={clsx(postListLinks, postListRow.container)}
+              to={`/post/${postHeader.id}`}
+            >
+              <div className={postListRow.title}>{postHeader.title}</div>
+              <div className={postListRow.author}>
+                {postHeader.author_nickname}
+              </div>
+              <div className={postListRow.created_at}>
+                {dateToStr(postHeader.created_at)}
+              </div>
+              <div className={postListRow.likes}>{postHeader.likes}</div>
+              <div className={postListRow.views}>{postHeader.views}</div>
+            </Link>
+          ))
+        ) : (
+          <p className={noPost}>
+            {keyword ? (
+              <>“{keyword}”에 대한 검색 결과가 없습니다.</>
+            ) : (
+              <>
+                아직 게시글이 없습니다.
+                <br />첫 게시글을 작성해 보세요.
+              </>
+            )}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/client/src/page/Main/Main.tsx
+++ b/client/src/page/Main/Main.tsx
@@ -20,7 +20,7 @@ const Main = () => {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const [posts, setPosts] = useState<IPostHeader[]>([]);
+  const [posts, setPosts] = useState<IPostHeader[] | null>([]);
   const [totalPosts, setTotalPosts] = useState(0);
 
   const { searchParams, setSearchParams, parsed } = useMainPageSearchParams();
@@ -28,30 +28,34 @@ const Main = () => {
   useLayoutEffect(() => {
     const queryString = `?${searchParams.toString()}`;
 
-    sendGetPostsRequest(queryString).then((data) => {
-      if (data?.status >= 400) {
-        // TODO: 에러 핸들링
-        return;
-      }
+    sendGetPostsRequest(queryString)
+      .then((data) => {
+        if (data?.status >= 400) {
+          setPosts(null);
+          return;
+        }
 
-      const total = data?.total;
+        const total = parseInt(data?.total, 10);
 
-      if (typeof total !== "number") {
-        // TODO: 에러 핸들링
-        return;
-      }
+        if (isNaN(total)) {
+          // TODO: 에러 핸들링
+          return;
+        }
 
-      const pageCount = Math.ceil(total / parsed.perPage);
+        const pageCount = Math.ceil(total / parsed.perPage);
 
-      if (pageCount > 0 && parsed.index > pageCount) {
-        const nextSearchParams = new URLSearchParams(searchParams);
-        nextSearchParams.set("index", String(pageCount));
-        setSearchParams(nextSearchParams);
-      } else {
-        setPosts(mapDBToPostHeaders(data.postHeaders));
-        setTotalPosts(data?.total ?? 0);
-      }
-    });
+        if (pageCount > 0 && parsed.index > pageCount) {
+          const nextSearchParams = new URLSearchParams(searchParams);
+          nextSearchParams.set("index", String(pageCount));
+          setSearchParams(nextSearchParams);
+        } else {
+          setPosts(mapDBToPostHeaders(data.postHeaders));
+          setTotalPosts(data?.total ?? 0);
+        }
+      })
+      .catch(() => {
+        setPosts(null);
+      });
   }, [parsed.index, parsed.perPage, parsed.keyword, parsed.sortBy]);
 
   const handlePostSort = (sortBy: SortBy | null) => {

--- a/client/src/page/Main/Main.tsx
+++ b/client/src/page/Main/Main.tsx
@@ -100,7 +100,12 @@ const Main = () => {
       {/* TODO: 최상단 헤더 연결 후 TestMain 제거 */}
       <TestMain />
 
-      <PostList posts={posts} sortBy={parsed.sortBy} onSort={handlePostSort} />
+      <PostList
+        posts={posts}
+        keyword={parsed.keyword}
+        sortBy={parsed.sortBy}
+        onSort={handlePostSort}
+      />
 
       <Pagination
         currentPage={parsed.index}

--- a/client/src/utils/date-to-str.tsx
+++ b/client/src/utils/date-to-str.tsx
@@ -1,5 +1,4 @@
-export const dateToStr = (date : Date) => {
-    
+export const dateToStr = (date : Date, willShorten? : boolean) : string => {
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');
@@ -7,5 +6,23 @@ export const dateToStr = (date : Date) => {
     const minutes = String(date.getMinutes()).padStart(2, '0');
     const seconds = String(date.getSeconds()).padStart(2, '0');
 
-    return `${year}.${month}.${day} ${hours}:${minutes}:${seconds}`;
-}
+    if (!willShorten) {
+        return `${year}.${month}.${day} ${hours}:${minutes}:${seconds}`;
+    }
+
+    const current = new Date();
+
+    const currentYear = current.getFullYear();
+    const currentMonth = String(current.getMonth() + 1).padStart(2, '0');
+    const currentDay = String(current.getDate()).padStart(2, '0');
+
+    if (currentYear === year) {
+        if (currentMonth === month && currentDay === day) {
+            return `${hours}:${minutes}:${seconds}`;
+        } else {
+            return `${month}.${day} ${hours}:${minutes}`;
+        }
+    } else {
+        return `${year}.${month}.${day}`;
+    }
+};

--- a/shared/posts/models.ts
+++ b/shared/posts/models.ts
@@ -18,4 +18,5 @@ export interface IPostHeader {
     author_nickname : string;
     created_at : Date;
     likes : number;
+    views : number;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #92

## 📝 작업 내용

- [x] 게시글 목록에서 조회수 표시
- 게시글 목록에서 특수한 상황 처리
  - [x] 조회 결과 게시글이 없을 때, 게시글이 없음을 표시
    - [x] 검색 결과가 없을 때, 검색 결과가 없음을 표시
  - [x] 게시글 로드에 실패했을 때, 로드 실패 표시
- [x] 게시글 목록의 작성일시 정보 최소화 (생략할 수 있는 부분 생략)
  - 같은 날이면 연월일 생략 -> `HH:mm:ss`
  - 같은 해면 연도 생략 -> `MM.DD HH:mm` 또는 `MM.DD`
  - 다른 해면 시각 생략 -> `YYYY.MM.DD`

### 🖼️ 스크린샷

#### 🖼️ 게시글 없음

> ![no-post](https://github.com/user-attachments/assets/d4d41c53-7e6a-44be-bd5c-ef0fab57ae5a)

#### 🖼️ 검색 결과 없음

> ![no-search](https://github.com/user-attachments/assets/01e1862d-5a08-4416-871f-f5fc49e06cb1)

#### 🖼️ 로드 실패

> ![load-failed](https://github.com/user-attachments/assets/44a21df6-363a-4475-ab24-ff22eecb0c8f)

## 💬 리뷰 요구사항

- 잘못 구현되었거나 수정 필요한 부분이 있으면 말씀해 주세요.
- 작업 내용에 대해서 다른 의견 있으면 말씀해 주세요.