### PR TITLE
[채팅] 메세지 기록 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 test_case
 
 datas
+logs

--- a/client/src/component/Chats/ChatRooms/SearchedChatRooms.tsx
+++ b/client/src/component/Chats/ChatRooms/SearchedChatRooms.tsx
@@ -184,7 +184,7 @@ const SearchedChatRooms: React.FC<Props> = ({ open }) => {
 							"검색된 채팅방 없음"
 						) : (
 							<Rooms
-								isMine={true}
+								isMine={false}
 								rooms={searchedRooms.rooms[currentPage]}
 							/>
 						)}

--- a/server/controller/chats_controller.ts
+++ b/server/controller/chats_controller.ts
@@ -2,11 +2,14 @@ import { Request, Response, NextFunction } from "express";
 import {
 	ICreateRoomRequest,
 	ICreateRoomResponse,
+	IGetRoomMessageLogsRequest,
+	IGetRoomMessageLogsResponse,
 	IReadRoomRequest,
 	IReadRoomResponse,
 } from "shared";
 import {
 	addRoom,
+	getMessageLogs,
 	getRoomsByKeyword,
 	getRoomsByUserId,
 } from "../db/context/chats_context";
@@ -41,8 +44,6 @@ export const handleRoomsRead = async (
 			keyword: decodeURIComponent(req.query.keyword as string) || "",
 		};
 
-		console.log(body);
-
 		let response: IReadRoomResponse = {
 			totalRoomCount: 0,
 			roomHeaders: [],
@@ -64,6 +65,28 @@ export const handleRoomsRead = async (
 			response.totalRoomCount = result.totalRoomCount;
 			response.roomHeaders = result.roomHeaders;
 		}
+
+		res.status(200).json(response);
+	} catch (err) {
+		next(err);
+	}
+};
+
+export const handleMessageLogsRead = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const body: IGetRoomMessageLogsRequest = {
+			roomId: parseInt(req.params.room_id),
+		};
+		const userId = req.userId;
+
+		const result = await getMessageLogs(userId, body.roomId);
+		const response: IGetRoomMessageLogsResponse = {
+			messageLogs: result,
+		};
 
 		res.status(200).json(response);
 	} catch (err) {

--- a/server/db/sql/chats.sql
+++ b/server/db/sql/chats.sql
@@ -7,6 +7,18 @@ CREATE TABLE IF NOT EXISTS rooms (
     updated_at TIMESTAMP ON UPDATE NOW()
 );
 
+/* user_id, room_id에 대한 index 고려하기 */
+CREATE TABLE IF NOT EXISTS messages (
+    id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    room_id INT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    is_system BOOLEAN NOT NULL,
+    FOREIGN KEY (room_id) REFERENCES rooms(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
 CREATE TABLE IF NOT EXISTS members (
     id INT NOT NULL,
     room_id INT NOT NULL,
@@ -18,16 +30,4 @@ CREATE TABLE IF NOT EXISTS members (
     FOREIGN KEY (room_id) REFERENCES rooms(id),
     FOREIGN KEY (id) REFERENCES users(id),
     FOREIGN KEY (last_message_id) REFERENCES messages(id)
-);
-
-/* user_id, room_id에 대한 index 고려하기 */
-CREATE TABLE IF NOT EXISTS messages (
-    id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    user_id INT NOT NULL,
-    room_id INT NOT NULL,
-    content TEXT NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-    is_system BOOLEAN NOT NULL,
-    FOREIGN KEY (room_id) REFERENCES rooms(id),
-    FOREIGN KEY (user_id) REFERENCES users(id)
 );

--- a/server/route/chats_router.ts
+++ b/server/route/chats_router.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import {
+	handleMessageLogsRead,
 	handleRoomCreate,
 	handleRoomsRead,
 } from "../controller/chats_controller";
@@ -7,6 +8,7 @@ import {
 const router = express.Router();
 router.use(express.json());
 
+router.get("/room/:room_id", handleMessageLogsRead);
 router.get("/rooms", handleRoomsRead);
 router.post("/room", handleRoomCreate);
 

--- a/shared/chats/dto.ts
+++ b/shared/chats/dto.ts
@@ -1,5 +1,5 @@
 export interface IMessage {
-	roomId: string; // 방 번호
+	roomId: number; // 방 번호
 	nickname: string; // 보낸 사람 이름
 	message: string; // 채팅 내용
 	createdAt: Date; // 생성 시간
@@ -8,7 +8,7 @@ export interface IMessage {
 }
 
 export interface IRoomHeader {
-	roomId: string; // 방 번호
+	roomId: number; // 방 번호
 	title: string; // 채팅방 이름
 	totalMembersCount: number; // 채팅방 멤버 수
 	isPrivate: boolean; // true : 비밀방

--- a/shared/chats/mappers.ts
+++ b/shared/chats/mappers.ts
@@ -2,13 +2,22 @@ import { ILiveRoomInfo, IMessage, IRoomHeader } from "./dto";
 
 export const mapDBToIMessage = (userId: number, dbData: any): IMessage => {
 	return {
-		roomId: dbData.roomId,
+		roomId: dbData.room_id,
 		nickname: dbData.nickname,
 		message: dbData.message,
-		createdAt: dbData.createdAt,
-		isMine: dbData.senderId === userId,
-		isSystem: dbData.senderId === 0,
+		createdAt: dbData.created_at,
+		isMine: dbData.user_id === userId,
+		isSystem: dbData.is_system,
 	};
+};
+
+export const mapDBToIMessages = (
+	userId: number,
+	dbDatas: any[]
+): IMessage[] => {
+	return dbDatas.map(dbData => {
+		return mapDBToIMessage(userId, dbData);
+	});
 };
 
 export const mapDBToIRoomHeader = (
@@ -27,7 +36,7 @@ export const mapDBToIRoomHeader = (
 export const mapDBToIRoomHeaders = (dbDatas: any[]): IRoomHeader[] => {
 	const liveRoomInfo = {
 		lastMessage: {
-			roomId: "",
+			roomId: 0,
 			nickname: "",
 			message: "",
 			createdAt: new Date(),

--- a/shared/chats/message.ts
+++ b/shared/chats/message.ts
@@ -3,7 +3,7 @@ import { IMessage } from "./dto";
 // 채팅방의 이전 메세지 기록 조회 ------------------------------------
 
 export interface IGetRoomMessageLogsRequest {
-	roomId: string; // 해당 방 번호
+	roomId: number; // 해당 방 번호
 }
 
 export interface IGetRoomMessageLogsResponse {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex: #이슈번호, #이슈번호

## 어떤 기능인가요?

- 채팅방에 입장했을 때, 이전 메세지 기록들을 불러오는 api입니다.

## 📝 작업 내용

### BE (rest api 서버)
- [x] roomId , userId로 message table 조회
- [x] IMessage[]로 변환하기
- [x] response로 전달 

<img width="383" alt="스크린샷 2024-08-20 오전 1 03 22" src="https://github.com/user-attachments/assets/92bc17b8-fe14-4181-9e44-116e24cf1c15">

## 💬 리뷰 요구사항(선택)

- 우선은 Postman으로 구현 확인했습니다.
- client에서는 다른 기능들 구현 한 이후에 만들겠습니다.
- 한 분이라도 보시면 머지하겠습니다.