### PR TITLE
[채팅] 채팅 기능을 위한 zustand state와 실제 적용

### DIFF
--- a/client/src/component/Chats/ChatRooms/ChatRooms.tsx
+++ b/client/src/component/Chats/ChatRooms/ChatRooms.tsx
@@ -10,6 +10,8 @@ export interface RoomsInfo {
 	rooms: {
 		[key: number]: IRoomHeader[];
 	};
+	// key : 현재 page
+	// values : 현재 page에서 보여 줄 채팅방 정보
 }
 
 const ChatRooms: FC = () => {

--- a/client/src/component/Chats/ChatRooms/Pagenation/Pagenation.tsx
+++ b/client/src/component/Chats/ChatRooms/Pagenation/Pagenation.tsx
@@ -24,7 +24,7 @@ const Pagenation: FC<IPagenationProps> = ({
 		const result = [];
 
 		let temp = [];
-		for (let i = 1; i <= total / 2; i++) {
+		for (let i = 1; i < total / 2 + 1; i++) {
 			temp.push(i);
 
 			// 각 페이지는 5개가 default

--- a/client/src/state/ChatRoomStore.ts
+++ b/client/src/state/ChatRoomStore.ts
@@ -1,0 +1,87 @@
+import { IMessage, IRoomHeader } from "shared";
+import { StateCreator, create } from "zustand";
+import { PersistOptions, persist } from "zustand/middleware";
+import { RoomsInfo } from "../component/Chats/ChatRooms/ChatRooms";
+
+interface IChatRoomState {
+	myRoomInfo: RoomsInfo;
+	chatRoomMessageLogs: Map<number, IMessage[]>;
+}
+
+interface IChatRoomActions {
+	setMyRoomInfo: (
+		totalRoomCount: number,
+		currentPage: number,
+		roomHeaders: IRoomHeader[]
+	) => void;
+	setMessageLogByRooms: (roomId: number, messageLogs: IMessage[]) => void;
+	updateMessageLogByRoom: (roomId: number, message: IMessage) => void;
+}
+
+export interface TChatRoomStore extends IChatRoomState, IChatRoomActions {}
+
+export type ChatRoomStatePersist = (
+	config: StateCreator<TChatRoomStore>,
+	options: PersistOptions<IChatRoomState>
+) => StateCreator<TChatRoomStore>;
+
+export const useChatRoom = create<TChatRoomStore>(
+	(persist as ChatRoomStatePersist)(
+		set => ({
+			myRoomInfo: {
+				totalRoomCount: 0,
+				rooms: {},
+			},
+			chatRoomMessageLogs: new Map<number, IMessage[]>(),
+			setMyRoomInfo: (
+				totalRoomCount: number,
+				currentPage: number,
+				roomHeaders: IRoomHeader[]
+			) =>
+				set(state => ({
+					...state,
+					myRoomInfo: {
+						totalRoomCount: totalRoomCount,
+						rooms: {
+							...state.myRoomInfo.rooms,
+							[currentPage]: roomHeaders,
+						},
+					},
+				})),
+			setMessageLogByRooms: (roomId: number, messageLogs: IMessage[]) =>
+				set(state => {
+					const newChatRoomMessageLogs = new Map(
+						state.chatRoomMessageLogs
+					);
+					newChatRoomMessageLogs.set(roomId, messageLogs);
+					return {
+						...state,
+						chatRoomMessageLogs: newChatRoomMessageLogs,
+					};
+				}),
+			updateMessageLogByRoom: (roomId: number, message: IMessage) =>
+				set(state => {
+					const newChatRoomMessageLogs = new Map(
+						state.chatRoomMessageLogs
+					);
+					const existingMessages =
+						newChatRoomMessageLogs.get(roomId) || [];
+					newChatRoomMessageLogs.set(roomId, [
+						...existingMessages,
+						message,
+					]);
+					return {
+						...state,
+						chatRoomMessageLogs: newChatRoomMessageLogs,
+					};
+				}),
+		}),
+		{
+			name: "ChatRoomStore",
+			partialize: state => ({
+				myRoomInfo: state.myRoomInfo,
+				chatRoomMessageLogs: state.chatRoomMessageLogs,
+			}),
+		}
+	)
+);


### PR DESCRIPTION
## 📝 작업 내용

- zustand state 추가
```ts
// 실제 local storage에 저장되는 데이터들
interface IChatRoomState {
	myRoomInfo: RoomsInfo;
	chatRoomMessageLogs: Map<number, IMessage[]>;
}
```
- 엥? IRoomInfo가 뭐에요?
    - 내 채팅방을 불러온 후, 페이지네이션을 통해 채팅방 목록을 보여주기 위한 타입입니다.
```ts
export interface RoomsInfo {
	totalRoomCount: number;
	rooms: {
		[key: number]: IRoomHeader[];
	};
	// key : 현재 page
	// values : 현재 page에서 보여 줄 채팅방 정보
}
```

- storage에 저장하기 위한 actions
    - api 요청 결과, 불러온 채팅방 리스트를 저장
    ```ts
    setMyRoomInfo: (
		    totalRoomCount: number,
		    currentPage: number,
		    roomHeaders: IRoomHeader[]
    ) => void;
    ```
    - 불러온 채팅방의 메세지 기록을 저장
    ```ts
    setMessageLogByRooms: (roomId: number, messageLogs: IMessage[]) => void;
     ```
    - 메세지 보낸 후, 메세지 기록에 추가
    ```ts
    updateMessageLogByRoom: (roomId: number, message: IMessage) => void;
    ```

- 실제 state 를 활용하도록 기존 코드 수정
    - 이번 commit에서는  setMyRoomInfo만 수정함
    - 채팅 개발이 끝나면 추가로 나머지도 작업할 예쩡

### 🖼️ 스크린샷 (실제 결과들)

- 채팅방 페이지 진입
    -  내가 속한 채팅방 리스트를 1페이지만 요청함 (api)
    -  요청 결과를 local storage에 저장 + 이를 통해 목록 보여줌
<img width="400" alt="스크린샷 2024-08-22 오후 7 52 46" src="https://github.com/user-attachments/assets/75579acc-caa2-452f-9cea-ee181b15a79b">

- 2번째 페이지 불러옴
    - 요청 결과를 local storage에 저장한 모습
<img width="400" alt="스크린샷 2024-08-22 오후 7 53 08" src="https://github.com/user-attachments/assets/e8fbbacc-75f2-49f1-99c8-22431c959732">

## 💬 리뷰 요구사항(선택)

- 이번 PR에서 아셔야 할 점은 actions의 사용법만 아시면 될 것 같습니다.
    - 혹시 궁금한 점, 이해가 안되는 점 있으면 알려주세요
