### PR TITLE
[FE] 유저 API에 에러 핸들링 함수 적용

### DIFF
--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -55,7 +55,10 @@ export const httpRequest = async (
   };
 };
 
-export const handleApiError = (error: ClientError, onError : (err: ClientError) => void) => {
+export const handleApiError = (
+  error: ClientError,
+  onError: (err: ClientError) => void
+) => {
   switch (error.code) {
     /* bad request */
     case 400:
@@ -63,7 +66,10 @@ export const handleApiError = (error: ClientError, onError : (err: ClientError) 
       break;
     /* unauthorized or tokenError */
     case 401:
-      if (isTokenError(error.message) || isUnauthorized(error.message) && isLogin) {
+      if (
+        isTokenError(error.message) ||
+        (isUnauthorized(error.message) && isLogin)
+      ) {
         setLogoutUser();
         onError(error);
       } else {
@@ -88,15 +94,20 @@ export const handleApiError = (error: ClientError, onError : (err: ClientError) 
   }
 };
 
-export const ApiCall = async(func : () => Promise<any>, onError : (err:ClientError) => void) => {
-    return func().then((res)=>{
-      if(res.status >= 400){
-        throw ClientError.autoFindErrorType(res.code, res.message);
+export const ApiCall = async (
+  func: () => Promise<any>,
+  onError: (err: ClientError) => void
+) => {
+  return func()
+    .then((res) => {
+      if (res.status >= 400) {
+        throw ClientError.autoFindErrorType(res.status, res.message);
       }
       // TODO : 지우기
       console.log(res);
       return res;
-    }).catch((err : ClientError)=>{
+    })
+    .catch((err: ClientError) => {
       // TODO : 각각의 에러 상황 핸들링하기 + 출력 지우기
       handleApiError(err, onError);
       return err;

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -73,6 +73,7 @@ export const handleApiError = (
         setLogoutUser();
         onError(error);
       } else {
+        onError(error);
         console.log(error.message);
       }
       break;

--- a/client/src/component/Header/Header.tsx
+++ b/client/src/component/Header/Header.tsx
@@ -20,6 +20,8 @@ import {
 import { useEffect, useRef, useState } from "react";
 import DropdownMenu from "./DropdownMenu";
 import { useModal } from "../../hook/useModal";
+import { ApiCall } from "../../api/api";
+import { ClientError } from "../../api/errors";
 
 const Header = () => {
   const navigate = useNavigate();
@@ -55,10 +57,16 @@ const Header = () => {
   };
 
   const handleLogout = async () => {
-    const result = await sendPostLogoutRequest();
-    if (result.status === 200) {
-      setLogoutUser();
+    const result = await ApiCall(
+      () => sendPostLogoutRequest(),
+      () => {}
+    );
+
+    if (result instanceof ClientError) {
+      return;
     }
+
+    setLogoutUser();
   };
 
   const handleUserInfo = () => {

--- a/client/src/page/User/CheckPassword.tsx
+++ b/client/src/page/User/CheckPassword.tsx
@@ -53,14 +53,14 @@ const CheckPassword: FC = () => {
 
     const errorHandle = (err: ClientError) => {
       if (err.code === 400) {
-      alert("비밀번호가 일치하지 않습니다.");
-      setPassword("");
-      return;
-    }
+        alert("비밀번호가 일치하지 않습니다.");
+        setPassword("");
+        return;
+      }
 
       if (err.code === 401) {
-      alert("로그인이 필요합니다.");
-      navigate("/login");
+        alert("로그인이 필요합니다.");
+        navigate("/login");
         return;
       }
     };
@@ -83,14 +83,21 @@ const CheckPassword: FC = () => {
   };
 
   const handleFinalConfirm = async () => {
-    finalModal.close();
-    alert("회원 탈퇴가 완료되었습니다.");
-    const result = await sendDeleteUserRequest();
-    if (result.status !== 200) {
+    const errorHandle = () => {
       alert("회원 탈퇴에 실패했습니다.");
       navigate(`/`);
       return;
+    };
+
+    const result = await ApiCall(() => sendDeleteUserRequest(), errorHandle);
+
+    if (result instanceof ClientError) {
+      return;
     }
+
+    finalModal.close();
+    alert("회원 탈퇴가 완료되었습니다.");
+
     setLogoutUser();
     navigate(`/`);
   };

--- a/client/src/page/User/CheckPassword.tsx
+++ b/client/src/page/User/CheckPassword.tsx
@@ -11,6 +11,8 @@ import { REGEX } from "./constants/constants";
 import { useModal } from "../../hook/useModal";
 import UserDeleteModal from "../../component/Header/UserDeleteModal";
 import { useUserStore } from "../../state/store";
+import { ClientError } from "../../api/errors";
+import { ApiCall } from "../../api/api";
 
 const MODAL_CONFIGS = {
   final: {
@@ -49,16 +51,26 @@ const CheckPassword: FC = () => {
       return;
     }
 
-    const result = await sendPOSTCheckPasswordRequest({ password });
-    if (result.status === 400) {
+    const errorHandle = (err: ClientError) => {
+      if (err.code === 400) {
       alert("비밀번호가 일치하지 않습니다.");
       setPassword("");
       return;
     }
 
-    if (result.status === 401) {
+      if (err.code === 401) {
       alert("로그인이 필요합니다.");
       navigate("/login");
+        return;
+      }
+    };
+
+    const result = await ApiCall(
+      () => sendPOSTCheckPasswordRequest({ password }),
+      errorHandle
+    );
+
+    if (result instanceof ClientError) {
       return;
     }
 
@@ -66,6 +78,7 @@ const CheckPassword: FC = () => {
       finalModal.open();
       return;
     }
+
     navigate(`/${next}?final=${final}`);
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #115 
- #116 

## 📝 작업 내용

- [x] 로그인 API에 적용
- [x] 회원가입 API에 적용
- [x] 비밀번호 확인 API 에 적용
- [x] 로그아웃 API에 적용
- [x] 유저 정보 변경 API에 적용
- [x] 회원 탈퇴 API에 적용

## 💬 리뷰 요구사항

- api.ts에 수정한부분이 있습니다. 따로 api.ts부분 수정하신 부분이 있다면 충돌이 날 수 있습니다.
- 괜찮으시다면 #116 이슈에 지금 PR을 연결하겠습니다.
- 잘못 구현된 부분이나 이상한 부분 있으면 말해주세요.
