### PR TITLE
[BE] 어드민용 사용자 목록 조회 API 구현

### DIFF
--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -8,7 +8,13 @@ export const handleGetUsers = async (
 	next: NextFunction
 ) => {
 	try {
-		const result = await getUsersInfo();
+		let index = parseInt(req.query.index as string) - 1 || 0;
+		let perPage = parseInt(req.query.perPage as string) || 10;
+		if (index < 0 || perPage < 0) {
+			index = 0;
+			perPage = 10;
+		}
+		const result = await getUsersInfo({ index, perPage });
 		res.status(200).json(mapUsersInfoToResponse(result));
 	} catch (err: any) {
 		next(err);

--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from "express";
+import { getUsersInfo } from "../db/context/users_context";
+import { mapUsersInfoToResponse } from "../db/mapper/users_mapper";
+
+export const handleGetUsers = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const result = await getUsersInfo();
+		res.status(200).json(mapUsersInfoToResponse(result));
+	} catch (err: any) {
+		next(err);
+	}
+};

--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -14,7 +14,10 @@ export const handleGetUsers = async (
 			index = 0;
 			perPage = 10;
 		}
-		const result = await getUsersInfo({ index, perPage });
+
+		let nickname = req.query.nickname as string;
+		let email = req.query.email as string;
+		const result = await getUsersInfo({ index, perPage, nickname, email });
 		res.status(200).json(mapUsersInfoToResponse(result));
 	} catch (err: any) {
 		next(err);

--- a/server/db/context/users_context.ts
+++ b/server/db/context/users_context.ts
@@ -195,13 +195,33 @@ export const getUsersInfo = async ({
 }: GetUsersInfoParams) => {
 	let conn: PoolConnection | null = null;
 	try {
-		let sql = `SELECT (SELECT count(*) FROM users)as total ,u.id, u.email, u.nickname, u.created_at, u.isDelete,
+		let sql = `SELECT COUNT(*) OVER() as total ,u.id, u.email, u.nickname, u.created_at, u.isDelete,
 		(SELECT COUNT(id) FROM comments WHERE author_id = u.id) as comment_count,
 		(SELECT COUNT(id) FROM posts WHERE author_id = u.id) as post_count 
 		FROM users u 
 		`;
 
 		const value = [];
+
+		if (nickname || email) {
+			sql += `WHERE `;
+		}
+
+		if (nickname) {
+			sql += `u.nickname LIKE ? `;
+			value.push(`%${nickname}%`);
+
+			if (email) {
+				sql += `AND `;
+			}
+		}
+
+		if (email) {
+			sql += `u.email LIKE ? `;
+			value.push(`%${email}%`);
+		}
+
+		sql += `ORDER BY u.id ASC`;
 
 		const pagenationSQL = ` LIMIT ? OFFSET ?`;
 

--- a/server/db/mapper/users_mapper.ts
+++ b/server/db/mapper/users_mapper.ts
@@ -33,7 +33,7 @@ export const mapUsersInfoToResponse = (
 	});
 
 	return {
-		total: userInfo.length,
+		total: queryResult[0].total,
 		userInfo,
 	};
 };

--- a/server/db/mapper/users_mapper.ts
+++ b/server/db/mapper/users_mapper.ts
@@ -1,0 +1,39 @@
+import { IUserInfoRow } from "../model/users";
+
+export interface IUserInfoResponse {
+	total: number;
+	userInfo: {
+		id: number;
+		email: string;
+		nickname: string;
+		createdAt: Date;
+		isDelete: boolean;
+		statistics: {
+			comments: number;
+			posts: number;
+		};
+	}[];
+}
+
+export const mapUsersInfoToResponse = (
+	queryResult: IUserInfoRow[]
+): IUserInfoResponse => {
+	const userInfo = queryResult.map(row => {
+		return {
+			id: row.id,
+			email: row.email,
+			nickname: row.nickname,
+			createdAt: row.created_at,
+			isDelete: row.isDelete,
+			statistics: {
+				comments: row.comment_count,
+				posts: row.post_count,
+			},
+		};
+	});
+
+	return {
+		total: userInfo.length,
+		userInfo,
+	};
+};

--- a/server/db/model/users.ts
+++ b/server/db/model/users.ts
@@ -1,3 +1,5 @@
+import { RowDataPacket } from "mysql2/promise";
+
 export interface IUser {
 	id: number;
 	email: string;
@@ -6,3 +8,15 @@ export interface IUser {
 	password: string;
 	salt: string;
 }
+
+export interface IUserInfo {
+	id: number;
+	email: string;
+	nickname: string;
+	created_at: Date;
+	isDelete: boolean;
+	comment_count: number;
+	post_count: number;
+}
+
+export interface IUserInfoRow extends IUserInfo, RowDataPacket {}

--- a/server/db/model/users.ts
+++ b/server/db/model/users.ts
@@ -1,3 +1,4 @@
+import e from "express";
 import { RowDataPacket } from "mysql2/promise";
 
 export interface IUser {
@@ -10,6 +11,7 @@ export interface IUser {
 }
 
 export interface IUserInfo {
+	total: number;
 	id: number;
 	email: string;
 	nickname: string;
@@ -17,6 +19,16 @@ export interface IUserInfo {
 	isDelete: boolean;
 	comment_count: number;
 	post_count: number;
+}
+
+export interface pagenation {
+	index: number;
+	perPage: number;
+}
+
+export interface GetUsersInfoParams extends pagenation {
+	nickname?: string;
+	email?: string;
 }
 
 export interface IUserInfoRow extends IUserInfo, RowDataPacket {}

--- a/server/db/sql/users.sql
+++ b/server/db/sql/users.sql
@@ -4,5 +4,6 @@ CREATE TABLE IF NOT EXISTS users (
     nickname VARCHAR(50) NOT NULL UNIQUE,
     isDelete Boolean NOT NULL DEFAULT FALSE,
     password TEXT NOT NULL,
-    salt TEXT NOT NULL
+    salt TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -1,0 +1,8 @@
+import express from "express";
+import { handleGetUsers } from "../controller/admin_controller";
+
+const router = express.Router();
+router.use(express.json());
+
+router.route("/user").get(handleGetUsers);
+export default router;

--- a/server/route/route.ts
+++ b/server/route/route.ts
@@ -3,6 +3,7 @@ import postRouter from "./posts_router";
 import userRouter from "./users_router";
 import commentRouter from "./comments_router";
 import likeRouter from "./likes_router";
+import adminRouter from "./admin_router";
 
 const router = express.Router();
 router.use(express.json());
@@ -12,5 +13,6 @@ router.use("/post", postRouter);
 router.use("/comment", commentRouter);
 router.use("/user", userRouter);
 router.use("/like", likeRouter);
+router.use("/admin", adminRouter);
 
 export default router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #128

## 📝 작업 내용

-   [x] `GET /api/admin/user?index={}&perPage={}&nickname={}&email={}` 엔드 포인트 추가
-   [x] 가입일 유저 스키마에 추가
-   [x] pagination 기능 추가
-   [x] 닉네임, 이메일 검색 기능 추가

가입일 추가하실때
```sql
ALTER TABLE users ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT NOW()
```
이 sql 문 사용하시면 될거 같습니다.
## 💬 리뷰 요구사항(선택)
- 잘못 구현된 부분이나 개선이 필요한 부분이 있다면 말씀해 주세요.
