### PR TITLE
[BE] 게시글 목록 조회 API 구현

### DIFF
--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -5,7 +5,8 @@ import {
 	restoreUser,
 } from "../db/context/users_context";
 import { mapUsersInfoToResponse } from "../db/mapper/users_mapper";
-import { ServerError } from "../middleware/errors";
+import { getAdminPosts } from "../db/context/posts_context";
+import { mapAdminPostsToResponse } from "../db/mapper/posts_mapper";
 
 export const handleGetUsers = async (
 	req: Request,
@@ -55,6 +56,24 @@ export const handleAdminRestoreUser = async (
 		await restoreUser(userId);
 		res.status(200).json({ message: "회원 복구 성공" });
 	} catch (err: any) {
+		next(err);
+	}
+};
+
+export const handleAdminGetPosts = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const index = parseInt(req.query.index as string) - 1 || 0;
+		const perPage = parseInt(req.query.perPage as string) || 10;
+		const keyword = req.query.keyword as string;
+
+		const posts = await getAdminPosts({ index, perPage, keyword });
+
+		res.json(mapAdminPostsToResponse(posts));
+	} catch (err) {
 		next(err);
 	}
 };

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -154,6 +154,11 @@ export const getAdminPosts = async ({
 		`;
 		const value = [];
 
+		if (keyword) {
+			sql += ` WHERE p.title LIKE ?`;
+			value.push(`%${keyword}%`);
+		}
+
 		sql += ` ORDER BY p.id ASC`;
 
 		sql += " LIMIT ? OFFSET ?";

--- a/server/db/mapper/posts_mapper.ts
+++ b/server/db/mapper/posts_mapper.ts
@@ -1,0 +1,33 @@
+import { IAdminPostRow } from "../model/posts";
+
+interface IAdminPostResponse {
+	total: number;
+	postHeaders: {
+		id: number;
+		title: string;
+		author_id: number;
+		created_at: Date;
+		isDelete: boolean;
+		is_private: boolean;
+	}[];
+}
+
+export const mapAdminPostsToResponse = (
+	queryResult: IAdminPostRow[]
+): IAdminPostResponse => {
+	const postHeaders = queryResult.map(row => {
+		return {
+			id: row.id,
+			title: row.title,
+			author_id: row.author_id,
+			created_at: row.created_at,
+			isDelete: row.isDelete,
+			is_private: row.is_private,
+		};
+	});
+
+	return {
+		total: queryResult[0].total,
+		postHeaders,
+	};
+};

--- a/server/db/mapper/posts_mapper.ts
+++ b/server/db/mapper/posts_mapper.ts
@@ -5,10 +5,10 @@ interface IAdminPostResponse {
 	postHeaders: {
 		id: number;
 		title: string;
-		author_id: number;
-		created_at: Date;
+		author: string;
+		createdAt: Date;
 		isDelete: boolean;
-		is_private: boolean;
+		isPrivate: boolean;
 	}[];
 }
 
@@ -19,10 +19,10 @@ export const mapAdminPostsToResponse = (
 		return {
 			id: row.id,
 			title: row.title,
-			author_id: row.author_id,
-			created_at: row.created_at,
+			author: row.author,
+			createdAt: row.created_at,
 			isDelete: row.isDelete,
-			is_private: row.is_private,
+			isPrivate: row.is_private,
 		};
 	});
 

--- a/server/db/model/posts.ts
+++ b/server/db/model/posts.ts
@@ -3,7 +3,7 @@ import { RowDataPacket } from "mysql2";
 export interface IAdminPost {
 	id: number;
 	title: string;
-	author_id: number;
+	author: string;
 	created_at: Date;
 	updated_at: Date;
 	isDelete: boolean;

--- a/server/db/model/posts.ts
+++ b/server/db/model/posts.ts
@@ -1,0 +1,13 @@
+import { RowDataPacket } from "mysql2";
+
+export interface IAdminPost {
+	id: number;
+	title: string;
+	author_id: number;
+	created_at: Date;
+	updated_at: Date;
+	isDelete: boolean;
+	is_private: boolean;
+}
+
+export interface IAdminPostRow extends IAdminPost, RowDataPacket {}

--- a/server/db/sql/posts.sql
+++ b/server/db/sql/posts.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS posts (
     updated_at TIMESTAMP ON UPDATE NOW(),
     views INT NOT NULL default 0,
     isDelete Boolean NOT NULL DEFAULT FALSE,
+    is_private Boolean NOT NULL DEFAULT FALSE,
     FOREIGN KEY (author_id) REFERENCES users(id)
 );
 

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import {
 	handleAdminDeleteUser,
+	handleAdminGetPosts,
 	handleAdminRestoreUser,
 	handleGetUsers,
 } from "../controller/admin_controller";
@@ -19,4 +20,6 @@ router
 router
 	.route("/user/:userId/restore")
 	.patch(restoreUserValidation, handleAdminRestoreUser);
+
+router.route("/post").get(handleAdminGetPosts);
 export default router;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #136

## 📝 작업 내용

- [x] `is_private` posts Table에 스키마 추가
- [x] `GET /api/admin/post?index={}&perPage={}&keyword={}` 엔드포인트 추가
- [x] 삭제된 게시글도 목록에 포함
- [x] pagination기능 추가

is_private coloum추가 하실 때
``` sql
ALTER TABLE posts ADD COLUMN is_private Boolean NOT NULL DEFAULT FALSE
```
이 sql 문 사용하시면 될거 같습니다.




## 💬 리뷰 요구사항

- 잘못 구현된 부분이나 개선이 필요한 부분이 있다면 말씀해 주세요.
