### PR TITLE
[FE/BE] 채팅방 입장 및 실시간 채팅

### DIFF
--- a/chat_server/app.ts
+++ b/chat_server/app.ts
@@ -1,12 +1,15 @@
-import express from "express";
+import cookie from "cookie";
 import { createServer } from "http";
+import jwt from "jsonwebtoken";
 import { Server } from "socket.io";
+
 import { instrument } from "@socket.io/admin-ui";
+
 import { handleChatConnection } from "./controllers/chat_controller";
 import { handleNotificationConnection } from "./controllers/notification_controller";
+import { Socket } from "dgram";
 
-const app = express();
-const httpServer = createServer(app);
+const httpServer = createServer();
 
 // socket.io 서버 설정
 const io = new Server(httpServer, {
@@ -24,6 +27,23 @@ instrument(io, {
 
 // 네임스페이스 설정
 const chatNamespace = io.of("/chat");
+chatNamespace.use((socket, next) => {
+	const cookieString = socket.handshake.headers.cookie;
+
+	if (cookieString === undefined) {
+		socket.disconnect();
+		return;
+	}
+
+	const cookies = cookie.parse(cookieString!) as {
+		refreshToken: string;
+		accessToken: string;
+	};
+
+	const { userId } = jwt.decode(cookies.refreshToken) as { userId: number };
+	(socket as unknown as Socket & { userId: number }).userId = userId;
+	next();
+});
 chatNamespace.on("connection", socket => {
 	handleChatConnection(socket);
 });

--- a/chat_server/events/chatroom_events.ts
+++ b/chat_server/events/chatroom_events.ts
@@ -1,13 +1,15 @@
 import { Socket } from "socket.io";
+import { IGetRoomMessageLogsResponse } from "shared";
+
 import {
 	createRoom,
 	getRooms,
 	joinRoom,
 	leaveRoom,
 } from "../services/chatroom_service";
+import { httpRequest } from "../services/api_service";
 
 // 일단 서비스 함수 파라미터 roomName으로 작성
-// TODO : DTO기반 수정
 
 // 채팅방 이벤트
 export const handleRoomEvents = (socket: Socket) => {
@@ -31,5 +33,20 @@ export const handleRoomEvents = (socket: Socket) => {
 		leaveRoom(socket, roomName);
 		socket.leave(roomName);
 		socket.to(roomName).emit("user_left", socket.id);
+	});
+
+	// 채팅방 입장
+	socket.on("enter_room", async (roomId, callback) => {
+		socket.join(`${roomId}`); // TEST : join room
+
+		// TODO : 캐싱 메시지 조회(redis -> http)
+
+		const { messageLogs }: IGetRoomMessageLogsResponse = await httpRequest(
+			`api/chat/room/${roomId}`,
+			"GET",
+			{}
+		);
+
+		callback(messageLogs);
 	});
 };

--- a/chat_server/events/message_events.ts
+++ b/chat_server/events/message_events.ts
@@ -1,15 +1,33 @@
+import { IKafkaMessageDTO, IMessage, ISocketMessageDTO } from "shared";
 import { Socket } from "socket.io";
-import { getMessageLogs, sendMessage } from "../services/message_service";
+
+import { sendMessage } from "../services/kafka_service";
 
 // 메세지 이벤트
 export const handleMessageEvents = (socket: Socket) => {
-	socket.on("send_message", (roomName, message) => {
-		sendMessage(socket, roomName, message);
-		socket.to(roomName).emit("receive_message", message);
-	});
+	socket.on("send_message", async (message: ISocketMessageDTO, callback) => {
+		const createdAt = new Date(message.createdAt);
 
-	socket.on("message_logs", roomName => {
-		const logs = getMessageLogs(roomName);
-		socket.emit("message_logs", logs);
+		const msg: IKafkaMessageDTO = {
+			...message,
+			createdAt,
+			userId: (socket as unknown as Socket & { userId: number }).userId,
+		};
+
+		try {
+			await sendMessage(msg);
+			callback(true);
+
+			// TODO : 캐시 저장
+
+			const receiveMsg: IMessage = {
+				...message,
+				createdAt,
+				isMine: false,
+			};
+			socket.to(`${message.roomId}`).emit("receive_message", receiveMsg);
+		} catch {
+			callback(false);
+		}
 	});
 };

--- a/chat_server/index.ts
+++ b/chat_server/index.ts
@@ -1,14 +1,10 @@
 import dotenv from "dotenv";
-import { IKafkaMessageDTO } from "shared";
 
 import httpServer from "./app";
 import { getRedisAPI, initRedisAPI } from "./config/redis_config";
 import { getKafkaAPI, initKafkaAPI } from "./config/kafka_config";
-import {
-	getProducer,
-	initProducer,
-	sendMessage,
-} from "./services/kafka_service";
+import { getProducer, initProducer } from "./services/kafka_service";
+import { initURL } from "./services/api_service";
 
 dotenv.config();
 
@@ -27,6 +23,9 @@ async function startServer() {
 	// 채팅 소켓 PORT
 	const CHAT_PORT = process.env.CHAT_PORT || 3000;
 
+	// HTTP PORT
+	const HTTP_PORT = process.env.HTTP_PORT || 8000;
+
 	// 레디스 서버 URL
 	const REDIS_URL = `redis://${HOST_IP}:${REDIS_PORT}`;
 
@@ -36,6 +35,9 @@ async function startServer() {
 		`${HOST_IP}:${KAFKA_PORT_2}`,
 		`${HOST_IP}:${KAFKA_PORT_3}`,
 	];
+
+	// HTTP URL
+	const HTTP_URL = `http://${HOST_IP}:${HTTP_PORT}`;
 
 	try {
 		// Redis 연결
@@ -56,26 +58,8 @@ async function startServer() {
 		await producer.connect();
 		console.log("Kafka Producer 연결 성공");
 
-		// TEST START: 추후 지울 것! (Kafka로 message 보내기)
-		const testMessage: IKafkaMessageDTO = {
-			roomId: 1,
-			userId: 1,
-			message: "test입니다.",
-			createdAt: new Date(),
-			isSystem: true,
-		};
-		console.log(
-			`
-producer message:
-roomId: ${testMessage.roomId}
-userId: ${testMessage.userId}
-message: ${testMessage.message}
-createdAt: ${testMessage.createdAt}
-isSystem: ${testMessage.isSystem}
-			`
-		);
-		sendMessage(testMessage);
-		// TEST END
+		// HTTP URL 초기화
+		initURL(HTTP_URL);
 
 		// 채팅 서버 실행
 		httpServer.listen(CHAT_PORT, () => {

--- a/chat_server/package.json
+++ b/chat_server/package.json
@@ -5,19 +5,19 @@
 		"dev": "nodemon --watch \"*.ts\" --exec \"ts-node\" --files ./index.ts"
 	},
 	"dependencies": {
+		"cookie": "^0.6.0",
+		"dotenv": "^16.4.5",
+		"jsonwebtoken": "^9.0.2",
+		"kafkajs": "^2.2.4",
+		"redis": "^4.7.0",
+		"socket.io": "^4.7.5"
+	},
+	"devDependencies": {
 		"@socket.io/admin-ui": "^0.5.1",
 		"@types/express": "^4.17.21",
 		"@types/node": "^22.2.0",
-		"cookie-parser": "^1.4.6",
-		"dotenv": "^16.4.5",
-		"express": "^4.19.2",
-		"express-validator": "^7.2.0",
-		"jsonwebtoken": "^9.0.2",
-		"kafkajs": "^2.2.4",
 		"nodemon": "^3.1.4",
-		"redis": "^4.7.0",
 		"shared": "^1.0.0",
-		"socket.io": "^4.7.5",
 		"ts-node": "^10.9.2",
 		"typescript": "^5.5.4"
 	}

--- a/chat_server/services/api_service.ts
+++ b/chat_server/services/api_service.ts
@@ -1,0 +1,40 @@
+let apiURL: string | null = null;
+
+const initURL = (url: string) => {
+	if (apiURL === null) {
+		apiURL = url;
+	}
+};
+
+const httpRequest = async (path: string, method: string, body: object) => {
+	if (apiURL === null) throw new Error("API URL이 초기화되지 않았습니다.");
+
+	const response = await fetch(`${apiURL}/${path}`, {
+		method,
+		credentials: "include",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: method === "GET" ? undefined : JSON.stringify(body), // body를 JSON 문자열로 변환
+	});
+
+	if (!response.ok) {
+		throw new Error(`HTTP 응답 확인: ${response.status}`);
+	}
+
+	// JSON 아닐 경우 처리
+	const contentType = response.headers.get("content-type");
+
+	if (contentType && contentType.includes("application/json")) {
+		// JSON 응답 처리
+		return await response.json();
+	} else {
+		// JSON이 아닌 응답 처리
+		const text = await response.text();
+		console.error("Unexpected content type:", contentType);
+		console.error("Response body:", text);
+		throw new Error("JSON이 아닙니다.");
+	}
+};
+
+export { initURL, httpRequest };

--- a/chat_server/services/kafka_service.ts
+++ b/chat_server/services/kafka_service.ts
@@ -31,7 +31,9 @@ const getProducer = (): Producer => {
 
 // Kafka로 message 송신
 const sendMessage = async (messageDTO: IKafkaMessageDTO) => {
-	const { roomId, userId, message, createdAt, isSystem } = messageDTO;
+	const { userId, roomId, message, createdAt, isSystem } = messageDTO;
+
+	const timestamp = new Date(createdAt).getTime().toString();
 
 	if (producer === null) {
 		throw new Error("Kafka Producer is null");
@@ -43,7 +45,7 @@ const sendMessage = async (messageDTO: IKafkaMessageDTO) => {
 			{
 				key: JSON.stringify({ roomId, userId }), // message key
 				value: JSON.stringify({ message, isSystem }), // message value (Buffer | string | null)
-				timestamp: createdAt.getTime().toString(), // string 형식의 시간 데이터
+				timestamp, // string 형식의 시간 데이터
 			},
 		],
 		acks: -1, // 리더와 모든 팔로워 파티션이 메시지를 기록했을 때 성공

--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -10,6 +10,10 @@ module.exports = {
 	parser: "@typescript-eslint/parser",
 	plugins: ["react-refresh"],
 	rules: {
+		"@typescript-eslint/no-unused-vars": [
+			"error",
+			{ argsIgnorePattern: "^_", varsIgnorePattern: "^_" }, // '_'로 시작하는 arg | var error
+		],
 		"react-refresh/only-export-components": [
 			"warn",
 			{ allowConstantExport: true },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,18 +10,17 @@ import CheckPassword from "./page/User/CheckPassword";
 import ProfileUpdate from "./page/User/ProfileUpdate";
 import clsx from "clsx";
 import { useErrorModal } from "./state/errorModalStore";
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useLayoutEffect } from "react";
 import ErrorModal from "./component/utils/ErrorModal";
 import OAuthRedirectHandler from "./page/OAuthRedirectHandler";
 import ChatTestPage from "./page/Chat/ChatTestPage";
 import ChatRoom from "./component/Chats/ChatRoom/ChatRoom";
 import ChatRooms from "./component/Chats/ChatRooms/ChatRooms";
-import { useUserStore } from "./state/store";
-import { io, Socket } from "socket.io-client";
 import { AdminUserMgmtPage } from "./page/Admin/AdminUserMgmtPage";
 import { AdminPostMgmtPage } from "./page/Admin/AdminPostMgmtPage";
 import { AdminStatsPage } from "./page/Admin/AdminStatsPage";
-
+import { useUserStore } from "./state/store";
+import { io } from "socket.io-client";
 
 function MainContainer({ children }: { children: React.ReactNode }) {
 	const location = useLocation();
@@ -48,39 +47,34 @@ function MainContainer({ children }: { children: React.ReactNode }) {
 }
 
 function App() {
-	const [socket, setSocket] = useState<Socket | null>(null);
 	const errorModal = useErrorModal();
-	const isLogin = useUserStore(state => state.isLogin);
+
+	const isLogin = useUserStore.use.isLogin();
+	const socket = useUserStore.use.socket();
+
+	const { setSocket } = useUserStore.use.actions();
 
 	useLayoutEffect(() => {
 		errorModal.clear();
-	}, []);
 
-	useEffect(() => {
-		if (isLogin) {
-			// 로그인 성공 시 chat_server에 소켓 연결
-			const socketInstance: Socket = io(
-				`${import.meta.env.VITE_CHAT_ADDRESS}/chat`
+		// 로그인은 되어 있으나 소켓이 없는 경우
+		if (isLogin && !socket) {
+			setSocket(
+				io(`${import.meta.env.VITE_CHAT_ADDRESS}/chat`, {
+					withCredentials: true,
+				})
 			);
 
-			socketInstance.on("connect", () => {
-				console.log(
-					"Connected to chat server with socket ID:",
-					socketInstance.id
-				);
-			});
-
-			socketInstance.on("disconnect", () => {
-				console.log("Disconnected from chat server");
-			});
-
-			socketInstance.on("update_user_list", userList => {
-				console.log("현재 접속 중인 사용자 목록:", userList);
-			});
-
-			setSocket(socketInstance);
+			return;
 		}
-	}, [isLogin]);
+
+		// 로그인이 안되있으나 소켓이 있는 경우
+		if (!isLogin && socket) {
+			socket.disconnect();
+			setSocket(null);
+			return;
+		}
+	}, []);
 
 	return (
 		<div className={AppContainer}>
@@ -92,7 +86,7 @@ function App() {
 						close={errorModal.close}
 					/>
 				)}
-				<Header socket={socket} />
+				<Header />
 				<MainContainer>
 					<Routes>
 						<Route

--- a/client/src/component/Header/Header.tsx
+++ b/client/src/component/Header/Header.tsx
@@ -22,16 +22,12 @@ import DropdownMenu from "./DropdownMenu";
 import { useModal } from "../../hook/useModal";
 import { ApiCall } from "../../api/api";
 import { ClientError } from "../../api/errors";
-import { Socket } from "socket.io-client";
 
-interface HeaderProps {
-	socket: Socket | null;
-}
-
-const Header: React.FC<HeaderProps> = ({ socket }) => {
+const Header: React.FC = () => {
 	const navigate = useNavigate();
 	const isLogin = useUserStore.use.isLogin();
 	const nickname = useUserStore.use.nickname();
+	const socket = useUserStore.use.socket();
 	const { setLogoutUser } = useUserStore.use.actions();
 	const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
 	const dropdownMenuRef = useRef<HTMLDivElement>(null);
@@ -75,6 +71,7 @@ const Header: React.FC<HeaderProps> = ({ socket }) => {
 			socket.disconnect();
 			console.log("로그아웃, socket disconnect");
 		}
+
 		setLogoutUser();
 	};
 

--- a/client/src/state/store.ts
+++ b/client/src/state/store.ts
@@ -1,17 +1,20 @@
 import { create } from "zustand";
 import { createSelectors } from "./selector";
 import { persist } from "zustand/middleware";
+import { io, Socket } from "socket.io-client";
 
 interface IUserState {
 	nickname: string;
 	loginTime: string;
 	isLogin: boolean;
+	socket: Socket | null;
 }
 
 interface IUserActions {
 	setNickName: (nickName: string) => void;
 	setLoginTime: (loginTime: string) => void;
 	setIsLogin: (isLogin: boolean) => void;
+	setSocket: (socket: Socket | null) => void;
 	setLoginUser: (nickname: string, loginTime: string) => void;
 	setLogoutUser: () => void;
 }
@@ -25,16 +28,33 @@ const useUserStoreBase = create<TUserStore>()(
 				nickname: "",
 				loginTime: "",
 				isLogin: false,
+				socket: null,
 
 				actions: {
 					setNickName: (nickname: string) =>
 						set({ nickname: nickname }),
 					setLoginTime: (loginTime: string) => set({ loginTime }),
 					setIsLogin: (isLogin: boolean) => set({ isLogin }),
+					setSocket: socket => set({ socket }),
 					setLoginUser: (nickname: string, loginTime: string) =>
-						set({ nickname, loginTime, isLogin: true }),
+						set({
+							nickname,
+							loginTime,
+							isLogin: true,
+							socket: io(
+								`${import.meta.env.VITE_CHAT_ADDRESS}/chat`,
+								{
+									withCredentials: true,
+								}
+							),
+						}),
 					setLogoutUser: () =>
-						set({ nickname: "", loginTime: "", isLogin: false }),
+						set({
+							nickname: "",
+							loginTime: "",
+							isLogin: false,
+							socket: null,
+						}),
 				},
 			};
 		},

--- a/shared/chats/dto.ts
+++ b/shared/chats/dto.ts
@@ -21,6 +21,15 @@ export interface ILiveRoomInfo {
 	newMessages: number; // 새로운 채팅 수
 }
 
+export interface ISocketMessageDTO {
+	roomId: number; // 방 번호
+	nickname: string; // 보낸 사람 이름
+	message: string; // 채팅 내용
+	createdAt: string; // 생성 시간
+	isMine?: boolean; // true : 내 메세지
+	isSystem: boolean; // true : 시스템 메세지
+}
+
 export interface IKafkaMessageDTO {
 	roomId: number; // 방 번호
 	userId: number; // 사용자 아이디(system: 0)

--- a/shared/chats/mappers.ts
+++ b/shared/chats/mappers.ts
@@ -7,7 +7,7 @@ export const mapDBToIMessage = (userId: number, dbData: any): IMessage => {
 		message: dbData.message,
 		createdAt: dbData.created_at,
 		isMine: dbData.user_id === userId,
-		isSystem: dbData.is_system,
+		isSystem: Boolean(dbData.is_system),
 	};
 };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #179 
- #180 
- #184 

resolved #179  #180 #184 

## 📝 작업 내용

### 🖼️ 실시간 채팅
![실시간 채팅](https://github.com/user-attachments/assets/f1716b26-f9ac-456a-8ff8-4c422ab4af1b)

### 🖼️ 채팅방 입장
![채팅방 입장](https://github.com/user-attachments/assets/871a517b-d0be-4361-bb70-d668faff4b63)

### 🖼️ DB에 저장된 메시지
![DB에 저장된 메시지](https://github.com/user-attachments/assets/0df5e2fd-a62e-4139-932a-58f38adc6834)

## 💬 리뷰 요구사항

1. 메시지 로그 API에서 message가 불러오지 않는 문제가 있습니다. 코드에서 잘못된 부분이 있을까요?
2. db mapper 함수에서 isSystem이 정수로 불려와서 수정한 코드가 있습니다. 수정해도 괜찮을까요?
3. 쿠키의 토큰은 decode만 했습니다.
4. 캐싱 기능은 아직 추가하지 않았습니다.
5. 테스트 방법
   1. client/.env: `VITE_CHAT_ADDRESS='http://localhost:3000'` 추가
   2. docker에 kafka 동작 확인
   3. `npm build --workspace=client`
   4. `npm run dev --workspace=server`
   6. `npm run dev --workspace=chat_server`
   7. `npm run dev --workspace=consumer-server`
   8. db rooms에 데이터 추가해주세요.
      - 예시
     ![ex1](https://github.com/user-attachments/assets/da56e036-6f48-4545-93c8-d119fc128d6b)
   9. db members에 데이터 추가해주세요.
      - 예시
      ![ex2](https://github.com/user-attachments/assets/f3da017d-4ee2-43df-91d7-99571e872f10)
   10. 서로 다른 브라우저(저는 웨일, 크롬으로 테스트했습니다.)에서 로그인 후 테스트

