### PR TITLE
[FE] 로딩 화면, 404 페이지 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import { io, Socket } from "socket.io-client";
 import { AdminUserMgmtPage } from "./page/Admin/AdminUserMgmtPage";
 import { AdminPostMgmtPage } from "./page/Admin/AdminPostMgmtPage";
 import { AdminStatsPage } from "./page/Admin/AdminStatsPage";
+import NotFound from "./page/error/NotFound";
 
 function MainContainer({ children }: { children: React.ReactNode }) {
 	const location = useLocation();
@@ -145,6 +146,10 @@ function App() {
 						<Route
 							path="/admin/stats"
 							element={<AdminStatsPage />}
+						/>
+						<Route
+							path="*"
+							element={<NotFound />}
 						/>
 					</Routes>
 				</MainContainer>

--- a/client/src/component/common/Loader/Loader.css.ts
+++ b/client/src/component/common/Loader/Loader.css.ts
@@ -1,0 +1,26 @@
+import { style, keyframes } from "@vanilla-extract/css";
+
+const spin = keyframes({
+	from: { transform: "rotate(0deg)" },
+	to: { transform: "rotate(360deg)" },
+});
+
+export const iconStyle = style({
+	fontSize: "50px",
+	animation: `${spin} 1s linear infinite`,
+	color: "#bdbdbd",
+});
+
+export const containerStyle = style({
+	display: "flex",
+	flexDirection: "column",
+	justifyContent: "center",
+	alignItems: "center",
+	height: "100vh",
+});
+
+export const textStyle = style({
+	marginTop: "20px",
+	fontSize: "16px",
+	color: "#fff",
+});

--- a/client/src/component/common/Loader/Loader.tsx
+++ b/client/src/component/common/Loader/Loader.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { AiOutlineLoading3Quarters } from "react-icons/ai";
+import * as styles from "./Loader.css";
+const Loader: React.FC = () => {
+	return (
+		<div className={styles.containerStyle}>
+			<AiOutlineLoading3Quarters className={styles.iconStyle} />
+			<p className={styles.textStyle}>잠시만 기다려주세요.</p>
+		</div>
+	);
+};
+
+export default Loader;

--- a/client/src/page/OAuthRedirectHandler.tsx
+++ b/client/src/page/OAuthRedirectHandler.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { sendOAuthLoginRequest } from "../api/users/oauth";
 import { useUserStore } from "../state/store";
+import Loader from "../component/common/Loader/Loader";
 
 //사용자 인증 완료 후 리디렉션된 후 처리
 const OAuthRedirectHandler = () => {
@@ -57,11 +58,13 @@ const OAuthRedirectHandler = () => {
 	return (
 		<div>
 			{loading ? (
-				<p>OAuth 로그인 처리 중</p>
+				<div>
+					<Loader />
+				</div>
 			) : error ? (
 				<p>{error}</p>
 			) : (
-				<p>OAuth 로그인 처리 완료</p>
+				<p>로그인 완료</p>
 			)}
 		</div>
 	);

--- a/client/src/page/error/NotFound.css.ts
+++ b/client/src/page/error/NotFound.css.ts
@@ -1,0 +1,58 @@
+import { style } from "@vanilla-extract/css";
+
+export const container = style({
+	display: "flex",
+	justifyContent: "center",
+	alignItems: "center",
+	height: "90vh",
+	textAlign: "center",
+	position: "relative",
+	padding: "0 20px",
+});
+
+export const content = style({
+	maxWidth: "600px",
+});
+
+export const logo = style({
+	fontSize: "100px",
+	color: "#BDBDBD",
+	marginBottom: "10px",
+});
+
+export const title = style({
+	fontSize: "24px",
+	fontWeight: "bold",
+	marginBottom: "20px",
+	color: "#BDBDBD",
+});
+
+export const description = style({
+	fontSize: "16px",
+	color: "#BDBDBD",
+	marginBottom: "40px",
+});
+
+export const button = style({
+	display: "inline-block",
+	padding: "15px 25px",
+	fontSize: "16px",
+	color: "#BDBDBD",
+	backgroundColor: "#000",
+	borderRadius: "10px",
+	textDecoration: "none",
+});
+
+export const backgroundText = style({
+	position: "absolute",
+	top: "50%",
+	left: "50%",
+	transform: "translate(-50%, -50%)",
+	fontSize: "120px",
+	fontWeight: "bold",
+	color: "#212121",
+	whiteSpace: "nowrap",
+	pointerEvents: "none",
+	userSelect: "none",
+	zIndex: -1,
+});

--- a/client/src/page/error/NotFound.tsx
+++ b/client/src/page/error/NotFound.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import * as styles from "./NotFound.css";
+import { TbFileSad } from "react-icons/tb";
+
+const NotFound: React.FC = () => {
+	return (
+		<div className={styles.container}>
+			<div className={styles.content}>
+				<div className={styles.logo}>
+					<TbFileSad />
+				</div>
+				<h1 className={styles.title}>
+					원하시는 페이지를 찾을 수 없습니다.
+				</h1>
+				<p className={styles.description}>
+					찾으려는 페이지의 주소가 잘못 입력되었거나, 주소의 변경 혹은
+					삭제로 인해 사용하실 수 없습니다. 입력하신 페이지의 주소가
+					정확한지 다시 한 번 확인해 주세요.
+				</p>
+				<Link
+					to="/"
+					className={styles.button}
+				>
+					메인으로 돌아가기
+				</Link>
+			</div>
+			<div className={styles.backgroundText}>404 Not Found</div>
+		</div>
+	);
+};
+
+export default NotFound;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #189 

## 📝 작업 내용

- 소셜 로그인 처리 중 로딩 화면을 구현했습니다. 
- 404 페이지를 구현했습니다. 


### 🖼️ 스크린샷 (선택)
- 로딩 화면
![image](https://github.com/user-attachments/assets/ab3411b6-325e-48eb-9c70-ca4247dd7536)

- 404 페이지
![image](https://github.com/user-attachments/assets/2fc714fb-da9d-4c18-a1de-c70662fcc902)


## 💬 리뷰 요구사항(선택)
파일 경로가 적절한지, 잘못된 사항이 있는지 확인해 주세요.
