### PR TITLE
[BE] 관리자용 게시물 삭제/복구 및 공개/비공개 API 구현

### DIFF
--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -5,7 +5,11 @@ import {
 	restoreUser,
 } from "../db/context/users_context";
 import { mapUsersInfoToResponse } from "../db/mapper/users_mapper";
-import { deletePost, getAdminPosts } from "../db/context/posts_context";
+import {
+	deletePost,
+	getAdminPosts,
+	restorePost,
+} from "../db/context/posts_context";
 import { mapAdminPostsToResponse } from "../db/mapper/posts_mapper";
 
 export const handleGetUsers = async (
@@ -88,6 +92,21 @@ export const handleAdminDeletePost = async (
 
 		await deletePost(postId);
 		res.status(200).json({ message: "게시글 삭제 성공" });
+	} catch (err: any) {
+		next(err);
+	}
+};
+
+export const handleAdminRestorePost = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const postId = parseInt(req.params.postId);
+
+		await restorePost(postId);
+		res.status(200).json({ message: "게시글 복구 성공" });
 	} catch (err: any) {
 		next(err);
 	}

--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -8,6 +8,7 @@ import { mapUsersInfoToResponse } from "../db/mapper/users_mapper";
 import {
 	deletePost,
 	getAdminPosts,
+	publicPost,
 	restorePost,
 } from "../db/context/posts_context";
 import { mapAdminPostsToResponse } from "../db/mapper/posts_mapper";
@@ -107,6 +108,21 @@ export const handleAdminRestorePost = async (
 
 		await restorePost(postId);
 		res.status(200).json({ message: "게시글 복구 성공" });
+	} catch (err: any) {
+		next(err);
+	}
+};
+
+export const handleAdminPublicPost = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const postId = parseInt(req.params.postId);
+
+		await publicPost(postId);
+		res.status(200).json({ message: "게시글 공개 성공" });
 	} catch (err: any) {
 		next(err);
 	}

--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -5,7 +5,7 @@ import {
 	restoreUser,
 } from "../db/context/users_context";
 import { mapUsersInfoToResponse } from "../db/mapper/users_mapper";
-import { getAdminPosts } from "../db/context/posts_context";
+import { deletePost, getAdminPosts } from "../db/context/posts_context";
 import { mapAdminPostsToResponse } from "../db/mapper/posts_mapper";
 
 export const handleGetUsers = async (
@@ -74,6 +74,21 @@ export const handleAdminGetPosts = async (
 
 		res.json(mapAdminPostsToResponse(posts));
 	} catch (err) {
+		next(err);
+	}
+};
+
+export const handleAdminDeletePost = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const postId = parseInt(req.params.postId);
+
+		await deletePost(postId);
+		res.status(200).json({ message: "게시글 삭제 성공" });
+	} catch (err: any) {
 		next(err);
 	}
 };

--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -8,6 +8,7 @@ import { mapUsersInfoToResponse } from "../db/mapper/users_mapper";
 import {
 	deletePost,
 	getAdminPosts,
+	privatePost,
 	publicPost,
 	restorePost,
 } from "../db/context/posts_context";
@@ -123,6 +124,21 @@ export const handleAdminPublicPost = async (
 
 		await publicPost(postId);
 		res.status(200).json({ message: "게시글 공개 성공" });
+	} catch (err: any) {
+		next(err);
+	}
+};
+
+export const handleAdminPrivatePost = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const postId = parseInt(req.params.postId);
+
+		await privatePost(postId);
+		res.status(200).json({ message: "게시글 비공개 성공" });
 	} catch (err: any) {
 		next(err);
 	}

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -263,13 +263,18 @@ export const updatePost = async (
 	}
 };
 
-export const deletePost = async (post_id: number, user_id: number) => {
+export const deletePost = async (post_id: number, user_id?: number) => {
 	let conn: PoolConnection | null = null;
 
 	try {
-		let values: number[] = [post_id, user_id];
+		let values: number[] = [post_id];
 
-		let sql = `UPDATE posts SET isDelete = true WHERE id = ? and author_id = ?`;
+		let sql = `UPDATE posts SET isDelete = true WHERE id = ? AND isDelete = FALSE`;
+
+		if (user_id) {
+			sql += ` and author_id = ?`;
+			values.push(user_id);
+		}
 
 		conn = await pool.getConnection();
 		const [rows]: any[] = await conn.query(sql, values);

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -336,3 +336,26 @@ export const publicPost = async (post_id: number) => {
 		if (conn) conn.release();
 	}
 };
+
+export const privatePost = async (post_id: number) => {
+	let conn: PoolConnection | null = null;
+
+	try {
+		let values: number[] = [post_id];
+
+		let sql = `UPDATE posts SET is_private = TRUE WHERE id = ? AND is_private = FALSE`;
+
+		conn = await pool.getConnection();
+		const [rows]: any[] = await conn.query(sql, values);
+
+		if (rows.affectedRows === 0) {
+			// 1. 이미 비공개된 게시글
+			// 2. 원인모를 이유로 실패함
+			throw ServerError.reference("게시글 비공개 실패");
+		}
+	} catch (err) {
+		throw err;
+	} finally {
+		if (conn) conn.release();
+	}
+};

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -290,3 +290,26 @@ export const deletePost = async (post_id: number, user_id?: number) => {
 		if (conn) conn.release();
 	}
 };
+
+export const restorePost = async (post_id: number) => {
+	let conn: PoolConnection | null = null;
+
+	try {
+		let values: number[] = [post_id];
+
+		let sql = `UPDATE posts SET isDelete = FALSE WHERE id = ? AND isDelete = TRUE`;
+
+		conn = await pool.getConnection();
+		const [rows]: any[] = await conn.query(sql, values);
+
+		if (rows.affectedRows === 0) {
+			// 1. 이미 복구된 게시글
+			// 2. 원인모를 이유로 실패함
+			throw ServerError.reference("게시글 복구 실패");
+		}
+	} catch (err) {
+		throw err;
+	} finally {
+		if (conn) conn.release();
+	}
+};

--- a/server/db/context/posts_context.ts
+++ b/server/db/context/posts_context.ts
@@ -313,3 +313,26 @@ export const restorePost = async (post_id: number) => {
 		if (conn) conn.release();
 	}
 };
+
+export const publicPost = async (post_id: number) => {
+	let conn: PoolConnection | null = null;
+
+	try {
+		let values: number[] = [post_id];
+
+		let sql = `UPDATE posts SET is_private = FALSE WHERE id = ? AND is_private = TRUE`;
+
+		conn = await pool.getConnection();
+		const [rows]: any[] = await conn.query(sql, values);
+
+		if (rows.affectedRows === 0) {
+			// 1. 이미 공개된 게시글
+			// 2. 원인모를 이유로 실패함
+			throw ServerError.reference("게시글 공개 실패");
+		}
+	} catch (err) {
+		throw err;
+	} finally {
+		if (conn) conn.release();
+	}
+};

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -10,7 +10,11 @@ import {
 	handleGetUsers,
 } from "../controller/admin_controller";
 import {
+	deletePostValidation,
 	deleteUserValidation,
+	privatePostValidation,
+	publicPostValidation,
+	restorePostValidation,
 	restoreUserValidation,
 } from "../utils/validations/admin/admin";
 
@@ -26,9 +30,17 @@ router
 	.patch(restoreUserValidation, handleAdminRestoreUser);
 
 router.route("/post").get(handleAdminGetPosts);
-router.route("/post/:postId").delete(handleAdminDeletePost);
-router.route("/post/:postId/restore").patch(handleAdminRestorePost);
-router.route("/post/:postId/public").patch(handleAdminPublicPost);
-router.route("/post/:postId/private").patch(handleAdminPrivatePost);
+router
+	.route("/post/:postId")
+	.delete(deletePostValidation, handleAdminDeletePost);
+router
+	.route("/post/:postId/restore")
+	.patch(restorePostValidation, handleAdminRestorePost);
+router
+	.route("/post/:postId/public")
+	.patch(publicPostValidation, handleAdminPublicPost);
+router
+	.route("/post/:postId/private")
+	.patch(privatePostValidation, handleAdminPrivatePost);
 
 export default router;

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -3,6 +3,7 @@ import {
 	handleAdminDeletePost,
 	handleAdminDeleteUser,
 	handleAdminGetPosts,
+	handleAdminRestorePost,
 	handleAdminRestoreUser,
 	handleGetUsers,
 } from "../controller/admin_controller";
@@ -24,4 +25,6 @@ router
 
 router.route("/post").get(handleAdminGetPosts);
 router.route("/post/:postId").delete(handleAdminDeletePost);
+router.route("/post/:postId/restore").patch(handleAdminRestorePost);
+
 export default router;

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -3,6 +3,7 @@ import {
 	handleAdminDeletePost,
 	handleAdminDeleteUser,
 	handleAdminGetPosts,
+	handleAdminPrivatePost,
 	handleAdminPublicPost,
 	handleAdminRestorePost,
 	handleAdminRestoreUser,
@@ -28,5 +29,6 @@ router.route("/post").get(handleAdminGetPosts);
 router.route("/post/:postId").delete(handleAdminDeletePost);
 router.route("/post/:postId/restore").patch(handleAdminRestorePost);
 router.route("/post/:postId/public").patch(handleAdminPublicPost);
+router.route("/post/:postId/private").patch(handleAdminPrivatePost);
 
 export default router;

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -3,6 +3,7 @@ import {
 	handleAdminDeletePost,
 	handleAdminDeleteUser,
 	handleAdminGetPosts,
+	handleAdminPublicPost,
 	handleAdminRestorePost,
 	handleAdminRestoreUser,
 	handleGetUsers,
@@ -26,5 +27,6 @@ router
 router.route("/post").get(handleAdminGetPosts);
 router.route("/post/:postId").delete(handleAdminDeletePost);
 router.route("/post/:postId/restore").patch(handleAdminRestorePost);
+router.route("/post/:postId/public").patch(handleAdminPublicPost);
 
 export default router;

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import {
+	handleAdminDeletePost,
 	handleAdminDeleteUser,
 	handleAdminGetPosts,
 	handleAdminRestoreUser,
@@ -22,4 +23,5 @@ router
 	.patch(restoreUserValidation, handleAdminRestoreUser);
 
 router.route("/post").get(handleAdminGetPosts);
+router.route("/post/:postId").delete(handleAdminDeletePost);
 export default router;

--- a/server/utils/validations/admin/admin.ts
+++ b/server/utils/validations/admin/admin.ts
@@ -10,10 +10,18 @@ const userIdValidator = param("userId")
 	.isInt({ min: 1 })
 	.withMessage(ERROR_MESSAGES.INVALID_USER_ID);
 
+const postIdValidator = param("postId")
+	.isInt({ min: 1 })
+	.withMessage(ERROR_MESSAGES.INVALID_POST_ID);
+
 /*
   Validation
   - 각 API 엔드포인트에 대한 유효성 검사
 */
 export const deleteUserValidation = [userIdValidator, validate];
-
 export const restoreUserValidation = [userIdValidator, validate];
+
+export const deletePostValidation = [postIdValidator, validate];
+export const restorePostValidation = [postIdValidator, validate];
+export const publicPostValidation = [postIdValidator, validate];
+export const privatePostValidation = [postIdValidator, validate];

--- a/server/utils/validations/admin/admin.ts
+++ b/server/utils/validations/admin/admin.ts
@@ -6,22 +6,24 @@ import { validate } from "../../../middleware/validate";
   Validators
   - 각 입력 값에 대한 유효성 검사
 */
-const userIdValidator = param("userId")
-	.isInt({ min: 1 })
-	.withMessage(ERROR_MESSAGES.INVALID_USER_ID);
+const userIdValidator = () =>
+	param("userId")
+		.isInt({ min: 1 })
+		.withMessage(ERROR_MESSAGES.INVALID_USER_ID);
 
-const postIdValidator = param("postId")
-	.isInt({ min: 1 })
-	.withMessage(ERROR_MESSAGES.INVALID_POST_ID);
+const postIdValidator = () =>
+	param("postId")
+		.isInt({ min: 1 })
+		.withMessage(ERROR_MESSAGES.INVALID_POST_ID);
 
 /*
   Validation
   - 각 API 엔드포인트에 대한 유효성 검사
 */
-export const deleteUserValidation = [userIdValidator, validate];
-export const restoreUserValidation = [userIdValidator, validate];
+export const deleteUserValidation = [userIdValidator(), validate];
+export const restoreUserValidation = [userIdValidator(), validate];
 
-export const deletePostValidation = [postIdValidator, validate];
-export const restorePostValidation = [postIdValidator, validate];
-export const publicPostValidation = [postIdValidator, validate];
-export const privatePostValidation = [postIdValidator, validate];
+export const deletePostValidation = [postIdValidator(), validate];
+export const restorePostValidation = [postIdValidator(), validate];
+export const publicPostValidation = [postIdValidator(), validate];
+export const privatePostValidation = [postIdValidator(), validate];

--- a/server/utils/validations/admin/constants.ts
+++ b/server/utils/validations/admin/constants.ts
@@ -1,3 +1,4 @@
 export const ERROR_MESSAGES = {
 	INVALID_USER_ID: "유효하지 않은 유저 ID입니다.",
+	INVALID_POST_ID: "유효하지 않은 게시글 ID입니다.",
 } as const;

--- a/server/utils/validations/posts/posts.ts
+++ b/server/utils/validations/posts/posts.ts
@@ -2,34 +2,35 @@ import { body, param } from "express-validator";
 import { validate } from "../../../middleware/validate";
 import { ERROR_MESSAGES } from "./constants";
 
-const postTitleValidator = body("title")
-	.notEmpty()
-	.withMessage(ERROR_MESSAGES.TITLE_REQUIRED)
-	.bail();
+const postTitleValidator = () =>
+	body("title").notEmpty().withMessage(ERROR_MESSAGES.TITLE_REQUIRED).bail();
 
-const postContentValidator = body("content")
-	.notEmpty()
-	.withMessage(ERROR_MESSAGES.CONTENT_REQUIRED)
-	.bail();
+const postContentValidator = () =>
+	body("content")
+		.notEmpty()
+		.withMessage(ERROR_MESSAGES.CONTENT_REQUIRED)
+		.bail();
 
-const patchBodyValidator = body("title")
-	.custom((value, { req }) => {
-		return value || req.body.content;
-	})
-	.withMessage(ERROR_MESSAGES.UPDATE_DATA_REQUIRED);
+const patchBodyValidator = () =>
+	body("title")
+		.custom((value, { req }) => {
+			return value || req.body.content;
+		})
+		.withMessage(ERROR_MESSAGES.UPDATE_DATA_REQUIRED);
 
-const deleteValidator = param("post_id")
-	.notEmpty()
-	.isInt({ min: 1 })
-	.withMessage(ERROR_MESSAGES.INVALID_POSR_ID)
-	.bail();
+const deleteValidator = () =>
+	param("post_id")
+		.notEmpty()
+		.isInt({ min: 1 })
+		.withMessage(ERROR_MESSAGES.INVALID_POSR_ID)
+		.bail();
 
 export const postValidation = [
-	postTitleValidator,
-	postContentValidator,
+	postTitleValidator(),
+	postContentValidator(),
 	validate,
 ];
 
-export const patchValidation = [patchBodyValidator, validate];
+export const patchValidation = [patchBodyValidator(), validate];
 
-export const deleteValidation = [deleteValidator, validate];
+export const deleteValidation = [deleteValidator(), validate];

--- a/server/utils/validations/users/user.ts
+++ b/server/utils/validations/users/user.ts
@@ -40,23 +40,23 @@ const passwordValidator = (
 /**
  * 비밀번호 확인 유효성 검사
  */
-const requiredPasswordValidator = body("requiredPassword")
-	.notEmpty()
-	.withMessage(ERROR_MESSAGES.REQUIRED_PASSWORD_MISSING)
-	.bail()
-	.custom((value, { req }) => {
-		if (value !== req.body.password) {
-			throw new Error(ERROR_MESSAGES.REQUIRED_PASSWORD_MISMATCH);
-		}
-		return true;
-	});
+const requiredPasswordValidator = () =>
+	body("requiredPassword")
+		.notEmpty()
+		.withMessage(ERROR_MESSAGES.REQUIRED_PASSWORD_MISSING)
+		.bail()
+		.custom((value, { req }) => {
+			if (value !== req.body.password) {
+				throw new Error(ERROR_MESSAGES.REQUIRED_PASSWORD_MISMATCH);
+			}
+			return true;
+		});
 
 /**
  * 닉네임 유효성 검사
  */
-const nicknameValidator = body("nickname")
-	.notEmpty()
-	.withMessage(ERROR_MESSAGES.NICKNAME_REQUIRED);
+const nicknameValidator = () =>
+	body("nickname").notEmpty().withMessage(ERROR_MESSAGES.NICKNAME_REQUIRED);
 
 /*
   Validation
@@ -69,8 +69,8 @@ const nicknameValidator = body("nickname")
 export const joinValidation = [
 	emailValidator(),
 	passwordValidator(),
-	requiredPasswordValidator,
-	nicknameValidator,
+	requiredPasswordValidator(),
+	nicknameValidator(),
 	validate,
 ];
 
@@ -87,7 +87,7 @@ export const loginValidation = [
  * 회원 정보 수정 API 유효성 검사
  */
 export const updateUserValidation = [
-	nicknameValidator,
+	nicknameValidator(),
 	passwordValidator(),
 	validate,
 ];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #140

## 📝 작업 내용

### 게시글 삭제
 - [x] `DELETE /api/admin/post/:post_id` 엔드포인트 추가
 - [x]  posts_controller에 `handlePostDelete` 함수 사용 (DB 에서 isDelete = 1로 바꾸는 기능 추가)
### 게시물 복구
- [x]  `PATCH /api/admin/post/:post_id/restore` 엔드포인트 추가
- [x] DB에서 isDelete = 0으로 바꾸는 기능 추가

### 게시물 공개
- [x] `PATCH /api/admin/post/:post_id/public` 엔드포인트 추가
- [x] DB에서 isPrivate = 0으로 바꾸는 기능 추가
### 게시물 비공개
- [x]  게시글 비공개 API: `PATCH /api/admin/post/:post_id/private`
- [x]  DB에서 isPrivate = 1으로 바꾸는 기능 추가

## 💬 리뷰 요구사항
- 게시물 비공개와 관련된 기능은 추후에 인화님하고 의견 나누어 본 후에 추가하도록 하겠습니다.

- 잘못 구현된 부분이나 개선이 필요한 부분이 있다면 말씀해 주세요.