### PR TITLE
[채팅] 채팅방 가입 기능 api

### DIFF
--- a/server/controller/chats_controller.ts
+++ b/server/controller/chats_controller.ts
@@ -4,11 +4,14 @@ import {
 	ICreateRoomResponse,
 	IGetRoomMessageLogsRequest,
 	IGetRoomMessageLogsResponse,
+	IJoinRoomRequest,
+	IJoinRoomResponse,
 	IReadRoomRequest,
 	IReadRoomResponse,
 } from "shared";
 import {
 	addRoom,
+	addUserToRoom,
 	getMessageLogs,
 	getRoomsByKeyword,
 	getRoomsByUserId,
@@ -86,6 +89,32 @@ export const handleMessageLogsRead = async (
 		const result = await getMessageLogs(userId, body.roomId);
 		const response: IGetRoomMessageLogsResponse = {
 			messageLogs: result,
+		};
+
+		res.status(200).json(response);
+	} catch (err) {
+		next(err);
+	}
+};
+
+export const handleRoomJoin = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const body: IJoinRoomRequest = {
+			roomId: parseInt(req.body.roomId),
+			content: req.body.content,
+			isPrivate: req.body.isPrivate === "true",
+			password: req.body.password || "",
+		};
+		const userId = req.userId;
+
+		const result = await addUserToRoom(userId, body.roomId, body.content);
+
+		const response: IJoinRoomResponse = {
+			roomId: result,
 		};
 
 		res.status(200).json(response);

--- a/server/db/context/chats_context.ts
+++ b/server/db/context/chats_context.ts
@@ -1,18 +1,10 @@
 import { ServerError } from "../../middleware/errors";
-import {
-	FieldPacket,
-	PoolConnection,
-	ResultSetHeader,
-	RowDataPacket,
-} from "mysql2/promise";
+import { PoolConnection } from "mysql2/promise";
 import pool from "../connect";
 import {
 	ICreateRoomRequest,
 	IReadRoomRequest,
-	IReadRoomResponse,
-	mapDBToIMessage,
 	mapDBToIMessages,
-	mapDBToIRoomHeader,
 	mapDBToIRoomHeaders,
 } from "shared";
 
@@ -197,6 +189,45 @@ export const getMessageLogs = async (userId: number, roomId: number) => {
 		const [rows]: any[] = await conn.query(sql, values);
 
 		return mapDBToIMessages(userId, rows);
+	} catch (err) {
+		throw err;
+	} finally {
+		if (conn) conn.release();
+	}
+};
+
+export const addUserToRoom = async (
+	userId: number,
+	roomId: number,
+	content: string
+) => {
+	let conn: PoolConnection | null = null;
+
+	try {
+		let sql = `INSERT INTO members (id, room_id) VALUES (?, ?)`;
+		let values: (string | number | boolean)[] = [userId, roomId];
+		conn = await pool.getConnection();
+		conn.beginTransaction();
+		const [insertMemberRows]: any[] = await conn.query(sql, values);
+
+		if (insertMemberRows.affectedRows === 0) {
+			conn.rollback();
+			throw ServerError.reference("가입 실패");
+		}
+
+		const content = (sql = `
+				INSERT INTO messages (user_id, room_id, content, is_system)
+				VALUES (?,?,?,?)`);
+		values = [userId, roomId, content, true];
+		const [insertSystemMessageRows]: any[] = await conn.query(sql, values);
+
+		if (insertSystemMessageRows.affectedRows === 0) {
+			conn.rollback();
+			throw ServerError.reference("가입 실패");
+		}
+
+		return roomId;
+		// system message 넣기
 	} catch (err) {
 		throw err;
 	} finally {

--- a/server/route/chats_router.ts
+++ b/server/route/chats_router.ts
@@ -2,6 +2,7 @@ import express from "express";
 import {
 	handleMessageLogsRead,
 	handleRoomCreate,
+	handleRoomJoin,
 	handleRoomsRead,
 } from "../controller/chats_controller";
 
@@ -11,5 +12,6 @@ router.use(express.json());
 router.get("/room/:room_id", handleMessageLogsRead);
 router.get("/rooms", handleRoomsRead);
 router.post("/room", handleRoomCreate);
+router.post("/join", handleRoomJoin);
 
 export default router;

--- a/shared/chats/chat-room.ts
+++ b/shared/chats/chat-room.ts
@@ -29,12 +29,14 @@ export interface IReadRoomResponse {
 // 채팅방 가입 --------------------------------------------------
 
 export interface IJoinRoomRequest {
-	roomId: string; // 가입 할 채팅방 번호
+	roomId: number; // 가입 할 채팅방 번호
+	content: string; // socket에서 생성한 가입 축하 인사, 이 대신 nickname 보내도 됨
+	isPrivate: boolean; // 비밀 방 여부
 	password: string; // 방 비밀번호 (null 허용)
 }
 
 export interface IJoinRoomResponse {
-	roomId: string; // 가입 된 채팅방 번호
+	roomId: number; // 가입 된 채팅방 번호
 }
 
 // 가입 성공 시, 채팅방의 사람들이 받는 socket event response


### PR DESCRIPTION
## 📝 작업 내용

- 가입에 사용하는 데이터 수정
    - 기존의 Request에 content, isPrivate를 추가함
        ```ts
        export interface IJoinRoomRequest {
	        roomId: number; // 가입 할 채팅방 번호
	        content: string; // socket에서 생성한 가입 축하 인사, 이 대신 nickname 보내도 됨
	        isPrivate: boolean; // 비밀 방 여부
	        password: string; // 방 비밀번호 (null 허용)
        }
        ```
    - 따라서 socket에서 이 api를 사용하기 위해서는 content도 보내야 함
    - content는 가입 축하 인사 : `${nickname}님이 방에 들어왔습니다.`
- [x]  IJoinRoomRequest와 userId로 memebers table에 insert
- [x]  위 과정 성공 -> system_message도 messages table에 추가 