### PR TITLE
채팅방 리스트 pagination 추가

### DIFF
--- a/client/src/component/Chats/ChatRooms/ChatRooms.tsx
+++ b/client/src/component/Chats/ChatRooms/ChatRooms.tsx
@@ -1,4 +1,11 @@
-import { ChangeEvent, FC, FormEvent, MouseEvent, useState } from "react";
+import {
+	ChangeEvent,
+	FC,
+	FormEvent,
+	MouseEvent,
+	useEffect,
+	useState,
+} from "react";
 import { CiCirclePlus } from "react-icons/ci";
 
 import {
@@ -11,6 +18,7 @@ import {
 	searchInput,
 } from "./ChatRooms.css";
 import Rooms from "./Rooms/Rooms";
+import Pagenation from "./Pagenation/Pagenation";
 
 interface IRoomHeader {
 	roomId: string;
@@ -19,7 +27,6 @@ interface IRoomHeader {
 	participantNum: number; // 채팅방에 속한 사람들
 	curNum: number | null; // 현재 접속 중인 사람들
 	lastMessage: string | null;
-	// lastChatTime: Date | null;
 }
 
 interface IReadRoomResponse {
@@ -27,56 +34,236 @@ interface IReadRoomResponse {
 	roomHeaders: IRoomHeader[];
 }
 
+const testSearch: IReadRoomResponse = {
+	totalRoomCount: 11,
+	roomHeaders: [
+		{
+			roomId: "13",
+			title: "search room test 1",
+			is_private: false,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "14",
+			title: "search room test 2",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "15",
+			title: "search room test 3",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "16",
+			title: "search room test 4",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "17",
+			title: "search room test 5",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "18",
+			title: "search room test 6",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "19",
+			title: "search room test 7",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "20",
+			title: "search room test 8",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "21",
+			title: "search room test 9",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "22",
+			title: "search room test 10",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+		{
+			roomId: "23",
+			title: "search room test 11",
+			is_private: true,
+			participantNum: 5,
+			lastMessage: null,
+			curNum: null,
+		},
+	],
+};
+
+const testMy: IReadRoomResponse = {
+	totalRoomCount: 11,
+	roomHeaders: [
+		{
+			roomId: "1",
+			title: "my room test1",
+			is_private: false,
+			participantNum: 1,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+		{
+			roomId: "2",
+			title: "my room search room test 1",
+			is_private: true,
+			participantNum: 2,
+			lastMessage: `231123`,
+			curNum: 3,
+		},
+		{
+			roomId: "3",
+			title: "my room test3",
+			is_private: false,
+			participantNum: 3,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+		{
+			roomId: "4",
+			title: "my room test4",
+			is_private: false,
+			participantNum: 4,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+		{
+			roomId: "5",
+			title: "my room test5",
+			is_private: false,
+			participantNum: 5,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+		{
+			roomId: "6",
+			title: "my room test6",
+			is_private: false,
+			participantNum: 6,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+		{
+			roomId: "7",
+			title: "my room test7",
+			is_private: false,
+			participantNum: 7,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+		{
+			roomId: "8",
+			title: "my room test8",
+			is_private: false,
+			participantNum: 8,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+		{
+			roomId: "9",
+			title: "my room test9",
+			is_private: false,
+			participantNum: 9,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+		{
+			roomId: "10",
+			title: "my room test10",
+			is_private: false,
+			participantNum: 10,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+		{
+			roomId: "11",
+			title: "my room test11",
+			is_private: false,
+			participantNum: 11,
+			lastMessage: `1234`,
+			curNum: 2,
+		},
+	],
+};
+
 const ChatRooms: FC = () => {
 	const [keyword, setKeyword] = useState<string>("");
+	const [searchCurPage, setSearchCurPage] = useState<number>(1);
+	const [myCurPage, setMyCurPage] = useState<number>(1);
 
 	// test 용 state
-	const [searchRooms, setSearchRooms] = useState<IReadRoomResponse>({
-		totalRoomCount: 14,
-		roomHeaders: [
-			{
-				roomId: "1",
-				title: "test1",
-				is_private: false,
-				participantNum: 5,
-				lastMessage: null,
-				curNum: null,
-			},
-			{
-				roomId: "2",
-				title: "test2",
-				is_private: true,
-				participantNum: 5,
-				lastMessage: null,
-				curNum: null,
-			},
-		],
-	});
-	const [myRooms, setMyRooms] = useState<IReadRoomResponse>({
-		totalRoomCount: 14,
-		roomHeaders: [
-			{
-				roomId: "1",
-				title: "test1",
-				is_private: false,
-				participantNum: 5,
-				lastMessage: `1234`,
-				curNum: 2,
-			},
-			{
-				roomId: "2",
-				title: "test2",
-				is_private: true,
-				participantNum: 5,
-				lastMessage: `231123`,
-				curNum: 3,
-			},
-		],
-	});
+	const [searchRooms, setSearchRooms] = useState<IRoomHeader[][] | null>(
+		null
+	);
+	const [myRooms, setMyRooms] = useState<IRoomHeader[][] | null>(null);
+
+	useEffect(() => {
+		setSearchRooms(
+			testSearch.roomHeaders.reduce((acc, item, index) => {
+				if (index % 2 === 0) acc.push([item]);
+				else acc[acc.length - 1].push(item);
+
+				return acc;
+			}, [] as IRoomHeader[][])
+		);
+		setMyRooms(
+			testMy.roomHeaders.reduce((acc, item, index) => {
+				if (index % 2 === 0) acc.push([item]);
+				else acc[acc.length - 1].push(item);
+
+				return acc;
+			}, [] as IRoomHeader[][])
+		);
+	}, []);
 
 	// 채팅 input Change
 	const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setKeyword(event.target.value);
+	};
+
+	// 검색 페이지 클릭
+	const onSearchPageClick = (page: number) => () => {
+		setSearchCurPage(page);
+	};
+
+	const onMyPageClick = (page: number) => () => {
+		setMyCurPage(page);
 	};
 
 	// 채팅방 검색
@@ -119,17 +306,45 @@ const ChatRooms: FC = () => {
 						/>
 					</div>
 				</div>
-				<Rooms
-					isMine={false}
-					rooms={searchRooms.roomHeaders}
-				/>
+				{searchRooms === null ? (
+					"검색된 채팅방 없음"
+				) : (
+					<>
+						<Rooms
+							isMine={false}
+							rooms={searchRooms[searchCurPage - 1]}
+						/>
+						{testSearch.totalRoomCount > 2 ? (
+							<Pagenation
+								total={testSearch.totalRoomCount}
+								curPage={searchCurPage}
+								setCurPage={setSearchCurPage}
+								onPageClick={onSearchPageClick}
+							/>
+						) : null}
+					</>
+				)}
 			</div>
 			<h3>내 채팅방</h3>
 			<div className={roomsWrapper}>
-				<Rooms
-					isMine={true}
-					rooms={myRooms.roomHeaders}
-				/>
+				{myRooms === null ? (
+					"내 채팅방 없음"
+				) : (
+					<>
+						<Rooms
+							isMine={true}
+							rooms={myRooms[myCurPage - 1]}
+						/>
+						{testMy.totalRoomCount > 2 ? (
+							<Pagenation
+								total={testMy.totalRoomCount}
+								curPage={myCurPage}
+								setCurPage={setMyCurPage}
+								onPageClick={onMyPageClick}
+							/>
+						) : null}
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/client/src/component/Chats/ChatRooms/Pagenation/Pagenation.tsx
+++ b/client/src/component/Chats/ChatRooms/Pagenation/Pagenation.tsx
@@ -1,0 +1,91 @@
+import { Dispatch, FC, SetStateAction, useEffect, useState } from "react";
+
+import { activePage, container, page } from "./pagenation.css";
+import clsx from "clsx";
+
+interface IPagenationProps {
+	total: number;
+	curPage: number;
+	setCurPage: Dispatch<SetStateAction<number>>;
+	onPageClick: (index: number) => () => void;
+}
+
+const Pagenation: FC<IPagenationProps> = ({
+	total,
+	curPage,
+	setCurPage,
+	onPageClick,
+}) => {
+	const [pageIndexs, setPageIndexs] = useState<number[][]>([[]]);
+	const [curPageListIndex, setCurPageListIndex] = useState<number>(0);
+
+	useEffect(() => {
+		// 페이지 리스트 만들기
+		const result = [];
+
+		let temp = [];
+		for (let i = 1; i <= total / 2 + 1; i++) {
+			temp.push(i);
+
+			// 각 페이지는 5개가 default
+			if (temp.length === 5) {
+				result.push(temp);
+				temp = [];
+			}
+		}
+
+		// 남은 페이지 push
+		if (temp.length > 0) result.push(temp);
+
+		setPageIndexs(result);
+		setCurPageListIndex(0);
+		setCurPage(1);
+	}, []);
+
+	// pre or next Click
+	const onPageListClick = (isNext: boolean) => () => {
+		if (isNext) {
+			const nextPageListIndex = curPageListIndex + 1;
+			setCurPage(pageIndexs[nextPageListIndex][0]);
+			setCurPageListIndex(nextPageListIndex);
+		} else {
+			const prePageListIndex = curPageListIndex - 1;
+			setCurPage(pageIndexs[prePageListIndex][0]);
+			setCurPageListIndex(prePageListIndex);
+		}
+	};
+
+	return (
+		<div className={container}>
+			{curPageListIndex > 0 ? (
+				<span
+					className={page}
+					onClick={onPageListClick(false)}
+				>
+					{"<"}
+				</span>
+			) : null}
+			{pageIndexs![curPageListIndex!].map((pageIndex, index) => (
+				<span
+					key={index}
+					className={clsx(page, {
+						[activePage]: pageIndex === curPage,
+					})}
+					onClick={onPageClick(pageIndex)}
+				>
+					{pageIndex}
+				</span>
+			))}
+			{curPageListIndex < pageIndexs.length - 1 ? (
+				<span
+					className={page}
+					onClick={onPageListClick(true)}
+				>
+					{">"}
+				</span>
+			) : null}
+		</div>
+	);
+};
+
+export default Pagenation;

--- a/client/src/component/Chats/ChatRooms/Pagenation/pagenation.css.ts
+++ b/client/src/component/Chats/ChatRooms/Pagenation/pagenation.css.ts
@@ -1,0 +1,19 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "../../../../App.css";
+
+export const container = style({
+	display: "flex",
+	justifyContent: "center",
+	gap: "10px",
+});
+
+export const page = style({
+	cursor: "pointer",
+	":hover": {
+		opacity: "0.7",
+	},
+});
+
+export const activePage = style({
+	fontSize: vars.fontSizing.T3,
+});


### PR DESCRIPTION
## 📝 작업 내용

- 채팅방에 대한 pagination 추가

### 🖼️ 스크린샷

### 동작
![pagination](https://github.com/user-attachments/assets/073daf00-66f8-4c50-8379-d43bec509f1d)

- perPage는 2개
- 임시 데이터로 검색된 결과가 있다는 가정하에 기능 구현

### 데이터 없을 시
![채팅방 없을 시(데이터 없을 시)](https://github.com/user-attachments/assets/176db6fc-ba92-4ad5-bd39-f2329a4d78a0)

💬 리뷰 요구사항(선택)
- 추후에 채팅방 리스트 페이지에서 search room list와 my room list를 모듈화하려고하는데,
pagination 컴포넌트를 rooms 컴포넌트에 추가하는게 맞을까요?