### PR TITLE
[BE] 소셜 로그인 재확인 관련 API 구현

### DIFF
--- a/server/controller/oauth_controller.ts
+++ b/server/controller/oauth_controller.ts
@@ -137,3 +137,18 @@ export const handleOAuthLogin = async (
 		next(err);
 	}
 };
+
+export const handleOAuthReconfirmUrlRead = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	try {
+		const provider = req.params.provider as TOAuthProvider;
+		const { reconfirmUrl } = buildLoginUrl(provider);
+
+		res.status(200).json({ url: reconfirmUrl });
+	} catch (err) {
+		next(err);
+	}
+};

--- a/server/route/oauth_router.ts
+++ b/server/route/oauth_router.ts
@@ -3,10 +3,12 @@ import {
 	handleOAuthLoginUrlRead,
 	handleOAuthLogin,
 	handleOAuthReconfirmUrlRead,
+	handleOAuthReconfirm,
 } from "../controller/oauth_controller";
+import { requireLogin } from "../middleware/auth";
 import {
 	getOAuthLoginUrlValidator,
-	postOAuthLoginValidation,
+	postOAuthLoginValidatior,
 } from "../utils/validations/oauth/oauth";
 
 const router = express.Router();
@@ -17,12 +19,18 @@ router.get(
 	getOAuthLoginUrlValidator(),
 	handleOAuthLoginUrlRead
 );
-router.post("/login", postOAuthLoginValidation, handleOAuthLogin);
+router.post("/login", postOAuthLoginValidatior(), handleOAuthLogin);
 
 router.get(
 	"/reconfirm-url/:provider",
 	getOAuthLoginUrlValidator(),
 	handleOAuthReconfirmUrlRead
+);
+router.post(
+	"/reconfirm",
+	requireLogin,
+	postOAuthLoginValidatior(),
+	handleOAuthReconfirm
 );
 
 export default router;

--- a/server/route/oauth_router.ts
+++ b/server/route/oauth_router.ts
@@ -2,9 +2,10 @@ import express from "express";
 import {
 	handleOAuthLoginUrlRead,
 	handleOAuthLogin,
+	handleOAuthReconfirmUrlRead,
 } from "../controller/oauth_controller";
 import {
-	getOAuthLoginUrlValidation,
+	getOAuthLoginUrlValidator,
 	postOAuthLoginValidation,
 } from "../utils/validations/oauth/oauth";
 
@@ -13,9 +14,15 @@ router.use(express.json());
 
 router.get(
 	"/login-url/:provider",
-	getOAuthLoginUrlValidation,
+	getOAuthLoginUrlValidator(),
 	handleOAuthLoginUrlRead
 );
 router.post("/login", postOAuthLoginValidation, handleOAuthLogin);
+
+router.get(
+	"/reconfirm-url/:provider",
+	getOAuthLoginUrlValidator(),
+	handleOAuthReconfirmUrlRead
+);
 
 export default router;

--- a/server/utils/oauth/constants.ts
+++ b/server/utils/oauth/constants.ts
@@ -18,6 +18,11 @@ type TOAuthProps = {
 		token: string;
 		user: string;
 	};
+
+	reconfirmParam: {
+		key: string;
+		value: string;
+	};
 };
 
 const getRedirectUri = (provider: TOAuthProvider) => {
@@ -37,6 +42,11 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			token: "https://oauth2.googleapis.com/token",
 			user: "https://www.googleapis.com/oauth2/v2/userinfo",
 		},
+
+		reconfirmParam: {
+			key: "prompt",
+			value: "consent",
+		},
 	},
 
 	kakao: {
@@ -50,6 +60,11 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			token: "https://kauth.kakao.com/oauth/token",
 			user: "https://kapi.kakao.com/v2/user/me",
 		},
+
+		reconfirmParam: {
+			key: "prompt",
+			value: "login",
+		},
 	},
 
 	naver: {
@@ -62,6 +77,11 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			login: "https://nid.naver.com/oauth2.0/authorize",
 			token: "https://nid.naver.com/oauth2.0/token",
 			user: "https://openapi.naver.com/v1/nid/me",
+		},
+
+		reconfirmParam: {
+			key: "auth_type",
+			value: "reauthenticate",
 		},
 	},
 };

--- a/server/utils/oauth/oauth.ts
+++ b/server/utils/oauth/oauth.ts
@@ -10,6 +10,16 @@ interface INaverUser {
 	response: IOAuthUser;
 }
 
+interface IOAuthTokens {
+	token_type: string;
+	access_token: string;
+	id_token?: string;
+	expires_in: number;
+	refresh_token: string;
+	refresh_token_expires_in?: number;
+	scope?: string;
+}
+
 /**
  * 주어진 provider로의 OAuth 로그인 요청 URL을 생성합니다.
  * @param provider - OAuth provider
@@ -44,7 +54,7 @@ export const buildLoginUrl = (provider: TOAuthProvider) => {
  * @param code - 사용자가 로그인하여 redirect URI를 통해 받은 authorization code
  * @returns `fetch()`의 두 번째 인수로 넘길 수 있는, access token 요청 옵션
  */
-export const buildTokenFetchOptions = (
+const buildTokenFetchOptions = (
 	provider: TOAuthProvider,
 	code: string
 ): RequestInit => {
@@ -70,6 +80,43 @@ export const buildTokenFetchOptions = (
 	};
 };
 
+const fetchOAuthTokensByAuthCode = async (
+	provider: TOAuthProvider,
+	authorizationCode: string
+) => {
+	const oAuthTokenResponse = await fetch(
+		oAuthProps[provider].requestEndpoint.token,
+		buildTokenFetchOptions(provider, authorizationCode)
+	);
+
+	if (oAuthTokenResponse.status >= 500) {
+		throw ServerError.etcError(
+			500,
+			"소셜 로그인 서비스 제공사 오류로 로그인에 실패했습니다."
+		);
+	} else if (oAuthTokenResponse.status >= 400) {
+		throw ServerError.badRequest(
+			"인가 코드가 유효하지 않아서 소셜 로그인에 실패했습니다."
+		);
+	}
+
+	return (await oAuthTokenResponse.json()) as IOAuthTokens;
+};
+
+const fetchOAuthUserByAccessToken = async (
+	provider: TOAuthProvider,
+	accessToken: string
+) => {
+	const url = oAuthProps[provider].requestEndpoint.user;
+	const headers = {
+		Authorization: `Bearer ${accessToken}`,
+		"Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+	};
+
+	const oAuthUserResponse = await fetch(url, { headers });
+	return await oAuthUserResponse.json();
+};
+
 const isNaverUserResponse = (payload: any): payload is INaverUser => {
 	return "response" in payload && "id" in payload.response;
 };
@@ -84,7 +131,7 @@ const isOAuthUserResponse = (payload: any): payload is IOAuthUser => {
  * @param payload
  * @returns
  */
-export const getOAuthAccountId = (
+const extractOAuthAccountId = (
 	provider: TOAuthProvider,
 	payload: any
 ): string => {
@@ -95,4 +142,21 @@ export const getOAuthAccountId = (
 	}
 
 	throw ServerError.etcError(500, "소셜 로그인 회원번호 조회 실패");
+};
+
+export const verifyAuthorizationCode = async (
+	provider: TOAuthProvider,
+	authorizationCode: string
+) => {
+	const oAuthTokens = await fetchOAuthTokensByAuthCode(
+		provider,
+		authorizationCode
+	);
+
+	const oAuthUser = await fetchOAuthUserByAccessToken(
+		provider,
+		oAuthTokens.access_token
+	);
+
+	return extractOAuthAccountId(provider, oAuthUser);
 };

--- a/server/utils/oauth/oauth.ts
+++ b/server/utils/oauth/oauth.ts
@@ -15,7 +15,7 @@ interface INaverUser {
  * @param provider - OAuth provider
  */
 export const buildLoginUrl = (provider: TOAuthProvider) => {
-	const { requestEndpoint, clientId, redirectUri, scope } =
+	const { requestEndpoint, clientId, redirectUri, scope, reconfirmParam } =
 		oAuthProps[provider];
 
 	const loginUrl = new URL(requestEndpoint.login);
@@ -28,8 +28,12 @@ export const buildLoginUrl = (provider: TOAuthProvider) => {
 		loginUrl.searchParams.set("scope", scope);
 	}
 
+	const reconfirmUrl = new URL(loginUrl);
+	reconfirmUrl.searchParams.set(reconfirmParam.key, reconfirmParam.value);
+
 	return {
 		loginUrl: loginUrl.toString(),
+		reconfirmUrl: reconfirmUrl.toString(),
 	};
 };
 

--- a/server/utils/validations/oauth/oauth.ts
+++ b/server/utils/validations/oauth/oauth.ts
@@ -3,7 +3,7 @@ import { validate } from "../../../middleware/validate";
 import { oAuthProviders } from "../../oauth/constants";
 import { ERROR_MESSAGES } from "./constants";
 
-export const getOAuthLoginUrlValidation = [
+export const getOAuthLoginUrlValidator = () => [
 	param("provider")
 		.isIn(oAuthProviders)
 		.withMessage(ERROR_MESSAGES.INVALID_OAUTH_PROVIDER),

--- a/server/utils/validations/oauth/oauth.ts
+++ b/server/utils/validations/oauth/oauth.ts
@@ -10,7 +10,7 @@ export const getOAuthLoginUrlValidator = () => [
 	validate,
 ];
 
-export const postOAuthLoginValidation = [
+export const postOAuthLoginValidatior = () => [
 	body("provider")
 		.isIn(oAuthProviders)
 		.withMessage(ERROR_MESSAGES.INVALID_OAUTH_PROVIDER),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #157

## 📝 작업 내용

소셜 로그인으로 가입한 계정의 정보 수정 및 탈퇴 기능 사용을 위해, 비밀번호 재확인 대신 소셜 로그인 재확인 관련 API를 구현합니다.

- [x] 소셜 로그인 재확인 URL 요청 API 구현 (OAuth 재인증 옵션 적용)
  - [x] 프로바이더별 재인증 옵션 파라미터 키-값 쌍 데이터 추가
- [x] 소셜 로그인 재확인 처리 API 구현
  - 기존 OAuth 로그인 처리 API 재사용 (Authorization code → OAuth access token → OAuth 회원번호 조회)
    - [x] 코드 재사용과 동작 이해를 돕기 위한 리팩터링 진행
  - [x] 로그인한 회원과 연동하지 않은 소셜 계정으로 진행 시, 소셜 로그인 재확인 실패 처리
  - 해당 provider, 회원번호를 연동한 유저의 이메일, 비밀번호 등록 여부에 따라서
    - [x] 이메일, 비밀번호 등록한 유저: 실패 처리 (비밀번호 재확인으로만 진행 가능)
    - [x] 이메일, 비밀번호를 등록하지 않은 유저: tempToken 발급

### API 상세

#### 서비스별 OAuth 로그인 재확인 URL 조회

- 메서드: `GET`
- 엔드포인트: `/api/oauth/reconfirm-url/{provider}`
- Params
  - provider: `google | kakao | naver`

#### OAuth 로그인 재확인

- 메서드: `POST`
- 엔드포인트: `/api/oauth/reconfirm`
- Request body
  ```typescript
  {
    "provider": "google" | "kakao" | "naver",
    "code": string
  }
  ```

### 기능 확인 방법

1. `GET /api/oauth/reconfirm-url/{provider}` 요청으로 OAuth 서비스 제공사별 로그인 재확인 URL 조회
2. 조회한 URL을 웹 브라우저에서 접속하고 로그인 재확인 절차 진행
3. 로그인 후 돌아오는 페이지의 주소에서 `code` 파라미터의 값 복사
   - DevTools 콘솔에서 `new URLSearchParams(location.search).get('code');`
4. `POST /api/oauth/reconfirm` 요청 (아래는 요청 본문)
   ```typescript
   {
     "provider": "google" | "kakao" | "naver",
     "code": "3에서 복사한 authorization code"
   }
   ```
5. 응답의 메시지와 쿠키에 세팅된 토큰(tempToken)으로 소셜 로그인 재확인 성공 확인

## 💬 리뷰 요구사항

- 이전 PR(#145)에서부터 소셜 로그인 요청 URL을 로그인 유형(로그인, 재확인), 프로바이더(구글, 네이버, 카카오)마다 각각 따로 요청해서 받도록 구현을 해 놓은 상태인데, (2×3=) 6가지 URL을 일괄적으로 받도록 변경하는 게 좋을지 의견 부탁드립니다.
  - FE에서 버튼을 배치하기 위해 세 번을 각각 요청하는 게 불합리해 보인다는 생각이 갑자기 들어서 질문을 드립니다.
- Redirect URI를 다른 경로로 바꾸길 희망한다면 말씀해 주세요.
- 잘못 구현되어서 수정이 필요한 부분이나, 그 외에도 변경했으면 하는 부분 있으면 말씀해 주세요.