### PR TITLE
[BE] 사용자 계정 삭제/복구 API 구현

### DIFF
--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -1,5 +1,9 @@
 import { Request, Response, NextFunction } from "express";
-import { deleteUser, getUsersInfo } from "../db/context/users_context";
+import {
+	deleteUser,
+	getUsersInfo,
+	restoreUser,
+} from "../db/context/users_context";
 import { mapUsersInfoToResponse } from "../db/mapper/users_mapper";
 import { ServerError } from "../middleware/errors";
 
@@ -42,6 +46,21 @@ export const handleAdminDeleteUser = async (
 		}
 		await deleteUser(userId);
 		res.status(200).json({ message: "회원 삭제 성공" });
+	} catch (err: any) {
+		next(err);
+	}
+};
+
+export const handleAdminRestoreUser = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const userId = parseInt(req.params.userId);
+
+		await restoreUser(userId);
+		res.status(200).json({ message: "회원 복구 성공" });
 	} catch (err: any) {
 		next(err);
 	}

--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -35,15 +35,8 @@ export const handleAdminDeleteUser = async (
 	next: NextFunction
 ) => {
 	try {
-		if (!req.params.userId) {
-			throw ServerError.badRequest("userId가 존재하지 않습니다.");
-		}
-
 		const userId = parseInt(req.params.userId);
 
-		if (isNaN(userId)) {
-			throw ServerError.badRequest("userId가 숫자가 아닙니다.");
-		}
 		await deleteUser(userId);
 		res.status(200).json({ message: "회원 삭제 성공" });
 	} catch (err: any) {

--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
-import { getUsersInfo } from "../db/context/users_context";
+import { deleteUser, getUsersInfo } from "../db/context/users_context";
 import { mapUsersInfoToResponse } from "../db/mapper/users_mapper";
+import { ServerError } from "../middleware/errors";
 
 export const handleGetUsers = async (
 	req: Request,
@@ -19,6 +20,28 @@ export const handleGetUsers = async (
 		let email = req.query.email as string;
 		const result = await getUsersInfo({ index, perPage, nickname, email });
 		res.status(200).json(mapUsersInfoToResponse(result));
+	} catch (err: any) {
+		next(err);
+	}
+};
+
+export const handleAdminDeleteUser = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		if (!req.params.userId) {
+			throw ServerError.badRequest("userId가 존재하지 않습니다.");
+		}
+
+		const userId = parseInt(req.params.userId);
+
+		if (isNaN(userId)) {
+			throw ServerError.badRequest("userId가 숫자가 아닙니다.");
+		}
+		await deleteUser(userId);
+		res.status(200).json({ message: "회원 삭제 성공" });
 	} catch (err: any) {
 		next(err);
 	}

--- a/server/db/context/users_context.ts
+++ b/server/db/context/users_context.ts
@@ -269,6 +269,28 @@ export const deleteUser = async (userId: number) => {
 	}
 };
 
+export const restoreUser = async (userId: number) => {
+	let conn: PoolConnection | null = null;
+	try {
+		const sql = `UPDATE users SET isDelete=FALSE WHERE id=? AND isDelete=TRUE`;
+		const value = [userId];
+
+		conn = await pool.getConnection();
+		const [rows]: [ResultSetHeader, FieldPacket[]] = await conn.query(
+			sql,
+			value
+		);
+
+		if (rows.affectedRows === 0) {
+			throw ServerError.badRequest("회원 복구 실패");
+		}
+	} catch (err: any) {
+		throw err;
+	} finally {
+		if (conn) conn.release();
+	}
+};
+
 export const isUserDeleted = async (params: TDeleteUserInfo) => {
 	const { email, userId } = params;
 	let conn: PoolConnection | null = null;

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -4,13 +4,18 @@ import {
 	handleAdminRestoreUser,
 	handleGetUsers,
 } from "../controller/admin_controller";
-import { restoreUserValidation } from "../utils/validations/admin/admin";
+import {
+	deleteUserValidation,
+	restoreUserValidation,
+} from "../utils/validations/admin/admin";
 
 const router = express.Router();
 router.use(express.json());
 
 router.route("/user").get(handleGetUsers);
-router.route("/user/:userId").delete(handleAdminDeleteUser);
+router
+	.route("/user/:userId")
+	.delete(deleteUserValidation, handleAdminDeleteUser);
 router
 	.route("/user/:userId/restore")
 	.patch(restoreUserValidation, handleAdminRestoreUser);

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -1,12 +1,17 @@
 import express from "express";
 import {
 	handleAdminDeleteUser,
+	handleAdminRestoreUser,
 	handleGetUsers,
 } from "../controller/admin_controller";
+import { restoreUserValidation } from "../utils/validations/admin/admin";
 
 const router = express.Router();
 router.use(express.json());
 
 router.route("/user").get(handleGetUsers);
 router.route("/user/:userId").delete(handleAdminDeleteUser);
+router
+	.route("/user/:userId/restore")
+	.patch(restoreUserValidation, handleAdminRestoreUser);
 export default router;

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -1,8 +1,12 @@
 import express from "express";
-import { handleGetUsers } from "../controller/admin_controller";
+import {
+	handleAdminDeleteUser,
+	handleGetUsers,
+} from "../controller/admin_controller";
 
 const router = express.Router();
 router.use(express.json());
 
 router.route("/user").get(handleGetUsers);
+router.route("/user/:userId").delete(handleAdminDeleteUser);
 export default router;

--- a/server/utils/validations/admin/admin.ts
+++ b/server/utils/validations/admin/admin.ts
@@ -14,4 +14,6 @@ const userIdValidator = param("userId")
   Validation
   - 각 API 엔드포인트에 대한 유효성 검사
 */
+export const deleteUserValidation = [userIdValidator, validate];
+
 export const restoreUserValidation = [userIdValidator, validate];

--- a/server/utils/validations/admin/admin.ts
+++ b/server/utils/validations/admin/admin.ts
@@ -7,7 +7,7 @@ import { validate } from "../../../middleware/validate";
   - 각 입력 값에 대한 유효성 검사
 */
 const userIdValidator = param("userId")
-	.isNumeric()
+	.isInt({ min: 1 })
 	.withMessage(ERROR_MESSAGES.INVALID_USER_ID);
 
 /*

--- a/server/utils/validations/admin/admin.ts
+++ b/server/utils/validations/admin/admin.ts
@@ -1,0 +1,17 @@
+import { param } from "express-validator";
+import { ERROR_MESSAGES } from "./constants";
+import { validate } from "../../../middleware/validate";
+
+/*
+  Validators
+  - 각 입력 값에 대한 유효성 검사
+*/
+const userIdValidator = param("userId")
+	.isNumeric()
+	.withMessage(ERROR_MESSAGES.INVALID_USER_ID);
+
+/*
+  Validation
+  - 각 API 엔드포인트에 대한 유효성 검사
+*/
+export const restoreUserValidation = [userIdValidator, validate];

--- a/server/utils/validations/admin/constants.ts
+++ b/server/utils/validations/admin/constants.ts
@@ -1,0 +1,3 @@
+export const ERROR_MESSAGES = {
+	INVALID_USER_ID: "유효하지 않은 유저 ID입니다.",
+} as const;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #134

## 📝 작업 내용

### 사용자 계정 삭제 API
- [x] `DELETE /api/admin/user/:user_id` 엔드포인트 추가
- [x] 회원 정보 DB에 isDelete = 1 수정
- [x] 성공 response 반환

### 사용자 계정 복구 API
- [x] `PATCH /api/admin/user/:user_id/restore` 엔드포인트 추가
- [x] 회원 정보 DB에 isDelete = 0 수정
- [x] 성공 response 반환

## 💬 리뷰 요구사항

- 잘못 구현된 부분이나 개선이 필요한 부분이 있다면 말씀해 주세요.
