### PR TITLE
[FE] 회원 관련 화면 레이아웃 중앙 정렬 구현

### DIFF
--- a/client/src/App.css.ts
+++ b/client/src/App.css.ts
@@ -66,3 +66,7 @@ export const mainContainer = style({
   flexDirection: "column",
   alignItems: "center",
 });
+
+export const justifyCenter = style({
+  justifyContent: "center",
+});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom";
 import "./root.css";
 import User from "./page/User/User";
 import Posts from "./component/Posts/Posts";
@@ -8,16 +8,39 @@ import PostInfoPage from "./page/Posts/PostInfoPage";
 import Join from "./page/User/Join";
 import Main from "./page/Main/Main";
 import Header from "./component/Header/Header";
-import { AppContainer, mainContainer } from "./App.css";
+import { AppContainer, justifyCenter, mainContainer } from "./App.css";
 import CheckPassword from "./page/User/CheckPassword";
 import ProfileUpdate from "./page/User/ProfileUpdate";
+import clsx from "clsx";
+
+function MainContainer({ children }: { children: React.ReactNode }) {
+  const location = useLocation();
+
+  // 중앙 정렬이 필요한 페이지들
+  const centerJustifyRoutes = [
+    "/login",
+    "/join",
+    "/checkPassword",
+    "/profileUpdate",
+  ];
+
+  return (
+    <div
+      className={clsx(mainContainer, {
+        [justifyCenter]: centerJustifyRoutes.includes(location.pathname),
+      })}
+    >
+      {children}
+    </div>
+  );
+}
 
 function App() {
   return (
     <div className={AppContainer}>
       <BrowserRouter>
         <Header />
-        <div className={mainContainer}>
+        <MainContainer>
           <Routes>
             <Route path="/" element={<Main />} />
             <Route path="/user" element={<User />} />
@@ -29,7 +52,7 @@ function App() {
             <Route path="/posts" element={<Posts />} />
             <Route path="/post/:id" element={<PostInfoPage />} />
           </Routes>
-        </div>
+        </MainContainer>
       </BrowserRouter>
     </div>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #105 

## 📝 작업 내용

- [x] 특정 라우트에서 mainContainer 스타일을 동적으로 변경할 수 있는 기능 추가
- [x] clsx를 사용하여 조건부 스타일링 구현
- [x] 변경된 레이아웃이 다른 컴포넌트에 영향을 주지 않는지 확인 
### 🖼️ 스크린샷


<details>
<summary>🖼️로그인 화면</summary>

 ![image](https://github.com/user-attachments/assets/1ad1a8e6-b342-42d5-8738-ee6d4212d50a)
</details>
<details>
<summary>🖼️회원가입 화면</summary>

![image](https://github.com/user-attachments/assets/ae4ff831-693f-4821-b813-33f9dd34029e)
</details>
<details>
<summary>🖼️비밀번호 확인 화면</summary>

![image](https://github.com/user-attachments/assets/bfa40671-f8c7-42b0-80b8-b32f7cc886f1)
</details>
<details>
<summary>🖼️유저정보 수정 화면</summary>

![image](https://github.com/user-attachments/assets/9ed6640b-971b-4deb-a182-f63962c9e520)
</details>








## 💬 리뷰 요구사항

- 잘못 구현된 부분이나 이상한 부분 있으면 말해주세요.
