### PR TITLE
feat : 게시글 내용 조회 기능에  조회수 증가 로직 추가

### DIFF
--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -108,7 +108,7 @@ export const getPostInfo = async (post_id : number, user_id? : number) => {
         let postInfo = mapDBToPostInfo(rows[0]);
 
         if(postInfo.author_id !== user_id){
-            const sql2 = `UPDATE posts SET views = views + 1 WHERE id = ?`;
+            const sql2 = `UPDATE posts SET views = views + 1, updated_at = updated_at WHERE id = ?`;
 
             const [rows] : any[] = await conn.query(sql2, [post_id]);
 

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -105,9 +105,21 @@ export const getPostInfo = async (post_id : number, user_id? : number) => {
             throw ServerError.notFound("존재하지 않는 게시글입니다.");
         }
 
-        return mapDBToPostInfo(rows[0]);
-        
+        let postInfo = mapDBToPostInfo(rows[0]);
+
+        if(postInfo.author_id !== user_id){
+            const sql2 = `UPDATE posts SET views = views + 1 WHERE id = ?`;
+
+            const [rows] : any[] = await conn.query(sql2, [post_id]);
+
+            if (rows.affectedRows !== 0) {
+                postInfo.views += 1;
+            }
+        }
+
+        return postInfo;
     } catch (err){
+        console.log(err);
         throw err;
     } finally {
         if (conn) conn.release();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#108

## 📝 작업 내용

- ID가 `post_id`인 게시글 조회 성공 시
    - [x] user_id가 있는 경우 (로그인 중인 경우) -> author_id !== user_id 일 때만 views + 1 증가(실제 DB 업데이트)
    - [x] user_id가 없는 경우 (로그인 x) -> views + 1 증가(실제 DB 업데이트)
- [x] 조회수 갱신 성공 시, 게시글 조회 결과로 얻은 객체의 `views` 필드에 1을 더하여 응답
- [x] 조회수 갱신 실패 시, 게시글 조회 결과로 얻은 객체를 변경하지 않고 응답

### 🖼️ 스크린샷 (선택)
https://github.com/user-attachments/assets/d47b26ff-6e29-4bca-b1d1-a92cc9d2553d





## 💬 리뷰 요구사항(선택)
- 현재는 SELECT 문과 UPDATE 문을 사용하여 DB에 2번 접근하는데, 더 좋은 방법이 있을까요?
