### PR TITLE
Feature/add chat rooms enter logic

### DIFF
--- a/client/src/component/Chats/ChatRooms/Rooms/Room.tsx
+++ b/client/src/component/Chats/ChatRooms/Rooms/Room.tsx
@@ -2,6 +2,7 @@ import {
 	chatContainer,
 	lockIcon,
 	numContainer,
+	passwordInput,
 	roomContainer,
 	roomHeaderContainer,
 	roomWrapper,
@@ -10,6 +11,7 @@ import {
 import { IRoomHeader } from "./Rooms";
 import { CiLock } from "react-icons/ci";
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 
 interface Props {
 	room: IRoomHeader;
@@ -19,12 +21,28 @@ interface Props {
 
 const Room: React.FC<Props> = ({ room, isMine, index }) => {
 	const navigate = useNavigate();
+	const [open, setOpen] = useState(false);
+	const [password, setPassword] = useState("");
+
+	const enterRoom = () => {
+		// TODO: 해당 room으로 이동 -> aside에서 가능하도록 변경
+		if (!room.is_private) {
+			navigate(`/room/${room.roomId}`);
+			return;
+		}
+
+		// 서버로 비밀번호 확인 요청
+		// 비밀번호 일치하면 방 입장
+		navigate(`/room/${room.roomId}`);
+	};
 
 	const onRoomClick = () => {
-		// TODO: 비밀방 입장시 비밀번호 입력 모달 생성
+		if (isMine) {
+			enterRoom();
+			return;
+		}
 
-		// TODO: 해당 room으로 이동 -> aside에서 가능하도록 변경
-		navigate(`/room/${room.roomId}`);
+		setOpen(true);
 	};
 
 	return (
@@ -32,30 +50,55 @@ const Room: React.FC<Props> = ({ room, isMine, index }) => {
 			className={roomWrapper}
 			key={index}
 		>
-			<div
-				className={roomContainer}
-				onClick={onRoomClick}
-			>
-				<div className={roomHeaderContainer}>
-					<div className={titleContainer}>
+			{open ? (
+				<div className={roomContainer}>
+					<div className={roomHeaderContainer}>
+						<div className={titleContainer}>
+							{room.is_private ? (
+								<CiLock className={lockIcon} />
+							) : (
+								" "
+							)}
+							채팅방 이름: {room.title}
+						</div>
 						{room.is_private ? (
-							<CiLock className={lockIcon} />
-						) : (
-							" "
-						)}
-						채팅방 이름: {room.title}
-					</div>
-					<div className={numContainer}>
-						{isMine ? <span>접속 인원: {room.curNum}</span> : null}
-						<span>참여 인원: {room.participantNum}</span>
+							<input
+								className={passwordInput}
+								value={password}
+								onChange={e => setPassword(e.target.value)}
+							/>
+						) : null}
+						<button onClick={enterRoom}>입장하기</button>
 					</div>
 				</div>
-				{isMine ? (
-					<div className={chatContainer}>
-						<span>최근 메시지: {room.lastMessage}</span>
+			) : (
+				<div
+					className={roomContainer}
+					onClick={onRoomClick}
+				>
+					<div className={roomHeaderContainer}>
+						<div className={titleContainer}>
+							{room.is_private ? (
+								<CiLock className={lockIcon} />
+							) : (
+								" "
+							)}
+							채팅방 이름: {room.title}
+						</div>
+						<div className={numContainer}>
+							{isMine ? (
+								<span>접속 인원: {room.curNum}</span>
+							) : null}
+							<span>참여 인원: {room.participantNum}</span>
+						</div>
 					</div>
-				) : null}
-			</div>
+					{isMine ? (
+						<div className={chatContainer}>
+							<span>최근 메시지: {room.lastMessage}</span>
+						</div>
+					) : null}
+				</div>
+			)}
 		</div>
 	);
 };

--- a/client/src/component/Chats/ChatRooms/Rooms/Room.tsx
+++ b/client/src/component/Chats/ChatRooms/Rooms/Room.tsx
@@ -1,0 +1,63 @@
+import {
+	chatContainer,
+	lockIcon,
+	numContainer,
+	roomContainer,
+	roomHeaderContainer,
+	roomWrapper,
+	titleContainer,
+} from "./Rooms.css";
+import { IRoomHeader } from "./Rooms";
+import { CiLock } from "react-icons/ci";
+import { useNavigate } from "react-router-dom";
+
+interface Props {
+	room: IRoomHeader;
+	isMine: boolean;
+	index: number;
+}
+
+const Room: React.FC<Props> = ({ room, isMine, index }) => {
+	const navigate = useNavigate();
+
+	const onRoomClick = () => {
+		// TODO: 비밀방 입장시 비밀번호 입력 모달 생성
+
+		// TODO: 해당 room으로 이동 -> aside에서 가능하도록 변경
+		navigate(`/room/${room.roomId}`);
+	};
+
+	return (
+		<div
+			className={roomWrapper}
+			key={index}
+		>
+			<div
+				className={roomContainer}
+				onClick={onRoomClick}
+			>
+				<div className={roomHeaderContainer}>
+					<div className={titleContainer}>
+						{room.is_private ? (
+							<CiLock className={lockIcon} />
+						) : (
+							" "
+						)}
+						채팅방 이름: {room.title}
+					</div>
+					<div className={numContainer}>
+						{isMine ? <span>접속 인원: {room.curNum}</span> : null}
+						<span>참여 인원: {room.participantNum}</span>
+					</div>
+				</div>
+				{isMine ? (
+					<div className={chatContainer}>
+						<span>최근 메시지: {room.lastMessage}</span>
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+};
+
+export default Room;

--- a/client/src/component/Chats/ChatRooms/Rooms/Rooms.css.ts
+++ b/client/src/component/Chats/ChatRooms/Rooms/Rooms.css.ts
@@ -53,3 +53,8 @@ export const numContainer = style({
 export const chatContainer = style({
 	width: "100%",
 });
+
+export const passwordInput = style({
+	width: "50%",
+	height: "34px",
+});

--- a/client/src/component/Chats/ChatRooms/Rooms/Rooms.tsx
+++ b/client/src/component/Chats/ChatRooms/Rooms/Rooms.tsx
@@ -1,19 +1,7 @@
-import { FC, MouseEvent } from "react";
-import { CiLock } from "react-icons/ci";
+import { container } from "./Rooms.css";
+import Room from "./Room";
 
-import {
-	container,
-	chatContainer,
-	numContainer,
-	roomHeaderContainer,
-	roomContainer,
-	roomWrapper,
-	lockIcon,
-	titleContainer,
-} from "./Rooms.css";
-import { useNavigate } from "react-router-dom";
-
-interface IRoomHeader {
+export interface IRoomHeader {
 	roomId: string;
 	title: string;
 	is_private: boolean;
@@ -27,54 +15,15 @@ interface IRoomsProps {
 	rooms: IRoomHeader[];
 }
 
-const Rooms: FC<IRoomsProps> = ({ isMine, rooms }) => {
-	const navigate = useNavigate();
-
-	const onRoomClick =
-		(roomId: string) => (event: MouseEvent<HTMLDivElement>) => {
-			// TODO: 해당 room으로 이동
-			console.log(roomId);
-
-			// TODO: 비밀방 입장시 비밀번호 입력 모달 생성
-
-			// 테스트용 : /room/1
-			navigate("/room/1");
-		};
-
+const Rooms: React.FC<IRoomsProps> = ({ isMine, rooms }) => {
 	return (
 		<div className={container}>
 			{rooms.map((room, index) => (
-				<div
-					className={roomWrapper}
-					key={index}
-				>
-					<div
-						className={roomContainer}
-						onClick={onRoomClick(room.roomId)}
-					>
-						<div className={roomHeaderContainer}>
-							<div className={titleContainer}>
-								{room.is_private ? (
-									<CiLock className={lockIcon} />
-								) : (
-									" "
-								)}
-								채팅방 이름: {room.title}
-							</div>
-							<div className={numContainer}>
-								{isMine ? (
-									<span>접속 인원: {room.curNum}</span>
-								) : null}
-								<span>참여 인원: {room.participantNum}</span>
-							</div>
-						</div>
-						{isMine ? (
-							<div className={chatContainer}>
-								<span>최근 메시지: {room.lastMessage}</span>
-							</div>
-						) : null}
-					</div>
-				</div>
+				<Room
+					room={room}
+					isMine={isMine}
+					index={index}
+				/>
 			))}
 		</div>
 	);


### PR DESCRIPTION
## 📝 작업 내용

- 채팅방 리스트 컴포넌트(Rooms)와 채팅방 컴포넌트(Room) 분리
- Room 클릭 시 채팅방의 타입에 따라 다른 컴포넌트 렌더링
    - 비밀방 : 비밀번호 입력 input + 입장 버튼
    - 일반방 : 입장 버튼
    - 내가 속한 방 : 바로 입장함 (추가적인 렌더링x)

### 🖼️ 스크린샷
![화면-기록-2024-08-13-오후-3 54 40](https://github.com/user-attachments/assets/d87124e6-46ff-4114-86ad-1b0885096cc8)

## 💬 리뷰 요구사항(선택)
- 임의로 함수를 수정했는데 괜찮을까요?
- 수정 전
```ts
const onRoomClick =
		(roomId: string) => (event: MouseEvent<HTMLDivElement>) => {
			// TODO: 해당 room으로 이동
			console.log(roomId);

			// TODO: 비밀방 입장시 비밀번호 입력 모달 생성

			// 테스트용 : /room/1
			navigate("/room/1");
		};
```
- 수정 후
```ts
	const enterRoom = () => {
		// TODO: 해당 room으로 이동 -> aside에서 가능하도록 변경
		if (!room.is_private) {
			navigate(`/room/${room.roomId}`);
			return;
		}

		// 서버로 비밀번호 확인 요청
		// 비밀번호 일치하면 방 입장
		navigate(`/room/${room.roomId}`);
	};

	const onRoomClick = () => {
		if (isMine) {
			enterRoom();
			return;
		}

		setOpen(true);
	};
```
