### PR TITLE
[BE] 메시지 큐 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ package-lock.json
 dist
 test_case
 
-logs
+datas

--- a/chat_server/app.ts
+++ b/chat_server/app.ts
@@ -1,18 +1,12 @@
 import express from "express";
-import dotenv from "dotenv";
 import { createServer } from "http";
-import { Server, Socket } from "socket.io";
+import { Server } from "socket.io";
 import { instrument } from "@socket.io/admin-ui";
 import { handleChatConnection } from "./controllers/chat_controller";
 import { handleNotificationConnection } from "./controllers/notification_controller";
-import { connectRedis } from "./config/redis_config";
-import { connectProducer, sendMessage } from "./services/kafka_service"; // test 용
-import { ISendMessageRequest } from "./types/message";
 
 const app = express();
 const httpServer = createServer(app);
-
-dotenv.config();
 
 // socket.io 서버 설정
 const io = new Server(httpServer, {
@@ -39,38 +33,4 @@ notificationNamespace.on("connection", socket => {
 	handleNotificationConnection(socket);
 });
 
-const PORT = process.env.PORT || 3000;
-
-async function startServer() {
-	try {
-		// Redis 연결
-		await connectRedis();
-		console.log("Redis 연결 성공");
-
-		// Kafka Producer 연결
-		await connectProducer();
-		console.log("Kafka Producer 연결 성공");
-
-		// TEST: 추후 지울 것! (Kafka로 message 보내기)
-		const testMessage: ISendMessageRequest = {
-			roomId: "1",
-			nickname: "test",
-			message: "test입니다.",
-			created_at: new Date(),
-		};
-		await sendMessage(testMessage);
-		console.log(
-			`socket server: roomId: ${testMessage.roomId} nickname: ${testMessage.nickname} message: ${testMessage.message} created_at: ${testMessage.created_at}`
-		);
-
-		// 채팅 서버 실행
-		httpServer.listen(PORT, () => {
-			console.log(`채팅 서버 ${PORT}에서 실행 중`);
-		});
-	} catch (error) {
-		console.error("서버 시작 중 오류 발생:", error);
-	}
-}
-
-// 서버 실행
-startServer();
+export default httpServer;

--- a/chat_server/config/kafka_config.ts
+++ b/chat_server/config/kafka_config.ts
@@ -1,7 +1,7 @@
 import { Kafka, logLevel } from "kafkajs";
 
 /**
- * kafka API 객체
+ * Kafka API 객체
  */
 let kafka: Kafka | null = null;
 

--- a/chat_server/config/kafka_config.ts
+++ b/chat_server/config/kafka_config.ts
@@ -1,34 +1,37 @@
-import dotenv from "dotenv";
 import { Kafka, logLevel } from "kafkajs";
 
-dotenv.config();
-
-const isDev = !process.env.DOCKER_HOST_IP;
+/**
+ * kafka API 객체
+ */
+let kafka: Kafka | null = null;
 
 /**
- * Kafka 설정
+ * init Kafka API
  */
-const kafka = new Kafka({
-	clientId: "chat-socket-1", // Kafka와 송수신하는 Client ID
-	brokers: [
-		isDev
-			? "localhost:9092"
-			: `${process.env.DOCKER_HOST_IP}:${process.env.KAFKA_1_PORT}`,
-		isDev
-			? "localhost:9092"
-			: `${process.env.DOCKER_HOST_IP}:${process.env.KAFKA_2_PORT}`,
-		isDev
-			? "localhost:9092"
-			: `${process.env.DOCKER_HOST_IP}:${process.env.KAFKA_3_PORT}`,
-	], // Broker URL
-	logLevel: logLevel.WARN, // Console의 log 수준 (현재 값: Error or Warning)
-	retry: {
-		maxRetryTime: 10000, // 최대 재시도 시간
-		initialRetryTime: 300, // 처음 재시도까지 대기 시간 (ms)
-		retries: 5, // 최대 재시도 횟수
-		factor: 1.5, // 재시도 대기시간에 대한 배수, 다음 재시도는 이전 재시도 대기 시간의 factor를 곱한 시간
-		multiplier: 1, // factor에 대한 배수
-	},
-});
+const initKafkaAPI = (clientId: string, brokers: string[]): void => {
+	kafka = new Kafka({
+		clientId,
+		brokers,
+		logLevel: logLevel.NOTHING, // Console의 log 수준 (현재 값: NOTHING)
+		retry: {
+			maxRetryTime: 10000, // 최대 재시도 시간
+			initialRetryTime: 300, // 처음 재시도까지 대기 시간 (ms)
+			retries: 5, // 최대 재시도 횟수
+			factor: 1.5, // 재시도 대기시간에 대한 배수, 다음 재시도는 이전 재시도 대기 시간의 factor를 곱한 시간
+			multiplier: 1, // factor에 대한 배수
+		},
+	});
+};
 
-export default kafka;
+/**
+ * get Kafka API
+ */
+const getKafkaAPI = (): Kafka => {
+	if (kafka === null) {
+		throw new Error("Kafka API is null");
+	}
+
+	return kafka;
+};
+
+export { initKafkaAPI, getKafkaAPI };

--- a/chat_server/config/redis_config.ts
+++ b/chat_server/config/redis_config.ts
@@ -1,23 +1,27 @@
-import dotenv from "dotenv";
-import { createClient } from "redis";
+import { createClient, RedisClientType } from "redis";
 
-dotenv.config();
+/**
+ * Redis API 객체
+ */
+let redis: RedisClientType | null = null;
 
-const isDev = !process.env.DOCKER_HOST_IP;
-
-const redisClient = createClient({
-	url: isDev
-		? "redis://localhost:6379"
-		: `${process.env.DOCKER_HOST_IP}:${process.env.REDIS_PORT}`,
-});
-
-const connectRedis = async () => {
-	try {
-		await redisClient.connect();
-		console.log("Connected to Redis");
-	} catch (error) {
-		console.error("Could not connect to Redis", error);
+const initRedisAPI = (url: string) => {
+	if (redis === null) {
+		redis = createClient({
+			url,
+		});
 	}
 };
 
-export { redisClient, connectRedis };
+/**
+ * get Redis API
+ */
+const getRedisAPI = (): RedisClientType => {
+	if (redis === null) {
+		throw new Error("Redis API is null");
+	}
+
+	return redis;
+};
+
+export { getRedisAPI, initRedisAPI };

--- a/chat_server/index.ts
+++ b/chat_server/index.ts
@@ -1,8 +1,8 @@
 import dotenv from "dotenv";
-import { IMessage } from "shared";
+import { IKafkaMessageDTO } from "shared";
 
 import httpServer from "./app";
-import { connectRedis } from "./config/redis_config";
+import { getRedisAPI, initRedisAPI } from "./config/redis_config";
 import { getKafkaAPI, initKafkaAPI } from "./config/kafka_config";
 import {
 	getProducer,
@@ -13,42 +13,35 @@ import {
 dotenv.config();
 
 async function startServer() {
-	// 도커 호스트 IP
-	const DOCKER_HOST_IP = process.env.DOCKER_HOST_IP;
+	// 호스트 IP
+	const HOST_IP = process.env.DOCKER_HOST_IP || "localhost";
+
+	// 레디스 PORT
+	const REDIS_PORT = process.env.REDIS_PORT || "6379";
+
+	// 카프카 PORT
+	const KAFKA_PORT_1 = process.env.KAFKA_PORT_1 || "9092";
+	const KAFKA_PORT_2 = process.env.KAFKA_PORT_2 || "9093";
+	const KAFKA_PORT_3 = process.env.KAFKA_PORT_3 || "9094";
 
 	// 채팅 소켓 PORT
 	const CHAT_PORT = process.env.CHAT_PORT || 3000;
 
-	// 카프카 PORT
-	const KAFKA_PORT_1 = process.env.KAFKA_PORT_1;
-	const KAFKA_PORT_2 = process.env.KAFKA_PORT_2;
-	const KAFKA_PORT_3 = process.env.KAFKA_PORT_3;
-
-	// 레디스 PORT
-	const REDIS_PORT = process.env.REDIS_PORT;
-
 	// 레디스 서버 URL
-	const REDIS_URL =
-		DOCKER_HOST_IP && REDIS_PORT
-			? `${DOCKER_HOST_IP}:${REDIS_PORT}`
-			: "localhost:6379";
+	const REDIS_URL = `redis://${HOST_IP}:${REDIS_PORT}`;
 
 	// Broker URLs
 	const brokers: string[] = [
-		DOCKER_HOST_IP && KAFKA_PORT_1
-			? `${DOCKER_HOST_IP}:${KAFKA_PORT_1}`
-			: "localhost:9092",
-		DOCKER_HOST_IP && KAFKA_PORT_2
-			? `${DOCKER_HOST_IP}:${KAFKA_PORT_2}`
-			: "localhost:9093",
-		DOCKER_HOST_IP && KAFKA_PORT_3
-			? `${DOCKER_HOST_IP}:${KAFKA_PORT_3}`
-			: "localhost:9094",
+		`${HOST_IP}:${KAFKA_PORT_1}`,
+		`${HOST_IP}:${KAFKA_PORT_2}`,
+		`${HOST_IP}:${KAFKA_PORT_3}`,
 	];
 
 	try {
 		// Redis 연결
-		await connectRedis();
+		initRedisAPI(REDIS_URL);
+		const redis = getRedisAPI();
+		await redis.connect();
 		console.log("Redis 연결 성공");
 
 		// Kafka API
@@ -63,17 +56,23 @@ async function startServer() {
 		await producer.connect();
 		console.log("Kafka Producer 연결 성공");
 
-		// TEST: 추후 지울 것! (Kafka로 message 보내기)
-		const testMessage: IMessage = {
-			roomId: "1",
-			nickname: "test",
+		// TEST START: 추후 지울 것! (Kafka로 message 보내기)
+		const testMessage: IKafkaMessageDTO = {
+			roomId: 1,
+			userId: 1,
 			message: "test입니다.",
 			createdAt: new Date(),
-			isMine: false,
 			isSystem: true,
 		};
 		console.log(
-			`producer message:\nroomId: ${testMessage.roomId}\nmessage: ${testMessage.message}\ncreatedAt: ${testMessage.createdAt}`
+			`
+producer message:
+roomId: ${testMessage.roomId}
+userId: ${testMessage.userId}
+message: ${testMessage.message}
+createdAt: ${testMessage.createdAt}
+isSystem: ${testMessage.isSystem}
+			`
 		);
 		sendMessage(testMessage);
 		// TEST END

--- a/chat_server/index.ts
+++ b/chat_server/index.ts
@@ -1,0 +1,91 @@
+import dotenv from "dotenv";
+import { IMessage } from "shared";
+
+import httpServer from "./app";
+import { connectRedis } from "./config/redis_config";
+import { getKafkaAPI, initKafkaAPI } from "./config/kafka_config";
+import {
+	getProducer,
+	initProducer,
+	sendMessage,
+} from "./services/kafka_service";
+
+dotenv.config();
+
+async function startServer() {
+	// 도커 호스트 IP
+	const DOCKER_HOST_IP = process.env.DOCKER_HOST_IP;
+
+	// 채팅 소켓 PORT
+	const CHAT_PORT = process.env.CHAT_PORT || 3000;
+
+	// 카프카 PORT
+	const KAFKA_PORT_1 = process.env.KAFKA_PORT_1;
+	const KAFKA_PORT_2 = process.env.KAFKA_PORT_2;
+	const KAFKA_PORT_3 = process.env.KAFKA_PORT_3;
+
+	// 레디스 PORT
+	const REDIS_PORT = process.env.REDIS_PORT;
+
+	// 레디스 서버 URL
+	const REDIS_URL =
+		DOCKER_HOST_IP && REDIS_PORT
+			? `${DOCKER_HOST_IP}:${REDIS_PORT}`
+			: "localhost:6379";
+
+	// Broker URLs
+	const brokers: string[] = [
+		DOCKER_HOST_IP && KAFKA_PORT_1
+			? `${DOCKER_HOST_IP}:${KAFKA_PORT_1}`
+			: "localhost:9092",
+		DOCKER_HOST_IP && KAFKA_PORT_2
+			? `${DOCKER_HOST_IP}:${KAFKA_PORT_2}`
+			: "localhost:9093",
+		DOCKER_HOST_IP && KAFKA_PORT_3
+			? `${DOCKER_HOST_IP}:${KAFKA_PORT_3}`
+			: "localhost:9094",
+	];
+
+	try {
+		// Redis 연결
+		await connectRedis();
+		console.log("Redis 연결 성공");
+
+		// Kafka API
+		initKafkaAPI("chat-group1-consumer1", brokers);
+		const kafka = getKafkaAPI();
+
+		// Kafka Producer
+		initProducer(kafka);
+		const producer = getProducer();
+
+		// Kafka Producer 연결
+		await producer.connect();
+		console.log("Kafka Producer 연결 성공");
+
+		// TEST: 추후 지울 것! (Kafka로 message 보내기)
+		const testMessage: IMessage = {
+			roomId: "1",
+			nickname: "test",
+			message: "test입니다.",
+			createdAt: new Date(),
+			isMine: false,
+			isSystem: true,
+		};
+		console.log(
+			`producer message:\nroomId: ${testMessage.roomId}\nmessage: ${testMessage.message}\ncreatedAt: ${testMessage.createdAt}`
+		);
+		sendMessage(testMessage);
+		// TEST END
+
+		// 채팅 서버 실행
+		httpServer.listen(CHAT_PORT, () => {
+			console.log(`채팅 서버 ${CHAT_PORT}에서 실행 중`);
+		});
+	} catch (error) {
+		console.error("서버 시작 중 오류 발생:", error);
+	}
+}
+
+// 서버 실행
+startServer();

--- a/chat_server/package.json
+++ b/chat_server/package.json
@@ -2,7 +2,7 @@
 	"scripts": {
 		"start": "node dist/app.js",
 		"build": "tsc -p .",
-		"dev": "nodemon --watch \"*.ts\" --exec \"ts-node\" --files ./app.ts"
+		"dev": "nodemon --watch \"*.ts\" --exec \"ts-node\" --files ./index.ts"
 	},
 	"dependencies": {
 		"@socket.io/admin-ui": "^0.5.1",

--- a/chat_server/services/kafka_service.ts
+++ b/chat_server/services/kafka_service.ts
@@ -1,4 +1,4 @@
-import { IMessage } from "shared";
+import { IKafkaMessageDTO } from "shared";
 import { Kafka, Producer } from "kafkajs";
 
 /**
@@ -30,9 +30,8 @@ const getProducer = (): Producer => {
  */
 
 // Kafka로 message 송신
-const sendMessage = async (messageDTO: IMessage, id: string | null = null) => {
-	const { roomId, message, createdAt, isSystem } = messageDTO;
-	const userId = isSystem ? 0 : id;
+const sendMessage = async (messageDTO: IKafkaMessageDTO) => {
+	const { roomId, userId, message, createdAt, isSystem } = messageDTO;
 
 	if (producer === null) {
 		throw new Error("Kafka Producer is null");
@@ -42,9 +41,9 @@ const sendMessage = async (messageDTO: IMessage, id: string | null = null) => {
 		topic: "chat", // 토픽 이름
 		messages: [
 			{
-				key: roomId, // message key
-				value: JSON.stringify({ userId, message }), // message value (Buffer | string | null)
-				timestamp: createdAt.getTime().toString(), // ISO 형식의 시간 데이터
+				key: JSON.stringify({ roomId, userId }), // message key
+				value: JSON.stringify({ message, isSystem }), // message value (Buffer | string | null)
+				timestamp: createdAt.getTime().toString(), // string 형식의 시간 데이터
 			},
 		],
 		acks: -1, // 리더와 모든 팔로워 파티션이 메시지를 기록했을 때 성공

--- a/chat_server/services/kafka_service.ts
+++ b/chat_server/services/kafka_service.ts
@@ -1,31 +1,50 @@
-import kafka from "../config/kafka_config";
-import { ISendMessageRequest } from "../types/message";
+import { IMessage } from "shared";
+import { Kafka, Producer } from "kafkajs";
 
 /**
  * Kafka Producer 객체
  */
-const producer = kafka.producer();
+let producer: Producer | null = null;
+
+/**
+ * init Kafka Producer
+ */
+const initProducer = (kafka: Kafka) => {
+	// TODO: 최적화 필요
+	producer = kafka.producer();
+};
+
+/**
+ * get Kafka Producer
+ */
+const getProducer = (): Producer => {
+	if (producer === null) {
+		throw new Error("Kafka Producer is null");
+	}
+
+	return producer;
+};
 
 /**
  * Kafka 송신 메서드
  */
 
-// Kafka Producer 연결
-const connectProducer = async () => {
-	await producer.connect();
-};
-
 // Kafka로 message 송신
-const sendMessage = async (params: ISendMessageRequest) => {
-	const { roomId, nickname, message, created_at } = params;
+const sendMessage = async (messageDTO: IMessage, id: string | null = null) => {
+	const { roomId, message, createdAt, isSystem } = messageDTO;
+	const userId = isSystem ? 0 : id;
+
+	if (producer === null) {
+		throw new Error("Kafka Producer is null");
+	}
 
 	await producer.send({
 		topic: "chat", // 토픽 이름
 		messages: [
 			{
 				key: roomId, // message key
-				value: JSON.stringify({ nickname, message }), // message value (Buffer | string | null)
-				timestamp: created_at.getTime().toString(), // ISO 형식의 시간 데이터
+				value: JSON.stringify({ userId, message }), // message value (Buffer | string | null)
+				timestamp: createdAt.getTime().toString(), // ISO 형식의 시간 데이터
 			},
 		],
 		acks: -1, // 리더와 모든 팔로워 파티션이 메시지를 기록했을 때 성공
@@ -33,4 +52,4 @@ const sendMessage = async (params: ISendMessageRequest) => {
 	});
 };
 
-export { connectProducer, sendMessage };
+export { initProducer, getProducer, sendMessage };

--- a/consumer-server/src/config/dbConfig.ts
+++ b/consumer-server/src/config/dbConfig.ts
@@ -1,20 +1,35 @@
 import dotenv from "dotenv";
-import mariaDB, { PoolOptions } from "mysql2/promise";
+import mariaDB, { Pool, PoolOptions } from "mysql2/promise";
 
 dotenv.config();
 
-const isDev = !process.env.DOCKER_HOST_IP;
+/**
+ * DB Pool 객체
+ */
+let pool: Pool | null = null;
 
-const port = process.env.DB_PORT | 3306;
-const config: PoolOptions = {
-	connectionLimit: 1000,
-	host: process.env.DB_HOST,
-	user: process.env.DB_USER,
-	database: process.env.DB_NAME,
-	password: process.env.DB_PSWORD,
-	port: port,
-	multipleStatements: true,
+/**
+ * init DB Pool
+ */
+const initDBPool = (config: PoolOptions): void => {
+	if (pool === null) {
+		pool = mariaDB.createPool({
+			...config,
+			connectionLimit: 1000,
+			multipleStatements: true,
+		});
+		console.log("DB Pool 생성");
+	}
 };
-const pool = mariaDB.createPool(config);
 
-export default pool;
+/**
+ * get DB Pool
+ */
+const getDBPool = () => {
+	if (!pool) {
+		throw new Error("DB Pool is null");
+	}
+	return pool;
+};
+
+export { getDBPool, initDBPool };

--- a/consumer-server/src/config/dbConfig.ts
+++ b/consumer-server/src/config/dbConfig.ts
@@ -1,1 +1,20 @@
-// TODO: db config
+import dotenv from "dotenv";
+import mariaDB, { PoolOptions } from "mysql2/promise";
+
+dotenv.config();
+
+const isDev = !process.env.DOCKER_HOST_IP;
+
+const port = process.env.DB_PORT | 3306;
+const config: PoolOptions = {
+	connectionLimit: 1000,
+	host: process.env.DB_HOST,
+	user: process.env.DB_USER,
+	database: process.env.DB_NAME,
+	password: process.env.DB_PSWORD,
+	port: port,
+	multipleStatements: true,
+};
+const pool = mariaDB.createPool(config);
+
+export default pool;

--- a/consumer-server/src/config/kafkaConfig.ts
+++ b/consumer-server/src/config/kafkaConfig.ts
@@ -1,31 +1,37 @@
-import dotenv from "dotenv";
 import { Kafka, logLevel } from "kafkajs";
 
-dotenv.config();
+/**
+ * kafka API 객체
+ */
+let kafka: Kafka | null = null;
 
-const isDev = !process.env.DOCKER_HOST_IP;
+/**
+ * init Kafka API
+ */
+const initKafkaAPI = (clientId: string, brokers: string[]): void => {
+	kafka = new Kafka({
+		clientId,
+		brokers,
+		logLevel: logLevel.NOTHING, // Console의 log 수준 (현재 값: NOTHING)
+		retry: {
+			maxRetryTime: 10000, // 최대 재시도 시간
+			initialRetryTime: 300, // 처음 재시도까지 대기 시간 (ms)
+			retries: 5, // 최대 재시도 횟수
+			factor: 1.5, // 재시도 대기시간에 대한 배수, 다음 재시도는 이전 재시도 대기 시간의 factor를 곱한 시간
+			multiplier: 1, // factor에 대한 배수
+		},
+	});
+};
 
-const kafka = new Kafka({
-	clientId: "chat-consumer-1",
-	brokers: [
-		isDev
-			? "localhost:9092"
-			: `${process.env.DOCKER_HOST_IP}:${process.env.KAFKA_1_PORT}`,
-		isDev
-			? "localhost:9092"
-			: `${process.env.DOCKER_HOST_IP}:${process.env.KAFKA_2_PORT}`,
-		isDev
-			? "localhost:9092"
-			: `${process.env.DOCKER_HOST_IP}:${process.env.KAFKA_3_PORT}`,
-	],
-	logLevel: logLevel.WARN,
-	retry: {
-		maxRetryTime: 10000,
-		initialRetryTime: 300,
-		retries: 5,
-		factor: 1.5,
-		multiplier: 1,
-	},
-});
+/**
+ * get Kafka API
+ */
+const getKafkaAPI = (): Kafka => {
+	if (kafka === null) {
+		throw new Error("Kafka API is null");
+	}
 
-export default kafka;
+	return kafka;
+};
+
+export { initKafkaAPI, getKafkaAPI };

--- a/consumer-server/src/index.ts
+++ b/consumer-server/src/index.ts
@@ -1,20 +1,57 @@
+import dotenv from "dotenv";
+
+import { getKafkaAPI, initKafkaAPI } from "./config/kafkaConfig";
 import {
-	connectConsumer,
-	subscribeConsumer,
+	getConsumer,
+	initConsumer,
 	processMessage,
 } from "./services/kafkaService";
 
+dotenv.config();
+
 const startServer = async () => {
+	// 도커 호스트 IP
+	const DOCKER_HOST_IP = process.env.DOCKER_HOST_IP;
+
+	// 카프카 PORT
+	const KAFKA_PORT_1 = process.env.KAFKA_PORT_1;
+	const KAFKA_PORT_2 = process.env.KAFKA_PORT_2;
+	const KAFKA_PORT_3 = process.env.KAFKA_PORT_3;
+
+	// Broker URLs
+	const brokers: string[] = [
+		DOCKER_HOST_IP && KAFKA_PORT_1
+			? `${DOCKER_HOST_IP}:${KAFKA_PORT_1}`
+			: "localhost:9092",
+		DOCKER_HOST_IP && KAFKA_PORT_2
+			? `${DOCKER_HOST_IP}:${KAFKA_PORT_2}`
+			: "localhost:9093",
+		DOCKER_HOST_IP && KAFKA_PORT_3
+			? `${DOCKER_HOST_IP}:${KAFKA_PORT_3}`
+			: "localhost:9094",
+	];
+
 	try {
+		// Kafka API
+		initKafkaAPI("chat-group1-consumer1", brokers);
+		const kafka = getKafkaAPI();
+
+		// Kafka Consumer
+		initConsumer(kafka, "chat-group1");
+		const consumer = getConsumer();
+
 		// Kafka Consumer 연결
-		await connectConsumer();
+		await consumer.connect();
 		console.log("Kafka Consumer 연결 성공");
 
-		// chat 구독
-		await subscribeConsumer("chat");
+		// Kafka Consumer chat 구독
+		await consumer.subscribe({ topic: "chat", fromBeginning: false });
 		console.log("Kafka Chat 구독 성공");
 
-		await processMessage();
+		// Kafka Consumer Message 수신 처리
+		await consumer.run({
+			eachMessage: processMessage,
+		});
 		console.log("Kafka Consumer 메시지 수신 중");
 	} catch (error) {
 		console.error("Error starting the Kafka Consumer", error);

--- a/consumer-server/src/index.ts
+++ b/consumer-server/src/index.ts
@@ -1,5 +1,6 @@
 import dotenv from "dotenv";
 
+import { getDBPool, initDBPool } from "./config/dbConfig";
 import { getKafkaAPI, initKafkaAPI } from "./config/kafkaConfig";
 import {
 	getConsumer,
@@ -10,35 +11,52 @@ import {
 dotenv.config();
 
 const startServer = async () => {
-	// 도커 호스트 IP
-	const DOCKER_HOST_IP = process.env.DOCKER_HOST_IP;
+	// 호스트 IP
+	const HOST_IP = process.env.DOCKER_HOST_IP || "localhost";
+
+	// DB PORT
+	const DB_PORT = parseInt(process.env.DB_PORT || "3306");
+
+	// DB config
+	const DB_USER = process.env.DB_USER || "root";
+	const DB_PSWORD = process.env.DB_PSWORD || "root";
+	const DB_NAME = process.env.DB_USER || "community_board";
 
 	// 카프카 PORT
-	const KAFKA_PORT_1 = process.env.KAFKA_PORT_1;
-	const KAFKA_PORT_2 = process.env.KAFKA_PORT_2;
-	const KAFKA_PORT_3 = process.env.KAFKA_PORT_3;
+	const KAFKA_PORT_1 = process.env.KAFKA_PORT_1 || "9092";
+	const KAFKA_PORT_2 = process.env.KAFKA_PORT_2 || "9093";
+	const KAFKA_PORT_3 = process.env.KAFKA_PORT_3 || "9094";
 
 	// Broker URLs
 	const brokers: string[] = [
-		DOCKER_HOST_IP && KAFKA_PORT_1
-			? `${DOCKER_HOST_IP}:${KAFKA_PORT_1}`
-			: "localhost:9092",
-		DOCKER_HOST_IP && KAFKA_PORT_2
-			? `${DOCKER_HOST_IP}:${KAFKA_PORT_2}`
-			: "localhost:9093",
-		DOCKER_HOST_IP && KAFKA_PORT_3
-			? `${DOCKER_HOST_IP}:${KAFKA_PORT_3}`
-			: "localhost:9094",
+		`${HOST_IP}:${KAFKA_PORT_1}`,
+		`${HOST_IP}:${KAFKA_PORT_2}`,
+		`${HOST_IP}:${KAFKA_PORT_3}`,
 	];
 
 	try {
-		// Kafka API
+		// Kafka API 초기화
 		initKafkaAPI("chat-group1-consumer1", brokers);
 		const kafka = getKafkaAPI();
 
-		// Kafka Consumer
+		// Kafka Consumer 초기화
 		initConsumer(kafka, "chat-group1");
 		const consumer = getConsumer();
+
+		// DB Pool 생성
+		initDBPool({
+			host: HOST_IP,
+			port: DB_PORT,
+			user: DB_USER,
+			database: DB_NAME,
+			password: DB_PSWORD,
+		});
+
+		// DB 연결 테스트
+		const pool = getDBPool();
+		const conn = await pool.getConnection();
+		console.log("DB 연결 성공");
+		conn.release();
 
 		// Kafka Consumer 연결
 		await consumer.connect();
@@ -48,11 +66,11 @@ const startServer = async () => {
 		await consumer.subscribe({ topic: "chat", fromBeginning: false });
 		console.log("Kafka Chat 구독 성공");
 
-		// Kafka Consumer Message 수신 처리
+		// Kafka Consumer Message 수신 연결
 		await consumer.run({
 			eachMessage: processMessage,
 		});
-		console.log("Kafka Consumer 메시지 수신 중");
+		console.log("Kafka Consumer 메시지 수신 중...");
 	} catch (error) {
 		console.error("Error starting the Kafka Consumer", error);
 	}

--- a/consumer-server/src/models/chatMessageModel.ts
+++ b/consumer-server/src/models/chatMessageModel.ts
@@ -1,1 +1,0 @@
-// TODO: DB Access Layer

--- a/consumer-server/src/services/kafkaService.ts
+++ b/consumer-server/src/services/kafkaService.ts
@@ -1,52 +1,58 @@
-import kafka from "../config/kafkaConfig";
+import { Consumer, EachMessagePayload, Kafka } from "kafkajs";
 
 /**
  * Kafka Consumer 객체
- * TODO: 최적화 필요
  */
-const consumer = kafka.consumer({
-	groupId: "chat-db-group", // 컨슈머 그룹 식별자 ID, 동일한 그룹은 같은 파티션 공유 및 메시지 병렬 처리
-	sessionTimeout: 30000, // 30초, 컨슈머 그룹이 해당 클라이언트가 연결을 끊었다고 간주하 전 대기 시간
-	heartbeatInterval: 3000, // 3초, 브로커와의 연결을 확인하는 대기 시간
-	retry: {
-		maxRetryTime: 10000, // 최대 재시도 시간
-		initialRetryTime: 100, // 처음 재시도까지 대기 시간 (ms)
-		retries: 5, // 최대 재시도 횟수
-		factor: 1.5, // 재시도 대기시간에 대한 배수, 다음 재시도는 이전 재시도 대기 시간의 factor를 곱한 시간
-		multiplier: 1.2, // factor에 대한 배수
-	},
-	maxInFlightRequests: 1, // 컨슈머 최대 처리 요청 수
-});
+let consumer: Consumer | null = null;
+
+/**
+ * init Kafka Consumer
+ */
+const initConsumer = (kafka: Kafka, groupId: string) => {
+	if (consumer === null) {
+		// TODO: 최적화 필요
+		consumer = kafka.consumer({
+			groupId, // 컨슈머 그룹 식별자 ID, 동일한 그룹은 같은 파티션 공유 및 메시지 병렬 처리
+			sessionTimeout: 30000, // 30초, 컨슈머 그룹이 해당 클라이언트가 연결을 끊었다고 간주하 전 대기 시간
+			heartbeatInterval: 3000, // 3초, 브로커와의 연결을 확인하는 대기 시간
+			retry: {
+				maxRetryTime: 10000, // 최대 재시도 시간
+				initialRetryTime: 100, // 처음 재시도까지 대기 시간 (ms)
+				retries: 5, // 최대 재시도 횟수
+				factor: 1.5, // 재시도 대기시간에 대한 배수, 다음 재시도는 이전 재시도 대기 시간의 factor를 곱한 시간
+				multiplier: 1.2, // factor에 대한 배수
+			},
+			maxInFlightRequests: 1, // 컨슈머 최대 처리 요청 수
+		});
+	}
+};
+
+/**
+ * get Kafka Consumer
+ */
+const getConsumer = (): Consumer => {
+	if (consumer === null) {
+		throw new Error("Kafka Consumer is null");
+	}
+
+	return consumer;
+};
 
 /**
  * Kafka 수신 메서드
  */
+const processMessage = async ({
+	message: { key, value, timestamp, offset },
+}: EachMessagePayload) => {
+	const roomId = key;
+	const { message, userId } = JSON.parse(value!.toString());
 
-// Kafka Consumer 연결
-const connectConsumer = async () => {
-	await consumer.connect();
+	// TEST: 추후에 삭제할 것
+	console.log(
+		`consume message:\nroomId: ${roomId}\nuserId: ${userId}\nmessage: ${message}\ntimestamp: ${timestamp}`
+	);
+
+	// TODO: DB Access Layer
 };
 
-// Kafka topic 구독
-const subscribeConsumer = async (topic: string) => {
-	await consumer.subscribe({ topic, fromBeginning: false });
-};
-
-// Kafka message 수신 처리
-const processMessage = async () => {
-	await consumer.run({
-		eachMessage: async ({ message: { key, value, timestamp, offset } }) => {
-			const roomId = key;
-			const { nickname, message } = JSON.parse(value!.toString());
-
-			// TEST: 추후에 삭제할 것
-			console.log(
-				`consume message: roomId: ${roomId}, nickname: ${nickname},message: ${message}, timestamp: ${timestamp}`
-			);
-
-			// TODO: DB Access Layer
-		},
-	});
-};
-
-export { connectConsumer, subscribeConsumer, processMessage };
+export { initConsumer, getConsumer, processMessage };

--- a/consumer-server/src/services/messageService.ts
+++ b/consumer-server/src/services/messageService.ts
@@ -1,0 +1,46 @@
+import { FieldPacket, PoolConnection, ResultSetHeader } from "mysql2/promise";
+import { IKafkaMessageDTO } from "shared";
+
+import { getDBPool } from "../config/dbConfig";
+
+// insert message
+const insertMessage = async (messageDTO: IKafkaMessageDTO): Promise<number> => {
+	let conn: PoolConnection | null = null;
+
+	const {
+		roomId,
+		userId,
+		message: content,
+		createdAt,
+		isSystem,
+	} = messageDTO;
+	const values = [userId, roomId, content, createdAt, isSystem];
+
+	const query = `
+    INSERT INTO messages (user_id, room_id, content, created_at, is_system)
+    VALUES (?, ?, ?, ?, ?)
+    `;
+
+	try {
+		const pool = getDBPool();
+
+		conn = await pool.getConnection();
+
+		const [result]: [ResultSetHeader, FieldPacket[]] = await conn.query(
+			query,
+			values
+		);
+
+		if (result.affectedRows === 0) {
+			throw new Error("메시지가 저장되지 않았습니다.");
+		}
+
+		return result.insertId;
+	} catch (error) {
+		throw error;
+	} finally {
+		if (conn !== null) conn.release();
+	}
+};
+
+export { insertMessage };

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,21 +4,21 @@ services:
         container_name: kafka-kraft-1
         hostname: kafka-kraft-1
         ports:
-            - ${KAFKA_1_PORT:-9092}:9092
+            - ${KAFKA_PORT_1:-9092}:9092
         restart: unless-stopped
         volumes:
-            - ${LOGS_PATH:-.}/logs/kafka/kafka-kraft-1:/var/lib/kafka/data
+            - ${KAFKA_DATA_PATH:-./datas}/kafka/kafka-kraft-1:/var/lib/kafka/data
         environment:
             KAFKA_NODE_ID: 1
             KAFKA_PROCESS_ROLES: broker,controller
             KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-            KAFKA_LISTENERS: INTERNAL://kafka-kraft-1:29092,CONTROLLER://kafka-kraft-1:29093,EXTERNAL://0.0.0.0:${KAFKA_1_PORT:-9092}
-            KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-kraft-1:29092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:${KAFKA_1_PORT:-9092}
+            KAFKA_LISTENERS: INTERNAL://kafka-kraft-1:29092,CONTROLLER://kafka-kraft-1:29093,EXTERNAL://0.0.0.0:${KAFKA_PORT_1:-9092}
+            KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-kraft-1:29092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:${KAFKA_PORT_1:-9092}
             KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-kraft-1:29093,2@kafka-kraft-2:29093,3@kafka-kraft-3:29093
             KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
             KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
             KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-            KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
+            KAFKA_AUTO_CREATE_TOPICS_ENABLE: false
             CLUSTER_ID: ${KAFKA_CLUSTER_ID:-q1Sh-9_ISia_zwGINzRvyQ}
 
     kafka-kraft-2:
@@ -26,21 +26,21 @@ services:
         container_name: kafka-kraft-2
         hostname: kafka-kraft-2
         ports:
-            - ${KAFKA_2_PORT:-9093}:9093
+            - ${KAFKA_PORT_2:-9093}:9093
         restart: unless-stopped
         volumes:
-            - ${LOGS_PATH:-.}/logs/kafka/kafka-kraft-2:/var/lib/kafka/data
+            - ${KAFKA_DATA_PATH:-./datas}/kafka/kafka-kraft-2:/var/lib/kafka/data
         environment:
             KAFKA_NODE_ID: 2
             KAFKA_PROCESS_ROLES: broker,controller
             KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-            KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-kraft-2:29092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:${KAFKA_2_PORT:-9093}
-            KAFKA_LISTENERS: INTERNAL://kafka-kraft-2:29092,CONTROLLER://kafka-kraft-2:29093,EXTERNAL://0.0.0.0:${KAFKA_2_PORT:-9093}
+            KAFKA_LISTENERS: INTERNAL://kafka-kraft-2:29092,CONTROLLER://kafka-kraft-2:29093,EXTERNAL://0.0.0.0:${KAFKA_PORT_2:-9093}
+            KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-kraft-2:29092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:${KAFKA_PORT_2:-9093}
             KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-kraft-1:29093,2@kafka-kraft-2:29093,3@kafka-kraft-3:29093
             KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
             KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
             KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-            KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
+            KAFKA_AUTO_CREATE_TOPICS_ENABLE: false
             CLUSTER_ID: ${KAFKA_CLUSTER_ID:-q1Sh-9_ISia_zwGINzRvyQ}
 
     kafka-kraft-3:
@@ -48,21 +48,21 @@ services:
         container_name: kafka-kraft-3
         hostname: kafka-kraft-3
         ports:
-            - ${KAFKA_3_PORT:-9094}:9094
+            - ${KAFKA_PORT_3:-9094}:9094
         restart: unless-stopped
         volumes:
-            - ${LOGS_PATH:-.}/logs/kafka/kafka-kraft-3:/var/lib/kafka/data
+            - ${KAFKA_DATA_PATH:-./datas}/kafka/kafka-kraft-3:/var/lib/kafka/data
         environment:
             KAFKA_NODE_ID: 3
             KAFKA_PROCESS_ROLES: broker,controller
             KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-            KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-kraft-3:29092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:${KAFKA_3_PORT:-9094}
-            KAFKA_LISTENERS: INTERNAL://kafka-kraft-3:29092,CONTROLLER://kafka-kraft-3:29093,EXTERNAL://0.0.0.0:${KAFKA_3_PORT:-9094}
+            KAFKA_LISTENERS: INTERNAL://kafka-kraft-3:29092,CONTROLLER://kafka-kraft-3:29093,EXTERNAL://0.0.0.0:${KAFKA_PORT_3:-9094}
+            KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-kraft-3:29092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:${KAFKA_PORT_3:-9094}
             KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-kraft-1:29093,2@kafka-kraft-2:29093,3@kafka-kraft-3:29093
             KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
             KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
             KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-            KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
+            KAFKA_AUTO_CREATE_TOPICS_ENABLE: false
             CLUSTER_ID: ${KAFKA_CLUSTER_ID:-q1Sh-9_ISia_zwGINzRvyQ}
 
     kafka-ui:

--- a/server/db/sql/chats.sql
+++ b/server/db/sql/chats.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS messages (
     room_id INT NOT NULL,
     content TEXT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    is_system BOOLEAN NOT NULL,
     FOREIGN KEY (room_id) REFERENCES rooms(id),
     FOREIGN KEY (user_id) REFERENCES users(id)
 );

--- a/shared/chats/dto.ts
+++ b/shared/chats/dto.ts
@@ -20,3 +20,11 @@ export interface ILiveRoomInfo {
 	curNum: number; // 현재 접속한 사용자 수
 	newMessages: number; // 새로운 채팅 수
 }
+
+export interface IKafkaMessageDTO {
+	roomId: number; // 방 번호
+	userId: number; // 사용자 아이디(system: 0)
+	message: string; // 채팅 내용
+	createdAt: Date; // 생성 시간
+	isSystem: boolean; // 시스템 메시지 유무
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #132 

resolved #132 

## 📝 작업 내용

- [x] 메시지 송수신 시 Kafka로 처리
- [x] 메시지 큐에서 메시지 처리 ( DB에 메시지 저장)

### 카프카로 송신된 데이터 DB에 저장
![메시지 큐 실습](https://github.com/user-attachments/assets/62ba1c39-84d2-4cf4-944b-bcee9d59b281)

## 💬 리뷰 요구사항

1. 메시지 수신 시 Kafka로 송신은 추후 소켓 구현 이후 구현 예정입니다. ( 메시지 송신 부분은 구현 완료 )
2. 서버 장애시 처리는 MVP 구현 이후 구현 예정입니다.
3. chat_server에 test 부분 지우시거나 주석처리하시고 작업 바랍니다.
4. erd 수정되었습니다. `server/db/sql/chats.sql` 확인하시고 적용해주세요.
5. 카프카 설정 변경이 있어습니다. 다시 설정해주세요.
   1. 프로젝트 루트로 이동
   2. 컨테이너 중지 : `docker stop kafka-kraft-1 kafka-kraft-2 kafka-kraft-3 redis kafka-ui`
   3. 컨테이너 삭제 : `docker rm -v kafka-kraft-1 kafka-kraft-2 kafka-kraft-3 redis kafka-ui`
   4. 프로젝트에서 디렉토리 삭제 ( logs )
   ![삭제 디렉토리](https://github.com/user-attachments/assets/f9ebd193-49a5-4e5d-9f28-4ed0010f6541)
   6. 컴포즈 올리기 : `docker-compose -f docker-compose.yaml up -d`
   7. 토픽 생성 (바로 실행하면 오류 있습니다. 올라간 컨테이너 실행 중인지 확인하고 진행해주세요.)
```powershell
# 윈도우 powershell
docker-compose exec kafka-kraft-1 `
	kafka-topics --create `
		--topic chat `
		--partitions 1 `
		--replication-factor 2 `
		--if-not-exists `
		--bootstrap-server kafka-kraft-1:9092
```
```bash
# 리눅스 및 맥
docker-compose exec kafka-kraft-1 \
	kafka-topics --create \
		--topic chat \
		--partitions 1 \
		--replication-factor 2 \
		--if-not-exists \
		--bootstrap-server kafka-kraft-1:9092
```