### PR TITLE
[BE] 유저별 통계 데이터 API 구현

### DIFF
--- a/server/controller/admin_controller.ts
+++ b/server/controller/admin_controller.ts
@@ -15,7 +15,11 @@ import {
 import { mapAdminPostsToResponse } from "../db/mapper/posts_mapper";
 import { getLogs } from "../db/context/logs_context";
 import { mapUserLogsToResponse } from "../db/mapper/logs_mapper";
-import { getIntervalStats, getTotalStats } from "../db/context/stats_context";
+import {
+	getIntervalStats,
+	getTotalStats,
+	getUserStat,
+} from "../db/context/stats_context";
 import { TInterval } from "../db/model/stats";
 import { mapStatsToResponse } from "../db/mapper/stats_mapper";
 import { ServerError } from "../middleware/errors";
@@ -203,6 +207,22 @@ export const handleAdminGetStats = async (
 		const stats = mapStatsToResponse(totalStats, intervalStats);
 
 		res.status(200).json(stats);
+	} catch (err: any) {
+		next(err);
+	}
+};
+
+export const handleAdminGetUserStat = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const userId = parseInt(req.params.userId);
+
+		const stats = await getUserStat(userId);
+
+		res.status(200).json({ stats });
 	} catch (err: any) {
 		next(err);
 	}

--- a/server/db/context/stats_context.ts
+++ b/server/db/context/stats_context.ts
@@ -168,9 +168,10 @@ export const getUserStat = async (userId: number): Promise<IUserStat> => {
 		`;
 
 		const commentSql = `
-			SELECT COUNT(*) AS count
-			FROM comments c
-			WHERE author_id = ? AND isDelete = 0
+		SELECT COUNT(*) AS count
+		FROM comments c
+		JOIN posts p ON c.post_id = p.id
+		WHERE c.author_id = 1 AND c.isDelete = 0 AND p.isDelete = 0
 		`;
 
 		// 유효한 게시물 수와 총 조회수

--- a/server/db/context/stats_context.ts
+++ b/server/db/context/stats_context.ts
@@ -9,6 +9,7 @@ import {
 	IStats,
 	IStatsInterval,
 	IStatsIntervalInput,
+	IUserStat,
 } from "../model/stats";
 
 export const getTotalStats = async (): Promise<IStats> => {
@@ -147,6 +148,45 @@ export const getIntervalStats = async ({
 			posts: postResults,
 			comments: commentResults,
 			users: userResults,
+		};
+	} catch (err: any) {
+		throw err;
+	} finally {
+		if (conn) conn.release();
+	}
+};
+
+export const getUserStat = async (userId: number): Promise<IUserStat> => {
+	let conn: PoolConnection | null = null;
+	try {
+		conn = await pool.getConnection();
+
+		const postSql = `
+			SELECT COUNT(*) AS count, COALESCE(SUM(views), 0) AS views
+			FROM posts
+			WHERE author_id = ? AND isDelete = 0
+		`;
+
+		const commentSql = `
+			SELECT COUNT(*) AS count
+			FROM comments c
+			WHERE author_id = ? AND isDelete = 0
+		`;
+
+		// 유효한 게시물 수와 총 조회수
+		const [postResults]: [IPostResult[], FieldPacket[]] = await conn.query(
+			postSql,
+			[userId]
+		);
+
+		// 유효한 댓글 수
+		const [commentResults]: [IStatResult[], FieldPacket[]] =
+			await conn.query(commentSql, [userId]);
+
+		return {
+			posts: postResults[0].count,
+			views: postResults[0].views || 0,
+			comments: commentResults[0].count,
 		};
 	} catch (err: any) {
 		throw err;

--- a/server/db/model/stats.ts
+++ b/server/db/model/stats.ts
@@ -23,6 +23,8 @@ export interface IStats {
 	users: number;
 }
 
+export interface IUserStat extends Omit<IStats, "users"> {}
+
 export interface IStatsInterval {
 	posts: IPostResultInterval[];
 	comments: IStatResultInterval[];

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -8,6 +8,7 @@ import {
 	handleAdminPublicPost,
 	handleAdminRestorePost,
 	handleAdminGetStats,
+	handleAdminGetUserStat,
 	handleAdminRestoreUser,
 	handleGetUsers,
 } from "../controller/admin_controller";
@@ -48,4 +49,7 @@ router
 router.route("/log/:userId").get(handleAdminGetLogs);
 
 router.route("/stat").get(handleAdminGetStats);
+
+router.route("/stat/:userId").get(handleAdminGetUserStat);
+
 export default router;

--- a/server/route/admin_router.ts
+++ b/server/route/admin_router.ts
@@ -15,6 +15,8 @@ import {
 import {
 	deletePostValidation,
 	deleteUserValidation,
+	getUserLogsValidation,
+	getUserStatValidation,
 	privatePostValidation,
 	publicPostValidation,
 	restorePostValidation,
@@ -46,10 +48,12 @@ router
 	.route("/post/:postId/private")
 	.patch(privatePostValidation, handleAdminPrivatePost);
 
-router.route("/log/:userId").get(handleAdminGetLogs);
+router.route("/log/:userId").get(getUserLogsValidation, handleAdminGetLogs);
 
 router.route("/stat").get(handleAdminGetStats);
 
-router.route("/stat/:userId").get(handleAdminGetUserStat);
+router
+	.route("/stat/:userId")
+	.get(getUserStatValidation, handleAdminGetUserStat);
 
 export default router;

--- a/server/utils/validations/admin/admin.ts
+++ b/server/utils/validations/admin/admin.ts
@@ -27,3 +27,7 @@ export const deletePostValidation = [postIdValidator(), validate];
 export const restorePostValidation = [postIdValidator(), validate];
 export const publicPostValidation = [postIdValidator(), validate];
 export const privatePostValidation = [postIdValidator(), validate];
+
+export const getUserLogsValidation = [userIdValidator(), validate];
+
+export const getUserStatValidation = [userIdValidator(), validate];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #169

## 📝 작업 내용

- [x] `GET /api/admin/stat/:user_id` 엔드포인트 생성
- [x] 해당 유저가 쓴 게시물 수, 댓글수, 조회수 출력
- [x] 삭제된 데이터(게시글, 댓글)는 제외

## 💬 리뷰 요구사항

- 전체 통계 데이터 쪽에서는 게시글 삭제했을 때 게시글에 쓴 댓글도 통계에 포함되지 않게 했는데요.
  유저별 통계 에서도 포함되지 않게 할까요?

- 삭제된 데이터도 포함되게 하고 싶으시면 말씀해주세요.
 
- 잘못 구현된 부분이나 개선이 필요한 부분이 있다면 말씀해 주세요.