### PR TITLE
[채팅] 채팅방 별 멤버 리스트 조회 api

### DIFF
--- a/server/controller/chats_controller.ts
+++ b/server/controller/chats_controller.ts
@@ -9,6 +9,7 @@ import {
 } from "shared";
 import {
 	addRoom,
+	getAllRoomMembers,
 	getMessageLogs,
 	getRoomsByKeyword,
 	getRoomsByUserId,
@@ -89,6 +90,19 @@ export const handleMessageLogsRead = async (
 		};
 
 		res.status(200).json(response);
+	} catch (err) {
+		next(err);
+	}
+};
+
+export const handleALLRoomMembersRead = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const result = await getAllRoomMembers();
+		res.status(200).json(result);
 	} catch (err) {
 		next(err);
 	}

--- a/server/db/context/chats_context.ts
+++ b/server/db/context/chats_context.ts
@@ -14,6 +14,7 @@ import {
 	mapDBToIMessages,
 	mapDBToIRoomHeader,
 	mapDBToIRoomHeaders,
+	mapDBToIRoomMembers,
 } from "shared";
 
 export const addRoom = async (userId: number, body: ICreateRoomRequest) => {
@@ -198,6 +199,31 @@ export const getMessageLogs = async (userId: number, roomId: number) => {
 
 		return mapDBToIMessages(userId, rows);
 	} catch (err) {
+		throw err;
+	} finally {
+		if (conn) conn.release();
+	}
+};
+
+export const getAllRoomMembers = async () => {
+	let conn: PoolConnection | null = null;
+	try {
+		conn = await pool.getConnection();
+
+		// members 모두 select
+		// 이 데이터를 room_id : user_id[] 형태로 바꿈
+		let sql = `
+			SELECT
+				id,
+				room_id
+			FROM
+				members
+		`;
+		const [rows]: any[] = await conn.query(sql);
+
+		return mapDBToIRoomMembers(rows);
+	} catch (err) {
+		console.error(err);
 		throw err;
 	} finally {
 		if (conn) conn.release();

--- a/server/route/chats_router.ts
+++ b/server/route/chats_router.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import {
+	handleALLRoomMembersRead,
 	handleMessageLogsRead,
 	handleRoomCreate,
 	handleRoomsRead,
@@ -8,6 +9,7 @@ import {
 const router = express.Router();
 router.use(express.json());
 
+router.get("/room_members", handleALLRoomMembersRead);
 router.get("/room/:room_id", handleMessageLogsRead);
 router.get("/rooms", handleRoomsRead);
 router.post("/room", handleRoomCreate);

--- a/shared/chats/dto.ts
+++ b/shared/chats/dto.ts
@@ -28,3 +28,9 @@ export interface IKafkaMessageDTO {
 	createdAt: Date; // 생성 시간
 	isSystem: boolean; // 시스템 메시지 유무
 }
+
+export interface IRoomMembers {
+	// key = roomId
+	// value = room member의 id list
+	[key: number]: number[];
+}

--- a/shared/chats/mappers.ts
+++ b/shared/chats/mappers.ts
@@ -1,4 +1,4 @@
-import { ILiveRoomInfo, IMessage, IRoomHeader } from "./dto";
+import { ILiveRoomInfo, IMessage, IRoomHeader, IRoomMembers } from "./dto";
 
 export const mapDBToIMessage = (userId: number, dbData: any): IMessage => {
 	return {
@@ -58,4 +58,18 @@ export const mapDBToLiveRoomInfo = (dbData: any): ILiveRoomInfo => {
 		curNum: dbData.curNum,
 		newMessages: dbData.newMessages,
 	};
+};
+
+export const mapDBToIRoomMembers = (dbDatas: any[]) => {
+	const roomMembers: IRoomMembers = {};
+
+	dbDatas.forEach((dbData: any) => {
+		if (roomMembers[dbData.room_id]) {
+			roomMembers[dbData.room_id].push(dbData.id);
+		} else {
+			roomMembers[dbData.room_id] = [dbData.id];
+		}
+	});
+
+	return roomMembers;
 };


### PR DESCRIPTION
## 📝 작업 내용

- 채팅방 멤버 dto, mapper함수 추가
```ts
export interface IRoomMembers {
	// key = roomId
	// value = room member의 id list
	[key: number]: number[];
}
```

- 채팅방 별 멤버 id list 반환 api
    - 사용 시기 : socket server 동작 시, 채팅방 별 멤버 id list를 받아와서 redis에 저장할 때 사용함.


## 💬 리뷰 요구사항(선택)

- 기타 의견 있으면 말씀해주세요
