### PR TITLE
검색 채팅방 리스트 & 내 채팅방 리스트(채팅 aside) UI 추가

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,8 +13,8 @@ import { useErrorModal } from "./state/errorModalStore";
 import { useLayoutEffect } from "react";
 import ErrorModal from "./component/utils/ErrorModal";
 import ChatTestPage from "./page/Chat/ChatTestPage";
-import ChatRooms from "./component/Chats/ChatRooms";
 import ChatRoom from "./component/Chats/ChatRoom/ChatRoom";
+import ChatRooms from "./component/Chats/ChatRooms/ChatRooms";
 
 function MainContainer({ children }: { children: React.ReactNode }) {
 	const location = useLocation();

--- a/client/src/component/Chats/ChatRooms.tsx
+++ b/client/src/component/Chats/ChatRooms.tsx
@@ -1,5 +1,0 @@
-const ChatRooms = () => {
-	return <div>ChatRooms</div>;
-};
-
-export default ChatRooms;

--- a/client/src/component/Chats/ChatRooms/ChatRooms.css.ts
+++ b/client/src/component/Chats/ChatRooms/ChatRooms.css.ts
@@ -1,0 +1,47 @@
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+	display: "flex",
+	flexDirection: "column",
+	width: "80%",
+	height: "500px",
+});
+
+export const roomsWrapper = style({
+	width: "100%",
+	height: "50%",
+	display: "flex",
+	flexDirection: "column",
+	justifyContent: "space-between",
+});
+
+export const searchContainer = style({
+	display: "flex",
+	flexDirection: "row",
+	justifyContent: "space-between",
+});
+
+export const searchInput = style({
+	width: "50%",
+	height: "34px",
+});
+
+export const searchButton = style({
+	cursor: "pointer",
+	height: "40px",
+});
+
+export const searchForm = style({
+	display: "flex",
+	width: "100%",
+	gap: "10px",
+});
+
+export const createButton = style({
+	cursor: "pointer",
+	width: "40px",
+	height: "40px",
+	":hover": {
+		opacity: "0.7",
+	},
+});

--- a/client/src/component/Chats/ChatRooms/ChatRooms.tsx
+++ b/client/src/component/Chats/ChatRooms/ChatRooms.tsx
@@ -1,0 +1,138 @@
+import { ChangeEvent, FC, FormEvent, MouseEvent, useState } from "react";
+import { CiCirclePlus } from "react-icons/ci";
+
+import {
+	container,
+	createButton,
+	roomsWrapper,
+	searchButton,
+	searchContainer,
+	searchForm,
+	searchInput,
+} from "./ChatRooms.css";
+import Rooms from "./Rooms/Rooms";
+
+interface IRoomHeader {
+	roomId: string;
+	title: string;
+	is_private: boolean;
+	participantNum: number; // 채팅방에 속한 사람들
+	curNum: number | null; // 현재 접속 중인 사람들
+	lastMessage: string | null;
+	// lastChatTime: Date | null;
+}
+
+interface IReadRoomResponse {
+	totalRoomCount: number;
+	roomHeaders: IRoomHeader[];
+}
+
+const ChatRooms: FC = () => {
+	const [keyword, setKeyword] = useState<string>("");
+
+	// test 용 state
+	const [searchRooms, setSearchRooms] = useState<IReadRoomResponse>({
+		totalRoomCount: 14,
+		roomHeaders: [
+			{
+				roomId: "1",
+				title: "test1",
+				is_private: false,
+				participantNum: 5,
+				lastMessage: null,
+				curNum: null,
+			},
+			{
+				roomId: "2",
+				title: "test2",
+				is_private: true,
+				participantNum: 5,
+				lastMessage: null,
+				curNum: null,
+			},
+		],
+	});
+	const [myRooms, setMyRooms] = useState<IReadRoomResponse>({
+		totalRoomCount: 14,
+		roomHeaders: [
+			{
+				roomId: "1",
+				title: "test1",
+				is_private: false,
+				participantNum: 5,
+				lastMessage: `1234`,
+				curNum: 2,
+			},
+			{
+				roomId: "2",
+				title: "test2",
+				is_private: true,
+				participantNum: 5,
+				lastMessage: `231123`,
+				curNum: 3,
+			},
+		],
+	});
+
+	// 채팅 input Change
+	const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setKeyword(event.target.value);
+	};
+
+	// 채팅방 검색
+	const onSearchSubmit = (event: FormEvent) => {
+		event.preventDefault();
+
+		if (keyword !== "") {
+			// TODO: 검색 시 데이터 가져오기 (alert는 테스트용)
+			alert(`keyword: ${keyword} 채팅방 검색`);
+			setKeyword("");
+		}
+	};
+
+	// 채팅창 생성
+	const onClickCreateRoom = (event: MouseEvent<HTMLElement>) => {
+		// TODO: 모달 생성
+		alert("채팅창 모달");
+	};
+
+	return (
+		<div className={container}>
+			<div className={roomsWrapper}>
+				<div className={searchContainer}>
+					<form
+						className={searchForm}
+						onSubmit={onSearchSubmit}
+					>
+						<input
+							className={searchInput}
+							placeholder="채팅방 검색"
+							value={keyword}
+							onChange={onSearchChange}
+						/>
+						<button className={searchButton}>검색</button>
+					</form>
+					<div onClick={onClickCreateRoom}>
+						<CiCirclePlus
+							className={createButton}
+							title="채팅방 생성"
+						/>
+					</div>
+				</div>
+				<Rooms
+					isMine={false}
+					rooms={searchRooms.roomHeaders}
+				/>
+			</div>
+			<h3>내 채팅방</h3>
+			<div className={roomsWrapper}>
+				<Rooms
+					isMine={true}
+					rooms={myRooms.roomHeaders}
+				/>
+			</div>
+		</div>
+	);
+};
+
+export default ChatRooms;

--- a/client/src/component/Chats/ChatRooms/Rooms/Rooms.css.ts
+++ b/client/src/component/Chats/ChatRooms/Rooms/Rooms.css.ts
@@ -1,0 +1,55 @@
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+	display: "flex",
+	flexDirection: "column",
+	gap: "10px",
+	justifyContent: "center",
+});
+
+export const roomWrapper = style({
+	height: "40px",
+	display: "flex",
+	flexDirection: "column",
+	justifyContent: "center",
+	border: "1px solid black",
+	borderRadius: "10px",
+	padding: "10px",
+	cursor: "pointer",
+	":hover": {
+		opacity: 0.7,
+	},
+});
+
+export const roomContainer = style({
+	display: "flex",
+	flexDirection: "column",
+	justifyContent: "center",
+});
+
+export const roomHeaderContainer = style({
+	display: "flex",
+	flexDirection: "row",
+	justifyContent: "space-between",
+});
+
+export const titleContainer = style({
+	display: "flex",
+	flexDirection: "row",
+	justifyContent: "center",
+	alignItems: "center",
+});
+
+export const lockIcon = style({
+	width: "20px",
+	height: "20px",
+});
+
+export const numContainer = style({
+	display: "flex",
+	gap: "10px",
+});
+
+export const chatContainer = style({
+	width: "100%",
+});

--- a/client/src/component/Chats/ChatRooms/Rooms/Rooms.tsx
+++ b/client/src/component/Chats/ChatRooms/Rooms/Rooms.tsx
@@ -1,0 +1,83 @@
+import { FC, MouseEvent } from "react";
+import { CiLock } from "react-icons/ci";
+
+import {
+	container,
+	chatContainer,
+	numContainer,
+	roomHeaderContainer,
+	roomContainer,
+	roomWrapper,
+	lockIcon,
+	titleContainer,
+} from "./Rooms.css";
+import { useNavigate } from "react-router-dom";
+
+interface IRoomHeader {
+	roomId: string;
+	title: string;
+	is_private: boolean;
+	participantNum: number; // 채팅방에 속한 사람들
+	curNum: number | null; // 현재 접속 중인 사람들
+	lastMessage: string | null;
+}
+
+interface IRoomsProps {
+	isMine: boolean;
+	rooms: IRoomHeader[];
+}
+
+const Rooms: FC<IRoomsProps> = ({ isMine, rooms }) => {
+	const navigate = useNavigate();
+
+	const onRoomClick =
+		(roomId: string) => (event: MouseEvent<HTMLDivElement>) => {
+			// TODO: 해당 room으로 이동
+			console.log(roomId);
+
+			// TODO: 비밀방 입장시 비밀번호 입력 모달 생성
+
+			// 테스트용 : /room/1
+			navigate("/room/1");
+		};
+
+	return (
+		<div className={container}>
+			{rooms.map((room, index) => (
+				<div
+					className={roomWrapper}
+					key={index}
+				>
+					<div
+						className={roomContainer}
+						onClick={onRoomClick(room.roomId)}
+					>
+						<div className={roomHeaderContainer}>
+							<div className={titleContainer}>
+								{room.is_private ? (
+									<CiLock className={lockIcon} />
+								) : (
+									" "
+								)}
+								채팅방 이름: {room.title}
+							</div>
+							<div className={numContainer}>
+								{isMine ? (
+									<span>접속 인원: {room.curNum}</span>
+								) : null}
+								<span>참여 인원: {room.participantNum}</span>
+							</div>
+						</div>
+						{isMine ? (
+							<div className={chatContainer}>
+								<span>최근 메시지: {room.lastMessage}</span>
+							</div>
+						) : null}
+					</div>
+				</div>
+			))}
+		</div>
+	);
+};
+
+export default Rooms;


### PR DESCRIPTION
## 📝 작업 내용

- 비밀방을 위한 디자인 수정 후 UI 추가
- 테스트를 위해 임시 데이터를 생성

### 수정된 피그마
![채팅방 피그마](https://github.com/user-attachments/assets/8d748454-729f-4ee6-98df-203345c7967e)

디자인에서 크게 2개의 단위로 나누어 작업했습니다.

### 1. search rooms
![검색 채팅방 리스트](https://github.com/user-attachments/assets/d538d1bd-fe00-4329-a702-909ef8fb467e)
- 채팅방 검색(search)
   - 서버에 채팅방 keyword 전달 (기능 미구현, alert: keyword: '내용' 채팅방 검색)
   - 검색된 채팅방 리스트 표시 (검색된 상태인 조건으로 임시 채팅방 검색 리스트 표시)
- 채팅방 생성(create room)
   - 채팅방 생성 모달을 엶 (기능 미구현, alert: 채팅창 모달)
- 채팅방 이동
   - 채팅방 클릭시 해당 채팅방(aside)으로 이동(테스트로 room/1로 이동)
   - 비밀 방일 시 비밀번호 입력 모달 엶 (기능 미구현, 테스트로 room/1로 이동)
   - 각 채팅방 별 요소
      - 채팅방 이름(room title)
      - 비밀 채팅방 유무(private room)
      - 채팅방 참가 인원(participants num)
- 채팅방에 대한 pagination 구현 예정

### 2. my rooms
![내 채팅방 리스트](https://github.com/user-attachments/assets/65adf59d-7f12-4c5e-a968-a64e6dfcb88a)
- 내가 참여한 채팅방 리스트
   - 검색을 통한 리스트 나열을 제외하곤 채팅방 검색 리스트와 같음
- 채팅방 이동
   - 채팅방 검색과 같음
   - 검색 채팅방 요소에서 2가지 요소 추가
      - 접속 인원(cur num)
      - 최근 메시지(last message)
- 채팅방에 대한 pagination 구현 예정

## 💬 리뷰 요구사항

1. 검색 채팅방과 내 채팅방을 분리하여 컴포넌트화 하는게 좋을까요?
2. 채팅방 리스트에서 채팅방을 컴포넌트화 하는게 좋을까요?
