### PR TITLE
[채팅-FIX] 여러 문제점 수정 

### DIFF
--- a/chat_server/app.ts
+++ b/chat_server/app.ts
@@ -1,3 +1,6 @@
+import dotenv from "dotenv";
+dotenv.config();
+
 import cookie from "cookie";
 import { createServer } from "http";
 import jwt from "jsonwebtoken";

--- a/chat_server/events/chatroom_events.ts
+++ b/chat_server/events/chatroom_events.ts
@@ -1,4 +1,9 @@
-import { IGetRoomMessageLogsResponse, IGetMyRoomRequestEvent, IReadRoomRequest, IRoomHeader } from "shared";
+import {
+	IGetRoomMessageLogsResponse,
+	IGetMyRoomRequestEvent,
+	IReadRoomRequest,
+	IRoomHeader,
+} from "shared";
 import { Socket } from "socket.io";
 
 import { httpRequest } from "../services/api_service";
@@ -12,14 +17,17 @@ export const handleRoomEvents = (socket: Socket) => {
 		// API 요청을 위해 IReadRoomRequest 타입 데이터
 		// TODO : IReadRoomRequest 데이터 "?:" 로 수정.
 		const requestData: IReadRoomRequest = {
-			page: 1,
-			perPage: 4,
+			page: data.page,
+			perPage: 2,
 			isSearch: false,
 			keyword: "",
 		};
 
 		try {
-			const response = await getMyRoomsToApi(requestData);
+			const response = await getMyRoomsToApi(
+				requestData,
+				socket.handshake.headers.cookie!
+			);
 			socket.emit("get_my_rooms", response.data);
 			console.log(response.data);
 

--- a/chat_server/utils/api.ts
+++ b/chat_server/utils/api.ts
@@ -9,8 +9,14 @@ const apiClient = axios.create({
 	},
 });
 
-export const getMyRoomsToApi = async (params: IReadRoomRequest) => {
+export const getMyRoomsToApi = async (
+	params: IReadRoomRequest,
+	cookies: string
+) => {
 	return apiClient.get(`/api/chat/rooms`, {
 		params,
+		headers: {
+			Cookie: `${cookies}`,
+		},
 	});
 };

--- a/client/src/component/Chats/ChatRooms/ChatRooms.tsx
+++ b/client/src/component/Chats/ChatRooms/ChatRooms.tsx
@@ -22,21 +22,30 @@ interface ChatRoomsProps {
 
 const ChatRooms: FC<ChatRoomsProps> = ({ socket }) => {
 	const [isOpen, setIsOpen] = useState(false);
+	const [currentPage, setCurrentPage] = useState<number>(1);
 	const isAsideOpen = true; // TODO : Aside UI 만들때 State 관리
 	const nickname = useUserStore(state => state.nickname);
 
 	useEffect(() => {
 		if (isAsideOpen) {
-			const data: IGetMyRoomRequestEvent = { nickname };
+			console.log(currentPage);
+			const data: IGetMyRoomRequestEvent = {
+				page: currentPage,
+				nickname,
+			};
 			socket?.emit("get_my_rooms", data);
 		}
-	}, [isAsideOpen, socket]);
+	}, [isAsideOpen, socket, currentPage]);
 
 	return (
 		<div className={container}>
 			{isOpen ? <CreateRoomModal close={setIsOpen} /> : null}
 			<SearchedChatRooms open={setIsOpen} />
-			<MyChatRooms socket={socket} />
+			<MyChatRooms
+				socket={socket}
+				currentPage={currentPage}
+				setCurrentPage={setCurrentPage}
+			/>
 		</div>
 	);
 };

--- a/consumer-server/package.json
+++ b/consumer-server/package.json
@@ -2,7 +2,7 @@
 	"scripts": {
 		"start": "node dist/app.js",
 		"build": "tsc -p .",
-		"dev": "nodemon --watch \"src\" --ext \"ts,js\" --exec \"ts-node\" ./src/index"
+		"dev": "nodemon --watch \"src\" --ext \"ts,js\" --exec \"ts-node\" ./src/index.ts"
 	},
 	"dependencies": {
 		"dotenv": "^16.4.5",

--- a/consumer-server/src/index.ts
+++ b/consumer-server/src/index.ts
@@ -1,4 +1,5 @@
 import dotenv from "dotenv";
+dotenv.config();
 
 import { getDBPool, initDBPool } from "./config/dbConfig";
 import { getKafkaAPI, initKafkaAPI } from "./config/kafkaConfig";
@@ -7,8 +8,6 @@ import {
 	initConsumer,
 	processMessage,
 } from "./services/kafkaService";
-
-dotenv.config();
 
 const startServer = async () => {
 	// 호스트 IP
@@ -20,12 +19,21 @@ const startServer = async () => {
 	// DB config
 	const DB_USER = process.env.DB_USER || "root";
 	const DB_PSWORD = process.env.DB_PSWORD || "root";
-	const DB_NAME = process.env.DB_USER || "community_board";
+	const DB_NAME = process.env.DB_NAME || "community_board";
 
 	// 카프카 PORT
 	const KAFKA_PORT_1 = process.env.KAFKA_PORT_1 || "9092";
 	const KAFKA_PORT_2 = process.env.KAFKA_PORT_2 || "9093";
 	const KAFKA_PORT_3 = process.env.KAFKA_PORT_3 || "9094";
+
+	console.log(`HOST_IP: ${HOST_IP}`);
+	console.log(`DB_PORT: ${DB_PORT}`);
+	console.log(`DB_USER: ${DB_USER}`);
+	console.log(`DB_PSWORD: ${DB_PSWORD}`);
+	console.log(`DB_NAME: ${DB_NAME}`);
+	console.log(`KAFKA_PORT_1: ${KAFKA_PORT_1}`);
+	console.log(`KAFKA_PORT_2: ${KAFKA_PORT_2}`);
+	console.log(`KAFKA_PORT_3: ${KAFKA_PORT_3}`);
 
 	// Broker URLs
 	const brokers: string[] = [

--- a/server/controller/chats_controller.ts
+++ b/server/controller/chats_controller.ts
@@ -109,13 +109,12 @@ export const handleRoomJoin = async (
 	try {
 		const body: IJoinRoomRequest = {
 			roomId: parseInt(req.body.roomId),
-			content: req.body.content,
 			isPrivate: req.body.isPrivate === "true",
 			password: req.body.password || "",
 		};
 		const userId = req.userId;
 
-		const result = await addUserToRoom(userId, body.roomId, body.content);
+		const result = await addUserToRoom(userId, body.roomId);
 
 		const response: IJoinRoomResponse = {
 			roomId: result,

--- a/server/controller/chats_controller.ts
+++ b/server/controller/chats_controller.ts
@@ -62,7 +62,7 @@ export const handleRoomsRead = async (
 			response.roomHeaders = result.roomHeaders;
 		} else {
 			// const userId = req.userId;
-			const userId = 1; // for. Token 검증 없이 기능 구현
+			const userId = req.userId;
 			const result = await getRoomsByUserId(
 				userId,
 				body.page,

--- a/server/db/context/chats_context.ts
+++ b/server/db/context/chats_context.ts
@@ -174,7 +174,7 @@ export const getMessageLogs = async (userId: number, roomId: number) => {
 			SELECT
 			    m.room_id,
 				u.nickname,
-				m.content,
+				m.message,
 				m.created_at,
                 m.user_id,
 				m.is_system

--- a/server/db/context/chats_context.ts
+++ b/server/db/context/chats_context.ts
@@ -197,38 +197,20 @@ export const getMessageLogs = async (userId: number, roomId: number) => {
 	}
 };
 
-export const addUserToRoom = async (
-	userId: number,
-	roomId: number,
-	content: string
-) => {
+export const addUserToRoom = async (userId: number, roomId: number) => {
 	let conn: PoolConnection | null = null;
 
 	try {
-		let sql = `INSERT INTO members (id, room_id) VALUES (?, ?)`;
-		let values: (string | number | boolean)[] = [userId, roomId];
+		const sql = `INSERT INTO members (id, room_id) VALUES (?, ?)`;
+		const values: (string | number | boolean)[] = [userId, roomId];
 		conn = await pool.getConnection();
-		conn.beginTransaction();
 		const [insertMemberRows]: any[] = await conn.query(sql, values);
 
 		if (insertMemberRows.affectedRows === 0) {
-			conn.rollback();
-			throw ServerError.reference("가입 실패");
-		}
-
-		const content = (sql = `
-				INSERT INTO messages (user_id, room_id, content, is_system)
-				VALUES (?,?,?,?)`);
-		values = [userId, roomId, content, true];
-		const [insertSystemMessageRows]: any[] = await conn.query(sql, values);
-
-		if (insertSystemMessageRows.affectedRows === 0) {
-			conn.rollback();
 			throw ServerError.reference("가입 실패");
 		}
 
 		return roomId;
-		// system message 넣기
 	} catch (err) {
 		throw err;
 	} finally {

--- a/server/db/sql/chats.sql
+++ b/server/db/sql/chats.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS messages (
     id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
     user_id INT NOT NULL,
     room_id INT NOT NULL,
-    content TEXT NOT NULL,
+    message TEXT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     is_system BOOLEAN NOT NULL,
     FOREIGN KEY (room_id) REFERENCES rooms(id),

--- a/shared/chats/chat-room.ts
+++ b/shared/chats/chat-room.ts
@@ -30,7 +30,6 @@ export interface IReadRoomResponse {
 
 export interface IJoinRoomRequest {
 	roomId: number; // 가입 할 채팅방 번호
-	content: string; // socket에서 생성한 가입 축하 인사, 이 대신 nickname 보내도 됨
 	isPrivate: boolean; // 비밀 방 여부
 	password: string; // 방 비밀번호 (null 허용)
 }

--- a/shared/chats/chat-room.ts
+++ b/shared/chats/chat-room.ts
@@ -52,5 +52,6 @@ export interface ILeaveRoomRequest {
 // 내가 속한 채팅방 조회 socket event request -------------------
 
 export interface IGetMyRoomRequestEvent {
+	page: number;
 	nickname: string;
 }


### PR DESCRIPTION
## 📝 작업 내용

### 1. 기존에 혼용되었던 field 이름 통일
- 메세지 관련 로직(함수, sql, DB column)에서 content , message가 혼용되어 사용됨
- 따라서 content -> message로 수정함

### 2. 각 디렉토리의 .env가 제대로 읽히지 않는 현상 수정
- chat_server
    - app.ts : dotenv가 명시되지 않아서 process.env에서 값을 읽어오지 못해 이를 추가함.
- 참고!
    - env파일에 환경변수를 제대로 정의했는데도 undefined로 읽히던 문제가 있었음!
    - 이유 분석
        - 각 프로젝트의 index.ts 또는 app.ts같이 서버를 실행시키기 위한 파일과 같은 위치에 .env 파일을 생성함
        - 하지만, package.json에서 정의한 script를 사용해서 서버를 실행시킴
        - 이 때, env파일을 package.json과 같은 위치에 있어야 제대로 읽어짐
        - 즉, 파일을 실행시키는 명령어를 내리는 디렉토리 위치에 env가 있어야 함!

### 3. 내 채팅방 기록 불러오기 기능 제대로 되도록 수정
- chat_server
    - api_server로 cookie를 전송함 (header에 추가함)
    - client로부터 currentPage를 받음 (해당 페이지에 속하는 채팅방 리스트를 가져오기 위함)
- client
    - currentPage 변화에 따라 해당 페이지의 채팅방 리스트를 가져오도록 변경
        - (1) 채팅방 aside 진입 시, page=1의 채팅방 리스트 불러오기 이벤트 (get_rooms) 발생
        - (2) get_rooms로 가져온 데이터를 zustand state 및 local storage에 저장
        - (3) 이후, 리렌더링해서 사용자에게 잘 보이게 함
        - (4) 다른 page 클릭 시, 다시 해당 페이지에 대한 채팅방 리스트 불러오기 이벤트 발생
        - (5) (2)~(4) 반복


## 리뷰 요구 사항

- 해당 브랜치를 로컬에서 직접 해보고 안되면 알려주세요
- 꼭 확인해주세요!