### PR TITLE
[Feature] 회원 가입 page 고도화

### DIFF
--- a/client/src/component/User/DuplicationCheckButton.tsx
+++ b/client/src/component/User/DuplicationCheckButton.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+interface Props {
+	onClick: () => void;
+}
+
+const DuplicationCheckButton: React.FC<Props> = ({ onClick }) => {
+	return (
+		<button
+			style={{
+				paddingLeft: 10,
+				paddingRight: 10,
+			}}
+			onClick={onClick}
+		>
+			중복 확인
+		</button>
+	);
+};
+
+export default DuplicationCheckButton;

--- a/client/src/component/User/EmailForm.tsx
+++ b/client/src/component/User/EmailForm.tsx
@@ -1,27 +1,29 @@
 import { FC } from "react";
-import InputField from "./InputField";
+import InputForm from "./InputForm";
 
 interface IEmailFormProps {
 	email: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	duplicationCheckFunc?: () => void;
 	isValid?: boolean;
 }
 
 const EmailForm: FC<IEmailFormProps> = ({
 	email,
 	onChange,
+	duplicationCheckFunc = () => {},
 	isValid = true,
 }) => {
 	return (
-		<InputField
-			labelText="이메일"
-			id="email"
-			type="email"
+		<InputForm
 			value={email}
+			labelText="이메일"
+			type="email"
 			onChange={onChange}
 			placeholder="이메일을 입력하세요."
 			isValid={isValid}
-			duplicateCheck={true}
+			isDuplicateCheck={true}
+			checkFunc={duplicationCheckFunc}
 		/>
 	);
 };

--- a/client/src/component/User/EmailForm.tsx
+++ b/client/src/component/User/EmailForm.tsx
@@ -5,6 +5,7 @@ interface IEmailFormProps {
 	email: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	errorMessage?: string;
+	isValid: boolean;
 	duplicationCheckFunc?: () => void;
 }
 
@@ -12,6 +13,7 @@ const EmailForm: FC<IEmailFormProps> = ({
 	email,
 	onChange,
 	errorMessage,
+	isValid,
 	duplicationCheckFunc = () => {},
 }) => {
 	return (
@@ -23,6 +25,7 @@ const EmailForm: FC<IEmailFormProps> = ({
 			placeholder="이메일을 입력하세요."
 			isDuplicateCheck={true}
 			errorMessage={errorMessage}
+			isValid={isValid}
 			checkFunc={duplicationCheckFunc}
 		/>
 	);

--- a/client/src/component/User/EmailForm.tsx
+++ b/client/src/component/User/EmailForm.tsx
@@ -21,6 +21,7 @@ const EmailForm: FC<IEmailFormProps> = ({
 			onChange={onChange}
 			placeholder="이메일을 입력하세요."
 			isValid={isValid}
+			duplicateCheck={true}
 		/>
 	);
 };

--- a/client/src/component/User/EmailForm.tsx
+++ b/client/src/component/User/EmailForm.tsx
@@ -6,6 +6,7 @@ interface IEmailFormProps {
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	errorMessage?: string;
 	isValid: boolean;
+	isDuplicateCheck?: boolean;
 	duplicationCheckFunc?: () => void;
 }
 
@@ -14,6 +15,7 @@ const EmailForm: FC<IEmailFormProps> = ({
 	onChange,
 	errorMessage,
 	isValid,
+	isDuplicateCheck = false,
 	duplicationCheckFunc = () => {},
 }) => {
 	return (
@@ -23,7 +25,7 @@ const EmailForm: FC<IEmailFormProps> = ({
 			type="email"
 			onChange={onChange}
 			placeholder="이메일을 입력하세요."
-			isDuplicateCheck={true}
+			isDuplicateCheck={isDuplicateCheck}
 			errorMessage={errorMessage}
 			isValid={isValid}
 			checkFunc={duplicationCheckFunc}

--- a/client/src/component/User/EmailForm.tsx
+++ b/client/src/component/User/EmailForm.tsx
@@ -4,15 +4,15 @@ import InputForm from "./InputForm";
 interface IEmailFormProps {
 	email: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	errorMessage?: string;
 	duplicationCheckFunc?: () => void;
-	isValid?: boolean;
 }
 
 const EmailForm: FC<IEmailFormProps> = ({
 	email,
 	onChange,
+	errorMessage,
 	duplicationCheckFunc = () => {},
-	isValid = true,
 }) => {
 	return (
 		<InputForm
@@ -21,8 +21,8 @@ const EmailForm: FC<IEmailFormProps> = ({
 			type="email"
 			onChange={onChange}
 			placeholder="이메일을 입력하세요."
-			isValid={isValid}
 			isDuplicateCheck={true}
+			errorMessage={errorMessage}
 			checkFunc={duplicationCheckFunc}
 		/>
 	);

--- a/client/src/component/User/InputField.tsx
+++ b/client/src/component/User/InputField.tsx
@@ -1,17 +1,28 @@
 import { FC, InputHTMLAttributes } from "react";
-import { input, inputBox, invalidInput, label } from "./css/InputField.css";
+import {
+	input,
+	inputBox,
+	inputWithBtn,
+	invalidInput,
+	label,
+} from "./css/InputField.css";
 import clsx from "clsx";
+import DuplicationCheckButton from "./DuplicationCheckButton";
 
 interface IInputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
 	labelText: string;
 	id: string;
 	isValid?: boolean;
+	duplicateCheck?: boolean;
+	checkFunc?: () => void;
 }
 
 const InputField: FC<IInputFieldProps> = ({
 	labelText,
 	id,
 	isValid,
+	duplicateCheck = false,
+	checkFunc = () => {},
 	...props
 }) => {
 	return (
@@ -22,11 +33,25 @@ const InputField: FC<IInputFieldProps> = ({
 			>
 				{labelText}
 			</label>
-			<input
-				className={clsx(input, { [invalidInput]: !isValid })}
-				id={id}
-				{...props}
-			/>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "row",
+					justifyContent: "space-between",
+				}}
+			>
+				<input
+					className={clsx(input, {
+						[invalidInput]: !isValid,
+						[inputWithBtn]: duplicateCheck,
+					})}
+					id={id}
+					{...props}
+				/>
+				{duplicateCheck && (
+					<DuplicationCheckButton onClick={checkFunc} />
+				)}
+			</div>
 		</div>
 	);
 };

--- a/client/src/component/User/InputField.tsx
+++ b/client/src/component/User/InputField.tsx
@@ -1,5 +1,6 @@
 import { FC, InputHTMLAttributes } from "react";
 import {
+	checkedLabel,
 	input,
 	inputBox,
 	inputWithBtn,
@@ -13,6 +14,7 @@ interface IInputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
 	labelText: string;
 	id: string;
 	isValid?: boolean;
+	isError?: boolean;
 	duplicateCheck?: boolean;
 	checkFunc?: () => void;
 }
@@ -21,6 +23,7 @@ const InputField: FC<IInputFieldProps> = ({
 	labelText,
 	id,
 	isValid,
+	isError,
 	duplicateCheck = false,
 	checkFunc = () => {},
 	...props
@@ -28,7 +31,7 @@ const InputField: FC<IInputFieldProps> = ({
 	return (
 		<div className={clsx(inputBox)}>
 			<label
-				className={label}
+				className={isValid ? checkedLabel : label}
 				htmlFor={id}
 			>
 				{labelText}
@@ -42,7 +45,7 @@ const InputField: FC<IInputFieldProps> = ({
 			>
 				<input
 					className={clsx(input, {
-						[invalidInput]: !isValid,
+						[invalidInput]: !isError,
 						[inputWithBtn]: duplicateCheck,
 					})}
 					id={id}

--- a/client/src/component/User/InputForm.tsx
+++ b/client/src/component/User/InputForm.tsx
@@ -11,7 +11,6 @@ interface IInputFormProps {
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	isDuplicateCheck: boolean;
 	checkFunc?: () => void;
-	isValid?: boolean;
 }
 
 const InputForm: FC<IInputFormProps> = ({
@@ -23,7 +22,6 @@ const InputForm: FC<IInputFormProps> = ({
 	onChange,
 	isDuplicateCheck,
 	checkFunc = () => {},
-	isValid = true,
 }) => {
 	return (
 		<div
@@ -39,11 +37,13 @@ const InputForm: FC<IInputFormProps> = ({
 				value={value}
 				onChange={onChange}
 				placeholder={placeholder}
-				isValid={isValid}
+				isValid={!errorMessage?.length}
 				duplicateCheck={isDuplicateCheck}
 				checkFunc={checkFunc}
 			/>
-			{!isValid && <ErrorMessageForm>{errorMessage}</ErrorMessageForm>}
+			{errorMessage && (
+				<ErrorMessageForm>{errorMessage}</ErrorMessageForm>
+			)}
 		</div>
 	);
 };

--- a/client/src/component/User/InputForm.tsx
+++ b/client/src/component/User/InputForm.tsx
@@ -1,0 +1,51 @@
+import { FC } from "react";
+import InputField from "./InputField";
+import ErrorMessageForm from "./ErrorMessageForm";
+
+interface IInputFormProps {
+	value: string;
+	labelText: string;
+	type: string;
+	placeholder: string;
+	errorMessage?: string;
+	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	isDuplicateCheck: boolean;
+	checkFunc?: () => void;
+	isValid?: boolean;
+}
+
+const InputForm: FC<IInputFormProps> = ({
+	value,
+	labelText,
+	type,
+	placeholder,
+	errorMessage,
+	onChange,
+	isDuplicateCheck,
+	checkFunc = () => {},
+	isValid = true,
+}) => {
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+			}}
+		>
+			<InputField
+				labelText={labelText}
+				id={type}
+				type={type}
+				value={value}
+				onChange={onChange}
+				placeholder={placeholder}
+				isValid={isValid}
+				duplicateCheck={isDuplicateCheck}
+				checkFunc={checkFunc}
+			/>
+			{!isValid && <ErrorMessageForm>{errorMessage}</ErrorMessageForm>}
+		</div>
+	);
+};
+
+export default InputForm;

--- a/client/src/component/User/InputForm.tsx
+++ b/client/src/component/User/InputForm.tsx
@@ -7,6 +7,7 @@ interface IInputFormProps {
 	labelText: string;
 	type: string;
 	placeholder: string;
+	isValid: boolean;
 	errorMessage?: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	isDuplicateCheck: boolean;
@@ -18,6 +19,7 @@ const InputForm: FC<IInputFormProps> = ({
 	labelText,
 	type,
 	placeholder,
+	isValid,
 	errorMessage,
 	onChange,
 	isDuplicateCheck,
@@ -37,7 +39,8 @@ const InputForm: FC<IInputFormProps> = ({
 				value={value}
 				onChange={onChange}
 				placeholder={placeholder}
-				isValid={!errorMessage?.length}
+				isValid={isValid}
+				isError={!errorMessage?.length}
 				duplicateCheck={isDuplicateCheck}
 				checkFunc={checkFunc}
 			/>

--- a/client/src/component/User/NicknameForm.tsx
+++ b/client/src/component/User/NicknameForm.tsx
@@ -3,27 +3,31 @@ import InputForm from "./InputForm";
 
 interface INicknameFormProps {
 	nickname: string;
+	labelText: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	duplicationCheckFunc?: () => void;
 	errorMessage?: string;
-	isValid: boolean;
+	isValid?: boolean;
+	isDuplicateCheck?: boolean;
 }
 
 const NicknameForm: FC<INicknameFormProps> = ({
 	nickname,
+	labelText,
 	onChange,
 	duplicationCheckFunc = () => {},
 	errorMessage,
-	isValid,
+	isValid = false,
+	isDuplicateCheck = false,
 }) => {
 	return (
 		<InputForm
 			value={nickname}
-			labelText="닉네임"
+			labelText={labelText}
 			type="email"
 			onChange={onChange}
 			placeholder="닉네임을 입력하세요."
-			isDuplicateCheck={true}
+			isDuplicateCheck={isDuplicateCheck}
 			errorMessage={errorMessage}
 			isValid={isValid}
 			checkFunc={duplicationCheckFunc}

--- a/client/src/component/User/NicknameForm.tsx
+++ b/client/src/component/User/NicknameForm.tsx
@@ -6,6 +6,7 @@ interface INicknameFormProps {
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	duplicationCheckFunc?: () => void;
 	errorMessage?: string;
+	isValid: boolean;
 }
 
 const NicknameForm: FC<INicknameFormProps> = ({
@@ -13,6 +14,7 @@ const NicknameForm: FC<INicknameFormProps> = ({
 	onChange,
 	duplicationCheckFunc = () => {},
 	errorMessage,
+	isValid,
 }) => {
 	return (
 		<InputForm
@@ -23,6 +25,7 @@ const NicknameForm: FC<INicknameFormProps> = ({
 			placeholder="닉네임을 입력하세요."
 			isDuplicateCheck={true}
 			errorMessage={errorMessage}
+			isValid={isValid}
 			checkFunc={duplicationCheckFunc}
 		/>
 	);

--- a/client/src/component/User/NicknameForm.tsx
+++ b/client/src/component/User/NicknameForm.tsx
@@ -23,6 +23,7 @@ const NicknameForm: FC<INicknameFormProps> = ({
 			onChange={onChange}
 			placeholder="닉네임을 입력하세요."
 			isValid={isValid}
+			duplicateCheck={true}
 		/>
 	);
 };

--- a/client/src/component/User/NicknameForm.tsx
+++ b/client/src/component/User/NicknameForm.tsx
@@ -1,29 +1,29 @@
 import { FC } from "react";
-import InputField from "./InputField";
+import InputForm from "./InputForm";
 
 interface INicknameFormProps {
-	labelText: string;
 	nickname: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	duplicationCheckFunc?: () => void;
 	isValid?: boolean;
 }
 
 const NicknameForm: FC<INicknameFormProps> = ({
-	labelText,
 	nickname,
 	onChange,
+	duplicationCheckFunc = () => {},
 	isValid = true,
 }) => {
 	return (
-		<InputField
-			labelText={labelText}
-			id="nickname"
-			type="text"
+		<InputForm
 			value={nickname}
+			labelText="닉네임"
+			type="email"
 			onChange={onChange}
 			placeholder="닉네임을 입력하세요."
 			isValid={isValid}
-			duplicateCheck={true}
+			isDuplicateCheck={true}
+			checkFunc={duplicationCheckFunc}
 		/>
 	);
 };

--- a/client/src/component/User/NicknameForm.tsx
+++ b/client/src/component/User/NicknameForm.tsx
@@ -5,14 +5,14 @@ interface INicknameFormProps {
 	nickname: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	duplicationCheckFunc?: () => void;
-	isValid?: boolean;
+	errorMessage?: string;
 }
 
 const NicknameForm: FC<INicknameFormProps> = ({
 	nickname,
 	onChange,
 	duplicationCheckFunc = () => {},
-	isValid = true,
+	errorMessage,
 }) => {
 	return (
 		<InputForm
@@ -21,8 +21,8 @@ const NicknameForm: FC<INicknameFormProps> = ({
 			type="email"
 			onChange={onChange}
 			placeholder="닉네임을 입력하세요."
-			isValid={isValid}
 			isDuplicateCheck={true}
+			errorMessage={errorMessage}
 			checkFunc={duplicationCheckFunc}
 		/>
 	);

--- a/client/src/component/User/PasswordForm.tsx
+++ b/client/src/component/User/PasswordForm.tsx
@@ -1,13 +1,14 @@
 import { FC } from "react";
 import InputField from "./InputField";
+import ErrorMessageForm from "./ErrorMessageForm";
 
 interface IPasswordFormProps {
 	labelText: string;
 	id?: string;
 	password: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-	isValid?: boolean;
 	placeholder?: string;
+	errorMessage?: string;
 }
 
 const PasswordForm: FC<IPasswordFormProps> = ({
@@ -15,25 +16,37 @@ const PasswordForm: FC<IPasswordFormProps> = ({
 	id = "password",
 	password,
 	onChange,
-	isValid = true,
 	placeholder,
+	errorMessage,
 }) => {
 	const preventCopyPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
 		e.preventDefault();
 	};
 	return (
-		<InputField
-			labelText={labelText}
-			id={id}
-			type="password"
-			value={password}
-			onChange={onChange}
-			placeholder={placeholder ? placeholder : "비밀번호를 입력하세요."}
-			isValid={isValid}
-			onCopy={preventCopyPaste}
-			onPaste={preventCopyPaste}
-			onCut={preventCopyPaste}
-		/>
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+			}}
+		>
+			<InputField
+				labelText={labelText}
+				id={id}
+				type="password"
+				value={password}
+				onChange={onChange}
+				placeholder={
+					placeholder ? placeholder : "비밀번호를 입력하세요."
+				}
+				isValid={!errorMessage?.length}
+				onCopy={preventCopyPaste}
+				onPaste={preventCopyPaste}
+				onCut={preventCopyPaste}
+			/>
+			{errorMessage && (
+				<ErrorMessageForm>{errorMessage}</ErrorMessageForm>
+			)}
+		</div>
 	);
 };
 

--- a/client/src/component/User/PasswordForm.tsx
+++ b/client/src/component/User/PasswordForm.tsx
@@ -9,6 +9,7 @@ interface IPasswordFormProps {
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	placeholder?: string;
 	errorMessage?: string;
+	isValid: boolean;
 }
 
 const PasswordForm: FC<IPasswordFormProps> = ({
@@ -18,6 +19,7 @@ const PasswordForm: FC<IPasswordFormProps> = ({
 	onChange,
 	placeholder,
 	errorMessage,
+	isValid,
 }) => {
 	const preventCopyPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
 		e.preventDefault();
@@ -38,7 +40,8 @@ const PasswordForm: FC<IPasswordFormProps> = ({
 				placeholder={
 					placeholder ? placeholder : "비밀번호를 입력하세요."
 				}
-				isValid={!errorMessage?.length}
+				isValid={isValid}
+				isError={!errorMessage?.length}
 				onCopy={preventCopyPaste}
 				onPaste={preventCopyPaste}
 				onCut={preventCopyPaste}

--- a/client/src/component/User/PasswordForm.tsx
+++ b/client/src/component/User/PasswordForm.tsx
@@ -7,6 +7,7 @@ interface IPasswordFormProps {
 	password: string;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	isValid?: boolean;
+	placeholder?: string;
 }
 
 const PasswordForm: FC<IPasswordFormProps> = ({
@@ -15,6 +16,7 @@ const PasswordForm: FC<IPasswordFormProps> = ({
 	password,
 	onChange,
 	isValid = true,
+	placeholder,
 }) => {
 	const preventCopyPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
 		e.preventDefault();
@@ -26,7 +28,7 @@ const PasswordForm: FC<IPasswordFormProps> = ({
 			type="password"
 			value={password}
 			onChange={onChange}
-			placeholder="비밀번호를 입력하세요."
+			placeholder={placeholder ? placeholder : "비밀번호를 입력하세요."}
 			isValid={isValid}
 			onCopy={preventCopyPaste}
 			onPaste={preventCopyPaste}

--- a/client/src/component/User/PasswordForm.tsx
+++ b/client/src/component/User/PasswordForm.tsx
@@ -9,7 +9,7 @@ interface IPasswordFormProps {
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	placeholder?: string;
 	errorMessage?: string;
-	isValid: boolean;
+	isValid?: boolean;
 }
 
 const PasswordForm: FC<IPasswordFormProps> = ({
@@ -19,7 +19,7 @@ const PasswordForm: FC<IPasswordFormProps> = ({
 	onChange,
 	placeholder,
 	errorMessage,
-	isValid,
+	isValid = false,
 }) => {
 	const preventCopyPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
 		e.preventDefault();

--- a/client/src/component/User/SubmitButton.tsx
+++ b/client/src/component/User/SubmitButton.tsx
@@ -4,11 +4,17 @@ import { submitButtonStyle } from "./css/SubmitButton.css";
 interface ISubmitButtonProps {
 	children: ReactNode;
 	onClick: () => void;
+	canJoin?: boolean;
 }
 
-const SubmitButton: FC<ISubmitButtonProps> = ({ children, onClick }) => {
+const SubmitButton: FC<ISubmitButtonProps> = ({
+	children,
+	onClick,
+	canJoin = true,
+}) => {
 	return (
 		<button
+			disabled={canJoin}
 			className={submitButtonStyle}
 			onClick={onClick}
 			type="submit"

--- a/client/src/component/User/SubmitButton.tsx
+++ b/client/src/component/User/SubmitButton.tsx
@@ -4,17 +4,17 @@ import { submitButtonStyle } from "./css/SubmitButton.css";
 interface ISubmitButtonProps {
 	children: ReactNode;
 	onClick: () => void;
-	canJoin?: boolean;
+	apply?: boolean;
 }
 
 const SubmitButton: FC<ISubmitButtonProps> = ({
 	children,
 	onClick,
-	canJoin = true,
+	apply = true,
 }) => {
 	return (
 		<button
-			disabled={canJoin}
+			disabled={!apply}
 			className={submitButtonStyle}
 			onClick={onClick}
 			type="submit"

--- a/client/src/component/User/SubmitButton.tsx
+++ b/client/src/component/User/SubmitButton.tsx
@@ -1,21 +1,22 @@
 import { FC, ReactNode } from "react";
-import { submitButtonStyle } from "./css/SubmitButton.css";
 
 interface ISubmitButtonProps {
 	children: ReactNode;
+	className: string;
 	onClick: () => void;
 	apply?: boolean;
 }
 
 const SubmitButton: FC<ISubmitButtonProps> = ({
 	children,
+	className,
 	onClick,
 	apply = true,
 }) => {
 	return (
 		<button
 			disabled={!apply}
-			className={submitButtonStyle}
+			className={className}
 			onClick={onClick}
 			type="submit"
 		>

--- a/client/src/component/User/SubmitButton.tsx
+++ b/client/src/component/User/SubmitButton.tsx
@@ -1,8 +1,9 @@
 import { FC, ReactNode } from "react";
+import { submitButtonStyle } from "./css/SubmitButton.css";
 
 interface ISubmitButtonProps {
 	children: ReactNode;
-	className: string;
+	className?: string;
 	onClick: () => void;
 	apply?: boolean;
 }
@@ -16,7 +17,7 @@ const SubmitButton: FC<ISubmitButtonProps> = ({
 	return (
 		<button
 			disabled={!apply}
-			className={className}
+			className={className ? className : submitButtonStyle}
 			onClick={onClick}
 			type="submit"
 		>

--- a/client/src/component/User/css/InputField.css.ts
+++ b/client/src/component/User/css/InputField.css.ts
@@ -14,6 +14,13 @@ export const label = style({
 	fontWeight: "bold",
 });
 
+export const checkedLabel = style({
+	width: "100%",
+	fontSize: "15px",
+	fontWeight: "bold",
+	color: "#36B700",
+});
+
 export const input = style({
 	width: "100%",
 	height: "40px",

--- a/client/src/component/User/css/InputField.css.ts
+++ b/client/src/component/User/css/InputField.css.ts
@@ -17,13 +17,26 @@ export const label = style({
 export const input = style({
 	width: "100%",
 	height: "40px",
-	padding: "0px",
+	paddingLeft: "10px",
+	paddingRight: "10px",
+	fontSize: "14px",
+	border: "1px solid #ccc",
+	borderRadius: "4px",
+});
+
+export const inputWithBtn = style({
+	width: "65%",
+	height: "40px",
+	paddingLeft: "10px",
+	paddingRight: "10px",
 	fontSize: "14px",
 	border: "1px solid #ccc",
 	borderRadius: "4px",
 });
 
 export const invalidInput = style({
+	paddingLeft: "10px",
+	paddingRight: "10px",
 	border: "1px solid red",
 	backgroundColor: "#ffebee",
 	color: "black",

--- a/client/src/component/User/css/SubmitButton.css.ts
+++ b/client/src/component/User/css/SubmitButton.css.ts
@@ -1,4 +1,5 @@
 import { style } from "@vanilla-extract/css";
+import { vars } from "../../../App.css";
 
 export const submitButtonStyle = style({
 	width: "100%",
@@ -8,6 +9,25 @@ export const submitButtonStyle = style({
 	borderRadius: "6px",
 	backgroundColor: "#555",
 	color: "#fff",
+	cursor: "pointer",
+	margin: "15px 0",
+	textAlign: "center",
+	fontSize: "16px",
+
+	":hover": {
+		backgroundColor: "#666",
+		opacity: 0.9,
+	},
+});
+
+export const applySubmitButtonStyle = style({
+	width: "100%",
+	height: "50px",
+	padding: "0",
+	border: "1px solid #444",
+	borderRadius: "6px",
+	backgroundColor: vars.color.successButton,
+	color: "white",
 	cursor: "pointer",
 	margin: "15px 0",
 	textAlign: "center",

--- a/client/src/page/User/Join.tsx
+++ b/client/src/page/User/Join.tsx
@@ -5,6 +5,10 @@ import SubmitButton from "../../component/User/SubmitButton";
 import NicknameForm from "../../component/User/NicknameForm";
 import { ERROR_MESSAGE, REGEX } from "./constants/constants";
 import { joinWrapper } from "./Join.css";
+import {
+	applySubmitButtonStyle,
+	submitButtonStyle,
+} from "../../component/User/css/SubmitButton.css";
 
 interface ValidateText {
 	text: string;
@@ -59,12 +63,21 @@ const Join: FC = () => {
 
 	const handlePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const isValid = REGEX.PASSWORD.test(e.target.value);
-		const errorMessage = isValid ? "" : ERROR_MESSAGE.PASSWORD_REGEX;
+		const errorMessage1 = isValid ? "" : ERROR_MESSAGE.PASSWORD_REGEX;
 
 		setPassword({
 			...password,
 			text: e.target.value,
 			isValid: isValid,
+			errorMessage: errorMessage1,
+		});
+
+		const isSame = e.target.value === requiredPassword.text;
+		const errorMessage = isSame ? "" : ERROR_MESSAGE.PASSWORD_MISMATCH;
+
+		setRequiredPassword({
+			...requiredPassword,
+			isValid: isSame,
 			errorMessage: errorMessage,
 		});
 	};
@@ -142,12 +155,14 @@ const Join: FC = () => {
 					onChange={handleEmail}
 					duplicationCheckFunc={checkEmailDuplication}
 					errorMessage={email.errorMessage}
+					isValid={email.isValid}
 				/>
 				<NicknameForm
 					nickname={nickname.text}
 					onChange={handleNickname}
 					duplicationCheckFunc={checkNicknameDuplication}
 					errorMessage={nickname.errorMessage}
+					isValid={nickname.isValid}
 				/>
 				<PasswordForm
 					password={password.text}
@@ -155,6 +170,7 @@ const Join: FC = () => {
 					labelText="비밀번호"
 					placeholder="10자 이상의 영문 대/소문자, 숫자를 사용"
 					errorMessage={password.errorMessage}
+					isValid={password.isValid}
 				/>
 				<PasswordForm
 					password={requiredPassword.text}
@@ -162,9 +178,13 @@ const Join: FC = () => {
 					onChange={handleRequiredPassword}
 					labelText="비밀번호 확인"
 					errorMessage={requiredPassword.errorMessage}
+					isValid={requiredPassword.isValid}
 				/>
 
 				<SubmitButton
+					className={
+						btnApply ? applySubmitButtonStyle : submitButtonStyle
+					}
 					onClick={() => {
 						console.log("눌럿쪙");
 					}}

--- a/client/src/page/User/Join.tsx
+++ b/client/src/page/User/Join.tsx
@@ -5,7 +5,7 @@ import SubmitButton from "../../component/User/SubmitButton";
 import NicknameForm from "../../component/User/NicknameForm";
 import ErrorMessageForm from "../../component/User/ErrorMessageForm";
 import { REGEX } from "./constants/constants";
-import { joinWrapper, passwordReqStyle } from "./Join.css";
+import { joinWrapper } from "./Join.css";
 import { sendPostJoinRequest } from "../../api/users/crud";
 import { useNavigate } from "react-router-dom";
 import { ClientError } from "../../api/errors";
@@ -165,10 +165,8 @@ const Join: FC = () => {
 				onChange={handlePasswordChange}
 				labelText="비밀번호"
 				isValid={invalidField !== "password"}
+				placeholder="10자 이상의 영문 대/소문자, 숫자를 사용"
 			/>
-			<div className={passwordReqStyle}>
-				조건 : 10자 이상의 영문 대/소문자, 숫자를 사용
-			</div>
 			<PasswordForm
 				password={requiredPassword}
 				id={"requiredPassword"}

--- a/client/src/page/User/Join.tsx
+++ b/client/src/page/User/Join.tsx
@@ -6,73 +6,12 @@ import NicknameForm from "../../component/User/NicknameForm";
 import { ERROR_MESSAGE, REGEX } from "./constants/constants";
 import { joinWrapper } from "./Join.css";
 
-// interface ValidationResult {
-// 	isValid: boolean;
-// 	errorMessage: string;
-// 	invalidField?: "email" | "password" | "requiredPassword" | "nickname";
-// }
-
 interface ValidateText {
 	text: string;
 	isValid: boolean;
 	isDuplicate?: boolean | null;
 	errorMessage: string;
 }
-
-// const createError = (
-// 	message: string,
-// 	field: ValidationResult["invalidField"]
-// ): ValidationResult => ({
-// 	isValid: false,
-// 	errorMessage: message,
-// 	invalidField: field,
-// });
-
-// const validateJoin = (
-// 	email: string,
-// 	password: string,
-// 	requiredPassword: string,
-// 	nickname: string
-// ): ValidationResult => {
-// 	const emailRegex = REGEX.EMAIL;
-// 	const passwordRegex = REGEX.PASSWORD;
-
-// 	if (!email) {
-// 		return createError("이메일을 입력하세요.", "email");
-// 	}
-
-// 	if (!emailRegex.test(email)) {
-// 		return createError("이메일 형식이 올바르지 않습니다.", "email");
-// 	}
-
-// 	if (!password) {
-// 		return createError("비밀번호를 입력하세요.", "password");
-// 	}
-
-// 	if (!passwordRegex.test(password)) {
-// 		return createError(
-// 			"비밀번호: 10자 이상의 영문 대/소문자, 숫자를 사용해 주세요.",
-// 			"password"
-// 		);
-// 	}
-
-// 	if (!requiredPassword) {
-// 		return createError("비밀번호 확인을 입력하세요.", "requiredPassword");
-// 	}
-
-// 	if (password !== requiredPassword) {
-// 		return createError("비밀번호가 일치하지 않습니다.", "requiredPassword");
-// 	}
-
-// 	if (!nickname) {
-// 		return createError("닉네임을 입력하세요.", "nickname");
-// 	}
-
-// 	return {
-// 		isValid: true,
-// 		errorMessage: "",
-// 	};
-// };
 
 const Join: FC = () => {
 	const [email, setEmail] = useState<ValidateText>({
@@ -100,14 +39,22 @@ const Join: FC = () => {
 
 	const [btnApply, setBtnApply] = useState<boolean>(false);
 
-	// handel func -----
-
 	const handleEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setEmail({ ...email, text: e.target.value, isValid: false });
+		setEmail({
+			...email,
+			text: e.target.value,
+			isValid: false,
+			errorMessage: "",
+		});
 	};
 
 	const handleNickname = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setNickname({ ...nickname, text: e.target.value, isValid: false });
+		setNickname({
+			...nickname,
+			text: e.target.value,
+			isValid: false,
+			errorMessage: "",
+		});
 	};
 
 	const handlePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -193,14 +140,14 @@ const Join: FC = () => {
 				<EmailForm
 					email={email.text}
 					onChange={handleEmail}
-					isValid={email.isValid}
 					duplicationCheckFunc={checkEmailDuplication}
+					errorMessage={email.errorMessage}
 				/>
 				<NicknameForm
 					nickname={nickname.text}
 					onChange={handleNickname}
-					isValid={nickname.isValid}
 					duplicationCheckFunc={checkNicknameDuplication}
+					errorMessage={nickname.errorMessage}
 				/>
 				<PasswordForm
 					password={password.text}

--- a/client/src/page/User/Join.tsx
+++ b/client/src/page/User/Join.tsx
@@ -83,24 +83,6 @@ const Join: FC = () => {
 
 	const navigate = useNavigate();
 
-	const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setEmail(e.target.value);
-	};
-
-	const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setPassword(e.target.value);
-	};
-
-	const handleRequiredPasswordChange = (
-		e: React.ChangeEvent<HTMLInputElement>
-	) => {
-		setRequiredPassword(e.target.value);
-	};
-
-	const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setNickname(e.target.value);
-	};
-
 	const handleJoinButton = async () => {
 		const validateResult = validateJoin(
 			email,
@@ -152,40 +134,58 @@ const Join: FC = () => {
 		}
 	};
 
+	// const emailDuplicationCheck = () => {
+	// 	// TODO : 이메일 중복 확인 API
+	// };
+
+	// const nicknameDuplicationCheck = () => {
+	// 	// TODO : 닉네임 중복 확인 API
+	// };
+
 	return (
 		<div className={joinWrapper}>
 			<h1>회원가입</h1>
-			<EmailForm
-				email={email}
-				onChange={handleEmailChange}
-				isValid={invalidField !== "email"}
-			/>
-			<PasswordForm
-				password={password}
-				onChange={handlePasswordChange}
-				labelText="비밀번호"
-				isValid={invalidField !== "password"}
-				placeholder="10자 이상의 영문 대/소문자, 숫자를 사용"
-			/>
-			<PasswordForm
-				password={requiredPassword}
-				id={"requiredPassword"}
-				onChange={handleRequiredPasswordChange}
-				labelText="비밀번호 확인"
-				isValid={invalidField !== "requiredPassword"}
-			/>
-			<NicknameForm
-				nickname={nickname}
-				onChange={handleNicknameChange}
-				labelText="닉네임"
-				isValid={invalidField !== "nickname"}
-			/>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					gap: "10px",
+				}}
+			>
+				<EmailForm
+					email={email}
+					onChange={e => setEmail(e.target.value)}
+					isValid={invalidField !== "email"}
+				/>
+				<NicknameForm
+					nickname={nickname}
+					onChange={e => setNickname(e.target.value)}
+					labelText="닉네임"
+					isValid={invalidField !== "nickname"}
+				/>
+				<PasswordForm
+					password={password}
+					onChange={e => setPassword(e.target.value)}
+					labelText="비밀번호"
+					isValid={invalidField !== "password"}
+					placeholder="10자 이상의 영문 대/소문자, 숫자를 사용"
+				/>
+				<PasswordForm
+					password={requiredPassword}
+					id={"requiredPassword"}
+					onChange={e => setRequiredPassword(e.target.value)}
+					labelText="비밀번호 확인"
+					isValid={invalidField !== "requiredPassword"}
+				/>
 
-			{errorMessage && (
-				<ErrorMessageForm>{errorMessage}</ErrorMessageForm>
-			)}
+				{errorMessage && (
+					<ErrorMessageForm>{errorMessage}</ErrorMessageForm>
+				)}
 
-			<SubmitButton onClick={handleJoinButton}>회원 가입</SubmitButton>
+				<SubmitButton onClick={handleJoinButton}>
+					회원 가입
+				</SubmitButton>
+			</div>
 		</div>
 	);
 };

--- a/client/src/page/User/Login.tsx
+++ b/client/src/page/User/Login.tsx
@@ -59,7 +59,7 @@ const Login: React.FC = () => {
 
 	const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const isValid = REGEX.PASSWORD.test(e.target.value);
-		const errorMessage = isValid ? "" : ERROR_MESSAGE.PASSWORD_REGEX;
+		const errorMessage = isValid ? "" : ERROR_MESSAGE.PASSWORD_WRONG;
 
 		setPassword({
 			...password,

--- a/client/src/page/User/Login.tsx
+++ b/client/src/page/User/Login.tsx
@@ -12,65 +12,28 @@ import {
 	iconStyle,
 	joinLink,
 } from "../../page/User/Login.css";
-import { REGEX } from "./constants/constants";
+import { ERROR_MESSAGE, REGEX } from "./constants/constants";
 import EmailForm from "../../component/User/EmailForm";
 import PasswordForm from "../../component/User/PasswordForm";
-import ErrorMessageForm from "../../component/User/ErrorMessageForm";
 import SubmitButton from "../../component/User/SubmitButton";
 import { useUserStore } from "../../state/store";
 import { ApiCall } from "../../api/api";
 import { ClientError } from "../../api/errors";
 import { sendPostLoginRequest } from "../../api/users/crud";
 import { getOAuthLoginUrl } from "../../api/users/oauth";
-
-interface ValidationResult {
-	isValid: boolean;
-	errorMessage: string;
-	invalidFields: ("email" | "password")[];
-}
-
-const createError = (
-	message: string,
-	fields: ("email" | "password")[]
-): ValidationResult => ({
-	isValid: false,
-	errorMessage: message,
-	invalidFields: fields,
-});
-
-const validateLogin = (email: string, password: string): ValidationResult => {
-	const emailRegex = REGEX.EMAIL;
-	const passwordRegex = REGEX.PASSWORD;
-
-	if (!email) {
-		return createError("이메일을 입력하세요.", ["email"]);
-	}
-
-	if (!password) {
-		return createError("비밀번호를 입력하세요.", ["password"]);
-	}
-
-	if (!emailRegex.test(email) || !passwordRegex.test(password)) {
-		return createError("이메일 또는 비밀번호가 틀렸습니다.", [
-			"email",
-			"password",
-		]);
-	}
-
-	return {
-		isValid: true,
-		errorMessage: "",
-		invalidFields: [],
-	};
-};
+import { ValidateText } from "./Join";
 
 const Login: React.FC = () => {
-	const [email, setEmail] = useState("");
-	const [password, setPassword] = useState("");
-	const [errorMessage, setErrorMessage] = useState("");
-	const [invalidFields, setInvalidFields] = useState<
-		("email" | "password")[]
-	>([]);
+	const [email, setEmail] = useState<ValidateText>({
+		text: "",
+		isValid: false,
+		errorMessage: "",
+	});
+	const [password, setPassword] = useState<ValidateText>({
+		text: "",
+		isValid: false,
+		errorMessage: "",
+	});
 
 	const { setLoginUser } = useUserStore.use.actions();
 
@@ -83,62 +46,81 @@ const Login: React.FC = () => {
 	const location = useLocation();
 
 	const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setEmail(e.target.value);
+		const isValid = REGEX.EMAIL.test(e.target.value);
+		const errorMessage = isValid ? "" : ERROR_MESSAGE.EMAIL_REGEX;
+
+		setEmail({
+			...email,
+			text: e.target.value,
+			isValid: isValid,
+			errorMessage: errorMessage,
+		});
 	};
 
 	const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setPassword(e.target.value);
+		const isValid = REGEX.PASSWORD.test(e.target.value);
+		const errorMessage = isValid ? "" : ERROR_MESSAGE.PASSWORD_REGEX;
+
+		setPassword({
+			...password,
+			text: e.target.value,
+			isValid: isValid,
+			errorMessage: errorMessage,
+		});
 	};
 
 	const handleLoginButton = async () => {
-		const validateResult = validateLogin(email, password);
+		const body = {
+			email: email.text,
+			password: password.text,
+		};
 
-		setErrorMessage(validateResult.errorMessage);
-		setInvalidFields(validateResult.invalidFields);
-
-		if (validateResult.isValid) {
-			const body = {
-				email,
-				password,
-			};
-
-			const errorHandle = (err: ClientError) => {
-				if (err.message) {
-					let message: string = err.message;
-					message = message.replace("Bad Request: ", "");
-					if (message.includes("또는")) {
-						setInvalidFields(["email", "password"]);
-						setErrorMessage(message);
-						return;
-					}
-
-					if (message.includes("이메일")) {
-						setInvalidFields(["email"]);
-						setErrorMessage(message);
-						return;
-					}
-					setErrorMessage(message);
+		const errorHandle = (err: ClientError) => {
+			if (err.message) {
+				let message: string = err.message;
+				message = message.replace("Bad Request: ", "");
+				if (message.includes("또는")) {
+					setEmail({
+						...email,
+						errorMessage: message,
+						isValid: false,
+					});
+					setPassword({
+						...password,
+						errorMessage: message,
+						isValid: false,
+					});
+					return;
 				}
-			};
 
-			const result = await ApiCall(
-				() => sendPostLoginRequest(body),
-				errorHandle
-			);
-
-			if (result instanceof ClientError) {
-				return;
+				if (message.includes("이메일")) {
+					setEmail({
+						...email,
+						errorMessage: message,
+						isValid: false,
+					});
+					return;
+				}
 			}
+		};
 
-			if (result.result) {
-				const { nickname, loginTime } = result.result;
+		const result = await ApiCall(
+			() => sendPostLoginRequest(body),
+			errorHandle
+		);
 
-				setLoginUser(nickname, loginTime);
+		if (result instanceof ClientError) {
+			return;
+		}
 
-				const redirect =
-					new URLSearchParams(location.search).get("redirect") || "/";
-				navigate(redirect);
-			}
+		if (result.result) {
+			const { nickname, loginTime } = result.result;
+
+			setLoginUser(nickname, loginTime);
+
+			const redirect =
+				new URLSearchParams(location.search).get("redirect") || "/";
+			navigate(redirect);
 		}
 	};
 
@@ -186,19 +168,18 @@ const Login: React.FC = () => {
 			<h1>로그인</h1>
 			<div>
 				<EmailForm
-					email={email}
+					email={email.text}
 					onChange={handleEmailChange}
-					isValid={!invalidFields.includes("email")}
+					isValid={email.isValid}
+					errorMessage={email.errorMessage}
 				/>
 				<PasswordForm
-					password={password}
+					password={password.text}
 					onChange={handlePasswordChange}
 					labelText="비밀번호"
-					isValid={!invalidFields.includes("password")}
+					isValid={password.isValid}
+					errorMessage={password.errorMessage}
 				/>
-				{errorMessage && (
-					<ErrorMessageForm>{errorMessage}</ErrorMessageForm>
-				)}
 				<SubmitButton onClick={handleLoginButton}>
 					로그인 버튼
 				</SubmitButton>

--- a/client/src/page/User/ProfileUpdate.tsx
+++ b/client/src/page/User/ProfileUpdate.tsx
@@ -64,7 +64,7 @@ const ProfileUpdate: FC = () => {
 			return false;
 		}
 
-		if (REGEX.PASSWORD.test(password) === false) {
+		if (!REGEX.PASSWORD.test(password)) {
 			setErrorMessage(
 				"비밀번호: 10자 이상의 영문 대/소문자, 숫자를 사용해 주세요."
 			);

--- a/client/src/page/User/constants/constants.ts
+++ b/client/src/page/User/constants/constants.ts
@@ -10,5 +10,6 @@ export const ERROR_MESSAGE = {
 	NICKNAME_REGEX: "12자 이하의 한글, 영문, 숫자를 사용해주세요.",
 	NICKNAME_DUPLE: "중복되는 닉네임입니다.",
 	PASSWORD_REGEX: "10자 이상의 영문 대/소문자, 숫자를 사용해 주세요.",
+	PASSWORD_WRONG: "비밀번호가 틀렸습니다.",
 	PASSWORD_MISMATCH: "비밀번호가 일치하지 않습니다.",
 };

--- a/client/src/page/User/constants/constants.ts
+++ b/client/src/page/User/constants/constants.ts
@@ -1,4 +1,14 @@
 export const REGEX = {
 	EMAIL: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,3}$/,
 	PASSWORD: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{10,}$/,
+	NICKNAME: /^[가-힣a-zA-Z0-9]{1,12}$/,
+};
+
+export const ERROR_MESSAGE = {
+	EMAIL_REGEX: "올바른 이메일 형식이 아닙니다.",
+	EMAIL_DUPLE: "중복되는 이메일입니다.",
+	NICKNAME_REGEX: "12자 이하의 한글, 영문, 숫자를 사용해주세요.",
+	NICKNAME_DUPLE: "중복되는 닉네임입니다.",
+	PASSWORD_REGEX: "10자 이상의 영문 대/소문자, 숫자를 사용해 주세요.",
+	PASSWORD_MISMATCH: "비밀번호가 일치하지 않습니다.",
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#206

## 📝 작업 내용

- 비밀번호 규칙 (힌트) placeholder로 보여주기
- 닉네임, 이메일 폼에 각각 중복 확인 버튼 추가
- 4개의 폼의 검증이 끝나야 회원 가입 버튼이 apply되도록 수정
- 가시적으로 폼 검증 상태 보여주도록 함.
- 로그인 폼, 프로필 업데이트 폼에서의 빌드 에러 수정

![Sep-06-2024 20-03-18](https://github.com/user-attachments/assets/42ac88f4-4fd2-49b4-8305-80df28e1f0af)

## 추가 사항

- API 사용은 next.js 마이그레이션 이후 작업할 예정입니다!