### PR TITLE
[FE] httpRequest의 error handling 함수 추가

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,9 @@ import { AppContainer, justifyCenter, mainContainer } from "./App.css";
 import CheckPassword from "./page/User/CheckPassword";
 import ProfileUpdate from "./page/User/ProfileUpdate";
 import clsx from "clsx";
+import { useErrorModal } from "./state/errorModalStore";
+import { useLayoutEffect } from "react";
+import ErrorModal from "./component/utils/ErrorModal";
 
 function MainContainer({ children }: { children: React.ReactNode }) {
   const location = useLocation();
@@ -36,9 +39,23 @@ function MainContainer({ children }: { children: React.ReactNode }) {
 }
 
 function App() {
+  const errorModal = useErrorModal();
+
+  useLayoutEffect(()=>{
+    errorModal.clear();
+  },[]);
+
   return (
     <div className={AppContainer}>
       <BrowserRouter>
+        {
+          (errorModal.isOpen) &&
+          <ErrorModal
+            message={errorModal.errorMessage}
+            onError={errorModal.onError}
+            close={errorModal.close}
+          />
+        }
         <Header />
         <MainContainer>
           <Routes>

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -55,7 +55,7 @@ export const httpRequest = async (
   };
 };
 
-export const ApiCall = async(func : () => Promise<any>) => {
+export const ApiCall = async(func : () => Promise<any>, onError? : () => void) => {
     func().then((res)=>{
       if(res.status >= 400){
         throw ClientError.autoFindErrorType(res.code, res.message);
@@ -65,15 +65,21 @@ export const ApiCall = async(func : () => Promise<any>) => {
       return res;
     }).catch((err : ClientError)=>{
       // TODO : 각각의 에러 상황 핸들링하기 + 출력 지우기
-      console.log(err);
-
       if(err.code === 400){
-        alert(err.message);
+        if(onError){
+          onError();
+        } else {
+          alert(err.message);
+        }
       }
 
       if (err.code === 401){
         if(isTokenError(err.message) || isUnauthorized(err.message) && isLogin){
-          alert("로그인이 만료되었습니다");
+          if(onError){
+            onError();
+          } else {
+            alert("로그인이 만료되었습니다");
+          }
           setLogoutUser();
         }
       }

--- a/client/src/api/errors.ts
+++ b/client/src/api/errors.ts
@@ -1,0 +1,59 @@
+import { isTokenError } from "./users/utils";
+
+export class ClientError extends Error {
+    code: number;
+  
+    constructor(code: number, message: string) {
+      super(message);
+      this.code = code;
+    }
+  
+    static autoFindErrorType(code : number, message : string){
+      switch(code){
+        case 400:
+          return ClientError.badRequest(message);
+        case 401:
+          if (isTokenError(message)) {
+            return ClientError.tokenError(message);
+          }
+          return ClientError.unauthorized(message);
+        case 403:
+          return ClientError.forbidden(message);
+        case 404:
+          return ClientError.notFound(message);
+        case 500:
+          return ClientError.reference(message);
+        default:
+          return ClientError.etcError(code, message);
+      }
+    }
+  
+    static badRequest(message: string) {
+      return new ClientError(400, message);
+    }
+  
+    static unauthorized(message: string) {
+      return new ClientError(401, message);
+    }
+  
+    static tokenError(message: string) {
+      return new ClientError(401, message);
+    }
+  
+    static forbidden(message: string) {
+      return new ClientError(403, message);
+    }
+  
+    static notFound(message: string) {
+      return new ClientError(404, message);
+    }
+  
+    static reference(message: string) {
+      return new ClientError(500, message);
+    }
+  
+    static etcError(code: number, message: string) {
+      const errorMsg = message;
+      return new ClientError(code, errorMsg);
+    }
+  }

--- a/client/src/api/users/utils.ts
+++ b/client/src/api/users/utils.ts
@@ -1,0 +1,5 @@
+export const isTokenError = (message: string) =>
+    message.indexOf("Token") !== -1;
+  
+export const isUnauthorized = (message: string) =>
+    message === "Unauthorized: 로그인이 필요합니다.";

--- a/client/src/component/Comments/CommentItem/CommentItem.tsx
+++ b/client/src/component/Comments/CommentItem/CommentItem.tsx
@@ -18,6 +18,9 @@ import {
   commentFooter,
   commentEditButtons,
 } from "./CommentItem.css";
+import { ApiCall } from "../../../api/api";
+import { useErrorModal } from "../../../state/errorModalStore";
+import { ClientError } from "../../../api/errors";
 
 interface ICommentItemProps {
   comment: IComment;
@@ -26,6 +29,7 @@ interface ICommentItemProps {
 
 const CommentItem = ({ comment, onUpdate }: ICommentItemProps) => {
   const [isEditMode, setIsEditMode] = useState(false);
+  const errorModal = useErrorModal();
 
   const contentNodes = useMemo(
     () =>
@@ -49,28 +53,24 @@ const CommentItem = ({ comment, onUpdate }: ICommentItemProps) => {
     const trimmedContent = content.trim();
 
     if (trimmedContent === comment.content) {
-      alert("댓글 내용이 이전과 동일합니다.");
+      errorModal.setErrorMessage("error:댓글 내용이 이전과 동일합니다.");
+      errorModal.open();
       return false;
     }
 
-    try {
-      const response = await sendPatchCommentRequest({
-        content,
-        id: comment.id,
-      });
+    const res = await ApiCall(
+        () => sendPatchCommentRequest({content,id: comment.id}),
+        (err) => {
+          errorModal.setErrorMessage(err.message);
+          errorModal.open();
+        }
+    );
 
-      if (response?.status >= 400) {
-        console.error(response);
-        alert("댓글 수정에 실패했습니다.");
-        return false;
-      }
-
-      alert("댓글을 수정했습니다.");
-    } catch (error) {
-      console.error(error);
-      alert("댓글 수정에 실패했습니다.");
+    if(res instanceof ClientError){
       return false;
     }
+
+    alert("댓글을 수정했습니다.");
 
     if (onUpdate) {
       await onUpdate();
@@ -88,19 +88,15 @@ const CommentItem = ({ comment, onUpdate }: ICommentItemProps) => {
       return;
     }
 
-    try {
-      const response = await sendDeleteCommentRequest(comment.id);
-
-      if (response?.status >= 400) {
-        console.error(response);
-        alert("댓글 삭제에 실패했습니다.");
-        return false;
+    const res = await ApiCall(
+      () => sendDeleteCommentRequest(comment.id),
+      (err) => {
+        errorModal.setErrorMessage(err.message);
+        errorModal.open();
       }
+    );
 
-      alert("댓글을 삭제했습니다.");
-    } catch (error) {
-      console.error(error);
-      alert("댓글 삭제에 실패했습니다.");
+    if (res instanceof ClientError){
       return false;
     }
 

--- a/client/src/component/Posts/Modal/PostModal.tsx
+++ b/client/src/component/Posts/Modal/PostModal.tsx
@@ -2,6 +2,8 @@ import { SetStateAction, useState } from 'react'
 import { CloseBtn, ContentTextArea, InputContainer, InputIndex, ModalBody, ModalContainer, ModalHeader, PostBtn, PostHeaderTitle, TitleInput } from './PostModal.css'
 import { sendCreatePostRequest, sendUpdatePostRequest } from '../../../api/posts/crud';
 import { ApiCall } from '../../../api/api';
+import { ClientError } from '../../../api/errors';
+import { useErrorModal } from '../../../state/errorModalStore';
 
 interface IPostData {
     id : number;
@@ -18,20 +20,30 @@ const PostModal : React.FC<IPostModalProps> = ({ close, originalPostData }) => {
     const isUpdateMode = originalPostData !== undefined;
 
     const modalMode = isUpdateMode ? "수정" : "생성";
+    const errorModal = useErrorModal();
 
     const [title, setTitle] = useState(isUpdateMode ? originalPostData.title : "");
     const [content, setContent] = useState(isUpdateMode ? originalPostData.content : "");
 
     const createPost = async() => {
-        const body = {
-            title,
-            content
-        };
+        const body = { title, content };
 
-        await ApiCall(()=>sendCreatePostRequest(body));
+        const res = await ApiCall(
+            ()=>sendCreatePostRequest(body), 
+            (err)=>{
+                errorModal.setErrorMessage(err.message);
+                errorModal.open();
+            }
+        );
+
+        if(res instanceof ClientError){
+            return;
+        }
+
+        window.location.reload();
     };
 
-    const updatePost = () => {
+    const updatePost = async () => {
         if (!originalPostData){
             return;
         }
@@ -43,9 +55,19 @@ const PostModal : React.FC<IPostModalProps> = ({ close, originalPostData }) => {
 
         const postId : number = originalPostData.id;
 
-        sendUpdatePostRequest(postId, body).then((res)=>{
-            console.log(res);
-        })
+        const res = await ApiCall(
+            ()=>sendUpdatePostRequest(postId, body),
+            (err)=>{
+                errorModal.setErrorMessage(err.message);
+                errorModal.open();
+            }
+        );
+
+        if(res instanceof ClientError){
+            return;
+        }
+
+        window.location.reload();
     };
 
     return (
@@ -59,7 +81,6 @@ const PostModal : React.FC<IPostModalProps> = ({ close, originalPostData }) => {
                                 createPost();
                             }
                             close(false);
-                            window.location.reload();
                         }}>{modalMode}</button>
                 <div className={PostHeaderTitle}>게시글 {modalMode}</div>
                 <button className={CloseBtn} onClick={()=>close(false)}>취소</button>

--- a/client/src/component/Posts/Modal/PostModal.tsx
+++ b/client/src/component/Posts/Modal/PostModal.tsx
@@ -1,6 +1,7 @@
 import { SetStateAction, useState } from 'react'
 import { CloseBtn, ContentTextArea, InputContainer, InputIndex, ModalBody, ModalContainer, ModalHeader, PostBtn, PostHeaderTitle, TitleInput } from './PostModal.css'
 import { sendCreatePostRequest, sendUpdatePostRequest } from '../../../api/posts/crud';
+import { ApiCall } from '../../../api/api';
 
 interface IPostData {
     id : number;
@@ -21,15 +22,13 @@ const PostModal : React.FC<IPostModalProps> = ({ close, originalPostData }) => {
     const [title, setTitle] = useState(isUpdateMode ? originalPostData.title : "");
     const [content, setContent] = useState(isUpdateMode ? originalPostData.content : "");
 
-    const createPost = () => {
+    const createPost = async() => {
         const body = {
             title,
             content
         };
 
-        sendCreatePostRequest(body).then((res)=>{
-            console.log(res);
-        })
+        await ApiCall(()=>sendCreatePostRequest(body));
     };
 
     const updatePost = () => {

--- a/client/src/component/utils/ErrorModal.css.ts
+++ b/client/src/component/utils/ErrorModal.css.ts
@@ -1,0 +1,56 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "../../App.css.ts";
+
+export const Background = style({
+    position : "absolute",
+    top : 0,
+    left : 0,
+    width : "100%",
+    height : "100%",
+    background : vars.color.secondaryDarkText,
+    opacity : 0.5
+});
+
+export const ErrorModalContainer = style({
+    position : "absolute",
+    top : "50%",
+    left : "50%",
+    transform : "translate(-50%, -50%)",
+    width : "300px",
+    height : "fit",
+    background : vars.color.task,
+    borderRadius : "5px",
+    textAlign : "center",
+    display : "flex",
+    flexDirection : "column",
+    padding : "10px",
+    gap : "10px",
+    opacity : 2
+});
+
+export const ErrorModalTitle = style({
+    color : vars.color.deleteButton,
+    fontWeight : "bold",
+    fontSize : vars.fontSizing.T2
+});
+
+export const ErrorModalText = style({
+    color : vars.color.darkText,
+    fontWeight : "bold",
+    fontSize : vars.fontSizing.T3,
+    paddingTop : "30px",
+    paddingBottom : "30px"
+})
+
+export const Btn = style({
+    display : "flex",
+    justifyContent : "center",
+    paddingLeft : "30px",
+    paddingRight : "30px"
+});
+
+export const CheckBtn = style({
+    backgroundColor : vars.color.successButton,
+    color : vars.color.brightText,
+    fontWeight : "bold"
+});

--- a/client/src/component/utils/ErrorModal.tsx
+++ b/client/src/component/utils/ErrorModal.tsx
@@ -1,0 +1,36 @@
+import { Background, Btn, CheckBtn, ErrorModalContainer, ErrorModalText, ErrorModalTitle } from "./ErrorModal.css";
+
+interface ErrorModalProps {
+    message : string;
+    close : () => void;
+    onError? : () => void;
+}
+
+const ErrorModal : React.FC<ErrorModalProps> = ({ message,  close, onError }) => {
+    const [title, msg] = message.split(":");
+
+    return (
+        <div>
+            <div className={Background}/>
+            <div className={ErrorModalContainer}>
+                    <div className={ErrorModalTitle}>
+                        {title}
+                    </div>
+                    <div className={ErrorModalText}>
+                        {msg}
+                    </div>
+                    <div className={Btn}>
+                        <button className={CheckBtn} onClick={()=>{
+                            if(onError){
+                                onError();
+                            }
+
+                            close();
+                        }}>확인</button>
+                    </div>
+            </div>
+        </div>
+    )
+};
+
+export default ErrorModal;

--- a/client/src/state/errorModalStore.ts
+++ b/client/src/state/errorModalStore.ts
@@ -1,0 +1,41 @@
+import { StateCreator, create } from "zustand";
+import { PersistOptions, persist } from "zustand/middleware";
+
+interface IErrorModalState {
+    isOpen : boolean;
+    onError? : () => void;
+    errorMessage : string;
+}
+
+interface IErrorModalActions {
+    open : () => void;
+    close : () => void;
+    clear : () => void;
+    setErrorMessage : (msg: string) => void;
+    setOnError : (onError : ()=>void) => void;
+}
+
+export interface TErrorModalStore extends IErrorModalState, IErrorModalActions {}
+
+export type ErrorModalStatePersist = (
+  config: StateCreator<TErrorModalStore>,
+  options: PersistOptions<IErrorModalState>
+) => StateCreator<TErrorModalStore>;
+
+export const useErrorModal = create<TErrorModalStore>(
+    (persist as ErrorModalStatePersist)(
+        (set) => ({
+            isOpen : false,
+            errorMessage : "",
+            open: () => set((state) => ({ ...state, isOpen : true })),
+            close: () => set((state) => ({ ...state, isOpen : false })),
+            clear: () => set((state) => ({ ...state, isOpen : false, error : undefined })),
+            setErrorMessage: (msg : string) => set((state) => ({ ...state, errorMessage : msg })),
+            setOnError: (onError : () => void) => set((state)=> ({ ...state, onError : onError})),
+        }),
+        { 
+            name: "errorModalStore",
+            partialize: (state) => ({ ...state, isOpen: false })
+         }
+    )
+);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#73 

## 📝 작업 내용

- ApiCall 함수 추가
    - 이유
        - http request 의 error 상황을 handling하는 로직을 각자 구현해야 하는 것이 불편했다.
        - 하지만, httpRequest 함수에서 에러 처리하는 로직을 다 구현하면 코드가 길어져서 가독성이 떨어진다.
        - 따라서 api 요청 error 상황을 handling하는 함수를 추가 구현하기로 했다.
    - 사용 방법
        - 기존
        ```ts
         const createPost = async() => {
             const body = {~~};
             sendCreatePostRequest(body).then((res)=>{
                 if(res.status >= 400){
                     console.log(res);
                     return;
                 }
             });
         };
        ```
        - 바뀐 사용법
        ```ts
        const createPost = async() => {
                const body = {
                    title,
                    content
                };
                await ApiCall(()=>sendCreatePostRequest(body));
        };
        ```
        - return 값을 사용할 경우
       ```ts
       // 특별히 에러 처리 안 할 경우
       const res = await ApiCall(()=>sendCreatePostRequest(body));
       if(res){
            return;
       } // -> 이후 원하는 로직 작성
       // 에러 일 때, 특별 처리를 하는 경우
       const errorHandle = () => { /* 원하는 로직 작성 */ };
       const res = await ApiCall(()=>sendCreatePostRequest(body), ()=>errorHandle());
       if(res){
            return;
       } // -> 이후 원하는 로직 작성
       ```

## 💬 리뷰 요구사항(선택)

- 현재 구현 방법 보다 좋거나, 수정사항이 있다면 말씀해주세요.

- 만약, 구현 방법이 맘에 드신다면 다른 에러 상황에 대한 핸들링 및 request 함수를 사용한 부분 코드들은 제가 다 수정하겠습니다.
