### PR TITLE
[BE] 회원 탈퇴 시 소셜 로그인 연동 해제

### DIFF
--- a/server/controller/oauth_controller.ts
+++ b/server/controller/oauth_controller.ts
@@ -1,5 +1,8 @@
 import { Request, Response, NextFunction } from "express";
-import { createOAuthConnection } from "../db/context/oauth_context";
+import {
+	createOAuthConnection,
+	updateOAuthRefreshToken,
+} from "../db/context/oauth_context";
 import { addRefreshToken } from "../db/context/token_context";
 import { addOAuthUser, readUserByOAuth } from "../db/context/users_context";
 import { getKstNow } from "../utils/getKstNow";
@@ -36,24 +39,35 @@ export const handleOAuthLogin = async (
 		const provider = req.body.provider as TOAuthProvider;
 		const authorizationCode = req.body.code as string;
 
-		let oAuthAccountId = await verifyAuthorizationCode(
-			provider,
-			authorizationCode
-		);
+		const { oAuthAccountId, oAuthRefreshToken } =
+			await verifyAuthorizationCode(provider, authorizationCode);
 		let user = await readUserByOAuth(provider, oAuthAccountId);
 
 		// TODO: 회원 등록부터 리프레시 토큰 등록까지의 동작에 트랜잭션 적용
 		//       (회원 등록 이후 과정이 실패했을 때 변경사항 롤백 필요)
 
-		// 유저가 존재하지 않으면 신규 회원가입 처리(랜덤 닉네임 부여)
-		if (!user) {
+		if (user && oAuthRefreshToken) {
+			await updateOAuthRefreshToken(
+				provider,
+				oAuthAccountId,
+				oAuthRefreshToken
+			);
+		} else if (!user) {
+			// 유저가 존재하지 않으면 신규 회원가입 처리(랜덤 닉네임 부여)
 			// TODO: 자연스러운 닉네임 생성
 			const nickname =
 				"신규 " +
-				(0x1000000 * Math.random()).toString(16).padStart(6, "0");
+				Math.floor(0x1000000 * Math.random())
+					.toString(16)
+					.padStart(6, "0");
 
 			const newUserId = await addOAuthUser(nickname);
-			await createOAuthConnection(provider, newUserId, oAuthAccountId);
+			await createOAuthConnection(
+				provider,
+				newUserId,
+				oAuthAccountId,
+				oAuthRefreshToken
+			);
 
 			user = {
 				nickname,
@@ -122,10 +136,8 @@ export const handleOAuthReconfirm = async (
 		const provider = req.body.provider as TOAuthProvider;
 		const authorizationCode = req.body.code as string;
 
-		let oAuthAccountId = await verifyAuthorizationCode(
-			provider,
-			authorizationCode
-		);
+		const { oAuthAccountId, oAuthRefreshToken } =
+			await verifyAuthorizationCode(provider, authorizationCode);
 		let userByOAuth = await readUserByOAuth(provider, oAuthAccountId);
 
 		if (!userByOAuth || userByOAuth.id !== req.userId) {
@@ -137,6 +149,14 @@ export const handleOAuthReconfirm = async (
 		} else if (userByOAuth.email) {
 			throw ServerError.badRequest(
 				"이메일, 비밀번호를 등록한 계정은 비밀번호 재확인으로 인증해야 합니다."
+			);
+		}
+
+		if (oAuthRefreshToken) {
+			await updateOAuthRefreshToken(
+				provider,
+				oAuthAccountId,
+				oAuthRefreshToken
 			);
 		}
 

--- a/server/controller/oauth_controller.ts
+++ b/server/controller/oauth_controller.ts
@@ -5,9 +5,9 @@ import {
 } from "../db/context/oauth_context";
 import { addRefreshToken } from "../db/context/token_context";
 import { addOAuthUser, readUserByOAuth } from "../db/context/users_context";
+import { TOAuthProvider } from "../db/model/oauth";
 import { getKstNow } from "../utils/getKstNow";
 import { ServerError } from "../middleware/errors";
-import { TOAuthProvider } from "../utils/oauth/constants";
 import { buildLoginUrl, verifyAuthorizationCode } from "../utils/oauth/oauth";
 import {
 	makeAccessToken,

--- a/server/db/context/oauth_context.ts
+++ b/server/db/context/oauth_context.ts
@@ -1,7 +1,7 @@
 import { FieldPacket, PoolConnection, ResultSetHeader } from "mysql2/promise";
 import { ServerError } from "../../middleware/errors";
-import { TOAuthProvider } from "../../utils/oauth/constants";
 import pool from "../connect";
+import { TOAuthProvider } from "../model/oauth";
 
 export const createOAuthConnection = async (
 	provider: string,

--- a/server/db/context/oauth_context.ts
+++ b/server/db/context/oauth_context.ts
@@ -130,3 +130,34 @@ export const updateOAuthRefreshToken = async (
 		if (conn) conn.release();
 	}
 };
+
+export const clearOAuthConnection = async (userId: number) => {
+	let conn: PoolConnection | null = null;
+
+	try {
+		const sql = `
+			UPDATE
+				oauth_connections
+			SET
+				oauth_refresh_token = NULL,
+				isDelete = TRUE
+			WHERE
+				user_id = ?
+		`;
+		const values = [userId];
+
+		conn = await pool.getConnection();
+		const [result]: [ResultSetHeader, FieldPacket[]] = await conn.query(
+			sql,
+			values
+		);
+
+		if (result.affectedRows === 0) {
+			throw ServerError.reference("소셜 로그인 전체 연동 해제 실패");
+		}
+	} catch (err) {
+		throw err;
+	} finally {
+		if (conn) conn.release();
+	}
+};

--- a/server/db/context/oauth_context.ts
+++ b/server/db/context/oauth_context.ts
@@ -1,26 +1,33 @@
 import { FieldPacket, PoolConnection, ResultSetHeader } from "mysql2/promise";
 import { ServerError } from "../../middleware/errors";
+import { TOAuthProvider } from "../../utils/oauth/constants";
 import pool from "../connect";
 
 export const createOAuthConnection = async (
 	provider: string,
 	userId: number,
-	oAuthAccountId: string
+	oAuthAccountId: string,
+	oAuthRefreshToken: string
 ) => {
 	let conn: PoolConnection | null = null;
 
 	try {
 		const sql = `
 			INSERT INTO
-				oauth_connections (user_id, oauth_provider_id, oauth_account_id)
+				oauth_connections (
+					user_id,
+					oauth_provider_id,
+					oauth_account_id,
+					oauth_refresh_token
+				)
 			SELECT
-				?, id, ?
+				?, id, ?, ?
 			FROM
 				oauth_providers
 			WHERE
 				name = ?
 		`;
-		const values = [userId, oAuthAccountId, provider];
+		const values = [userId, oAuthAccountId, oAuthRefreshToken, provider];
 
 		conn = await pool.getConnection();
 		const [result]: [ResultSetHeader, FieldPacket[]] = await conn.query(
@@ -30,6 +37,47 @@ export const createOAuthConnection = async (
 
 		if (result.affectedRows === 0) {
 			throw ServerError.etcError(500, "소셜 로그인 연동에 실패했습니다.");
+		}
+	} catch (err: any) {
+		if (err.code === "ER_DUP_ENTRY") {
+			throw ServerError.badRequest("이미 연동된 소셜 계정입니다.");
+		}
+
+		throw err;
+	} finally {
+		if (conn) conn.release();
+	}
+};
+
+export const updateOAuthRefreshToken = async (
+	provider: TOAuthProvider,
+	oAuthAccountId: string,
+	oAuthRefreshToken: string
+) => {
+	let conn: PoolConnection | null = null;
+
+	try {
+		const sql = `
+			UPDATE
+				oauth_connections
+			INNER JOIN
+				oauth_providers
+				ON oauth_connections.oauth_provider_id = oauth_providers.id
+				AND oauth_providers.name = ?
+				AND oauth_connections.oauth_account_id = ?
+			SET
+				oauth_connections.oauth_refresh_token = ?
+		`;
+		const values = [provider, oAuthAccountId, oAuthRefreshToken];
+
+		conn = await pool.getConnection();
+		const [result]: [ResultSetHeader, FieldPacket[]] = await conn.query(
+			sql,
+			values
+		);
+
+		if (result.affectedRows === 0) {
+			console.error("OAuth Refresh token 저장 실패");
 		}
 	} catch (err: any) {
 		if (err.code === "ER_DUP_ENTRY") {

--- a/server/db/mapper/oauth_mapper.ts
+++ b/server/db/mapper/oauth_mapper.ts
@@ -1,0 +1,14 @@
+import { RowDataPacket } from "mysql2";
+import { IOAuthConnection } from "../model/oauth";
+
+export const mapDBToOAuthConnections = (
+	rows: RowDataPacket[]
+): IOAuthConnection[] => {
+	return rows.map(row => ({
+		id: row.id,
+		user_id: row.user_id,
+		oauth_provider_name: row.oauth_provider_name,
+		oauth_account_id: row.oauth_account_id,
+		oauth_refresh_token: row.oauth_refresh_token,
+	}));
+};

--- a/server/db/model/oauth.ts
+++ b/server/db/model/oauth.ts
@@ -1,0 +1,11 @@
+export const oAuthProviders = ["google", "kakao", "naver"] as const;
+
+export type TOAuthProvider = (typeof oAuthProviders)[number];
+
+export interface IOAuthConnection {
+	id: number;
+	user_id: number;
+	oauth_provider_name: TOAuthProvider;
+	oauth_account_id: string;
+	oauth_refresh_token: string;
+}

--- a/server/db/sql/oauth.sql
+++ b/server/db/sql/oauth.sql
@@ -8,6 +8,8 @@ CREATE TABLE IF NOT EXISTS oauth_connections (
     user_id INT NOT NULL,
     oauth_provider_id INT NOT NULL,
     oauth_account_id VARCHAR(255) NOT NULL,
+    oauth_refresh_token TEXT NULL,
+    isDelete Boolean NOT NULL DEFAULT FALSE,
 
     FOREIGN KEY (user_id) REFERENCES users(id),
     FOREIGN KEY (oauth_provider_id) REFERENCES oauth_providers(id),

--- a/server/utils/oauth/constants.ts
+++ b/server/utils/oauth/constants.ts
@@ -6,6 +6,11 @@ type TOAuthVariable<T> = {
 	[provider in TOAuthProvider]: T;
 };
 
+interface IKeyValuePair {
+	key: string;
+	value: string;
+}
+
 type TOAuthProps = {
 	clientId: string;
 	clientSecret?: string;
@@ -19,10 +24,13 @@ type TOAuthProps = {
 		user: string;
 	};
 
-	reconfirmParam: {
-		key: string;
-		value: string;
+	requestAdditionalParam?: {
+		login?: IKeyValuePair;
+		token?: IKeyValuePair;
+		user?: IKeyValuePair;
 	};
+
+	reconfirmParam: IKeyValuePair;
 };
 
 const getRedirectUri = (provider: TOAuthProvider) => {
@@ -41,6 +49,13 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			login: "https://accounts.google.com/o/oauth2/v2/auth",
 			token: "https://oauth2.googleapis.com/token",
 			user: "https://www.googleapis.com/oauth2/v2/userinfo",
+		},
+
+		requestAdditionalParam: {
+			login: {
+				key: "access_type",
+				value: "offline",
+			},
 		},
 
 		reconfirmParam: {

--- a/server/utils/oauth/constants.ts
+++ b/server/utils/oauth/constants.ts
@@ -4,7 +4,7 @@ type TOAuthVariable<T> = {
 	[provider in TOAuthProvider]: T;
 };
 
-type TOAuthRequestType = "login" | "token" | "user";
+type TOAuthRequestType = "login" | "token" | "user" | "revoke";
 
 interface IKeyValuePairs {
 	[key: string]: string;
@@ -51,12 +51,19 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			login: "https://accounts.google.com/o/oauth2/v2/auth",
 			token: "https://oauth2.googleapis.com/token",
 			user: "https://www.googleapis.com/oauth2/v2/userinfo",
+			revoke: "https://oauth2.googleapis.com/revoke",
 		},
 
 		getAdditionalRequestOptionsFor: {
 			login: () => ({
 				searchParams: {
 					access_type: "offline",
+				},
+			}),
+
+			revoke: ({ accessToken }: { accessToken: string }) => ({
+				searchParams: {
+					token: accessToken,
 				},
 			}),
 		},
@@ -76,6 +83,15 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			login: "https://kauth.kakao.com/oauth/authorize",
 			token: "https://kauth.kakao.com/oauth/token",
 			user: "https://kapi.kakao.com/v2/user/me",
+			revoke: "https://kapi.kakao.com/v1/user/unlink",
+		},
+
+		getAdditionalRequestOptionsFor: {
+			revoke: ({ accessToken }: { accessToken: string }) => ({
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			}),
 		},
 
 		reconfirmParams: {
@@ -93,6 +109,21 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			login: "https://nid.naver.com/oauth2.0/authorize",
 			token: "https://nid.naver.com/oauth2.0/token",
 			user: "https://openapi.naver.com/v1/nid/me",
+			revoke: "https://nid.naver.com/oauth2.0/token",
+		},
+
+		getAdditionalRequestOptionsFor: {
+			revoke: ({ accessToken }: { accessToken: string }) => ({
+				headers: {
+					"Content-type": oAuthRequestContentType,
+				},
+				body: {
+					grant_type: "delete",
+					client_id: process.env.OAUTH_NAVER_CLIENT_ID ?? "",
+					client_secret: process.env.OAUTH_NAVER_CLIENT_SECRET ?? "",
+					access_token: accessToken,
+				},
+			}),
 		},
 
 		reconfirmParams: {

--- a/server/utils/oauth/constants.ts
+++ b/server/utils/oauth/constants.ts
@@ -4,9 +4,10 @@ type TOAuthVariable<T> = {
 	[provider in TOAuthProvider]: T;
 };
 
-interface IKeyValuePair {
-	key: string;
-	value: string;
+type TOAuthRequestType = "login" | "token" | "user";
+
+interface IKeyValuePairs {
+	[key: string]: string;
 }
 
 type TOAuthProps = {
@@ -17,23 +18,26 @@ type TOAuthProps = {
 	redirectUri: string;
 
 	requestEndpoint: {
-		login: string;
-		token: string;
-		user: string;
+		[key in TOAuthRequestType]: string;
 	};
 
-	requestAdditionalParam?: {
-		login?: IKeyValuePair;
-		token?: IKeyValuePair;
-		user?: IKeyValuePair;
+	getAdditionalRequestOptionsFor?: {
+		[key in TOAuthRequestType]?: (options?: any) => {
+			headers?: IKeyValuePairs;
+			searchParams?: IKeyValuePairs;
+			body?: IKeyValuePairs;
+		};
 	};
 
-	reconfirmParam: IKeyValuePair;
+	reconfirmParams: IKeyValuePairs;
 };
 
 const getRedirectUri = (provider: TOAuthProvider) => {
 	return `http://localhost:${process.env.PORT}/oauth/redirect/${provider}`;
 };
+
+export const oAuthRequestContentType =
+	"application/x-www-form-urlencoded;charset=utf-8";
 
 export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 	google: {
@@ -49,16 +53,16 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			user: "https://www.googleapis.com/oauth2/v2/userinfo",
 		},
 
-		requestAdditionalParam: {
-			login: {
-				key: "access_type",
-				value: "offline",
-			},
+		getAdditionalRequestOptionsFor: {
+			login: () => ({
+				searchParams: {
+					access_type: "offline",
+				},
+			}),
 		},
 
-		reconfirmParam: {
-			key: "prompt",
-			value: "consent",
+		reconfirmParams: {
+			prompt: "consent",
 		},
 	},
 
@@ -74,9 +78,8 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			user: "https://kapi.kakao.com/v2/user/me",
 		},
 
-		reconfirmParam: {
-			key: "prompt",
-			value: "login",
+		reconfirmParams: {
+			prompt: "login",
 		},
 	},
 
@@ -92,9 +95,8 @@ export const oAuthProps: TOAuthVariable<TOAuthProps> = {
 			user: "https://openapi.naver.com/v1/nid/me",
 		},
 
-		reconfirmParam: {
-			key: "auth_type",
-			value: "reauthenticate",
+		reconfirmParams: {
+			auth_type: "reauthenticate",
 		},
 	},
 };

--- a/server/utils/oauth/constants.ts
+++ b/server/utils/oauth/constants.ts
@@ -1,6 +1,4 @@
-export const oAuthProviders = ["google", "kakao", "naver"] as const;
-
-export type TOAuthProvider = (typeof oAuthProviders)[number];
+import { TOAuthProvider } from "../../db/model/oauth";
 
 type TOAuthVariable<T> = {
 	[provider in TOAuthProvider]: T;

--- a/server/utils/oauth/oauth.ts
+++ b/server/utils/oauth/oauth.ts
@@ -1,6 +1,7 @@
 import { stringify } from "node:querystring";
-import { oAuthProps, TOAuthProvider } from "./constants";
+import { TOAuthProvider } from "../../db/model/oauth";
 import { ServerError } from "../../middleware/errors";
+import { oAuthProps } from "./constants";
 
 interface IOAuthUser {
 	id: string;

--- a/server/utils/oauth/oauth.ts
+++ b/server/utils/oauth/oauth.ts
@@ -28,6 +28,12 @@ const grantTypeToKey: { [key in TOAuthTokenRequestGrantType]: string } = {
 	refresh_token: "refresh_token",
 };
 
+const buildOAuthState = (loginType: "login" | "reconfirm") => {
+	return stringify({
+		login_type: loginType,
+	});
+};
+
 /**
  * 주어진 provider로의 OAuth 로그인 요청 URL을 생성합니다.
  * @param provider - OAuth provider
@@ -47,6 +53,7 @@ export const buildLoginUrl = (provider: TOAuthProvider) => {
 	loginUrl.searchParams.set("response_type", "code");
 	loginUrl.searchParams.set("client_id", clientId);
 	loginUrl.searchParams.set("redirect_uri", redirectUri);
+	loginUrl.searchParams.set("state", buildOAuthState("login"));
 
 	if (scope) {
 		loginUrl.searchParams.set("scope", scope);
@@ -61,6 +68,7 @@ export const buildLoginUrl = (provider: TOAuthProvider) => {
 	}
 
 	const reconfirmUrl = new URL(loginUrl);
+	reconfirmUrl.searchParams.set("state", buildOAuthState("reconfirm"));
 	for (const key in reconfirmParams) {
 		reconfirmUrl.searchParams.set(key, reconfirmParams[key]);
 	}

--- a/server/utils/oauth/oauth.ts
+++ b/server/utils/oauth/oauth.ts
@@ -171,5 +171,8 @@ export const verifyAuthorizationCode = async (
 		oAuthTokens.access_token
 	);
 
-	return extractOAuthAccountId(provider, oAuthUser);
+	return {
+		oAuthAccountId: extractOAuthAccountId(provider, oAuthUser),
+		oAuthRefreshToken: oAuthTokens.refresh_token,
+	};
 };

--- a/server/utils/oauth/oauth.ts
+++ b/server/utils/oauth/oauth.ts
@@ -25,8 +25,14 @@ interface IOAuthTokens {
  * @param provider - OAuth provider
  */
 export const buildLoginUrl = (provider: TOAuthProvider) => {
-	const { requestEndpoint, clientId, redirectUri, scope, reconfirmParam } =
-		oAuthProps[provider];
+	const {
+		requestEndpoint,
+		clientId,
+		redirectUri,
+		scope,
+		requestAdditionalParam,
+		reconfirmParam,
+	} = oAuthProps[provider];
 
 	const loginUrl = new URL(requestEndpoint.login);
 
@@ -36,6 +42,13 @@ export const buildLoginUrl = (provider: TOAuthProvider) => {
 
 	if (scope) {
 		loginUrl.searchParams.set("scope", scope);
+	}
+
+	if (requestAdditionalParam?.login) {
+		loginUrl.searchParams.set(
+			requestAdditionalParam.login.key,
+			requestAdditionalParam.login.value
+		);
 	}
 
 	const reconfirmUrl = new URL(loginUrl);

--- a/server/utils/oauth/oauth.ts
+++ b/server/utils/oauth/oauth.ts
@@ -258,7 +258,7 @@ export const revokeOAuth = async (
 		...buildRevokeFetchParameters(provider, oAuthAccessToken)
 	);
 
-	console.log(await oAuthRevokeResponse.json());
+	const payload = await oAuthRevokeResponse.json();
 
 	if (oAuthRevokeResponse.status >= 500) {
 		throw ServerError.etcError(
@@ -268,6 +268,11 @@ export const revokeOAuth = async (
 	} else if (oAuthRevokeResponse.status >= 400) {
 		throw ServerError.badRequest(
 			"인가 수단이 유효하지 않아서 OAuth 연동 해제에 실패했습니다."
+		);
+	} else if (payload.error) {
+		throw ServerError.etcError(
+			500,
+			"서버의 요청 구성 문제로 OAuth 연동 해제에 실패했습니다."
 		);
 	}
 };

--- a/server/utils/validations/oauth/constants.ts
+++ b/server/utils/validations/oauth/constants.ts
@@ -1,4 +1,4 @@
-import { oAuthProviders } from "../../oauth/constants";
+import { oAuthProviders } from "../../../db/model/oauth";
 
 const oAuthProviderDomain = oAuthProviders.join(", ");
 

--- a/server/utils/validations/oauth/oauth.ts
+++ b/server/utils/validations/oauth/oauth.ts
@@ -1,6 +1,6 @@
 import { body, param } from "express-validator";
+import { oAuthProviders } from "../../../db/model/oauth";
 import { validate } from "../../../middleware/validate";
-import { oAuthProviders } from "../../oauth/constants";
 import { ERROR_MESSAGES } from "./constants";
 
 export const getOAuthLoginUrlValidator = () => [


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #158
- #157
  - #172

&nbsp;

## 📝 작업 내용

- [x] 프로바이더-서버 간 소셜 로그인 연동 해제 구현 준비
  - [x] <mark>OAuth 관련 DB 스키마 수정</mark>
    - 연동 해제 여부를 나타내는 `isDelete` 컬럼 추가 (해당 소셜 계정을 다른 유저에게 재연동하지 못하도록)
    - OAuth refresh token 컬럼 추가
  - [x] OAuth 토큰 요청 이후 OAuth refresh token을 DB에 기록
- [x] 소셜 로그인 연동 여부에 따라 회원 탈퇴 분기 처리
  - 연동 없음: 탈퇴 진행 (분기 처리가 없다는 점을 제외하면 현재 구현과 동일)
  - [x] 연동 있음: (모두) 연동 해제 후 탈퇴 진행
    - [x] (1) 소셜 로그인 연동 정보 조회: 프로바이더, 회원번호, refresh token
    - [x] (2) Refresh token으로 access token 재발급
    - [x] (3) 프로바이더에 OAuth 연동 해제 요청 및 응답 확인
    - [x] (4) 성공 시 DB에 연동 해제 반영
- [x] <mark>Redirect URI 처리 시 평소 소셜 로그인과 소셜 로그인 재확인을 구분하기 위해 `state` 서치 파라미터 사용</mark>
  - 평소 소셜 로그인: `state`를 `login_type=login`으로 세팅
  - 소셜 로그인 재확인: `state`를 `login_type=reconfirm`으로 세팅

&nbsp;

### oauth_connections 테이블 스키마 수정

```sql
ALTER TABLE oauth_connections
ADD COLUMN oauth_refresh_token TEXT NULL,
ADD COLUMN isDelete Boolean NOT NULL DEFAULT FALSE;
```

- 위 내용을 실행하면 바로 세팅 가능하지만, 구글로 로그인한 유저의 회원 탈퇴를 바로 진행할 수는 없습니다.
  - 구글은 첫 연결 때만 리프레시 토큰을 전달합니다.
- 구글로 로그인한 유저의 회원 탈퇴를 테스트하려면,
  1. “Google 계정 관리 → 보안 → [서드 파티 앱 및 서비스 연결](https://myaccount.google.com/connections)”에서 테스트 앱의 연결 끊기
  2. 커뮤니티 로그인 페이지에서 다시 구글로 로그인 (OAuth 리프레시 토큰 발급)
  3. 회원 탈퇴 기능 테스트

&nbsp;

### 기능 확인 방법

- #172 와 비슷한 방법으로 기능 확인 가능합니다.

&nbsp;

## 💬 리뷰 요구사항

- 일단 유저에게 한 번 연동한 소셜 계정은 그 유저에게만 재연동 가능하도록 구현했습니다. 다른 의견 있으면 말씀해 주세요.
  - 현재 이메일 유저는 탈퇴하더라도 같은 이메일로 재가입할 수 없습니다. 소셜 로그인 가입 유저에게도 비슷한 수준의 제약을 거는 게 공평해 보인다는 게 제 생각입니다.
- 평소 소셜 로그인과 소셜 로그인 재확인의 Redirect URI 분리를 희망하시면 말씀해 주세요. 현재는 state 서치 파라미터로 구분하도록 구현했습니다.
- 잘못 구현되어서 수정이 필요한 부분이나, 그 외에도 변경했으면 하는 부분 있으면 말씀해 주세요.