### PR TITLE
[FE] 라이트모드 스타일 임시 제거 및 클라이언트에 watch 스크립트 추가

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
-		"watch": "vite build --watch",
+		"watch": "NODE_ENV=development vite build --watch --mode development",
 		"build": "tsc -b && vite build",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"preview": "vite preview"

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
+		"watch": "vite build --watch",
 		"build": "tsc -b && vite build",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
 		"preview": "vite preview"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,7 +3,7 @@
 	line-height: 1.5;
 	font-weight: 400;
 
-	color-scheme: light dark;
+	color-scheme: /* light */ dark;
 	color: rgba(255, 255, 255, 0.87);
 	background-color: #242424;
 
@@ -47,17 +47,4 @@ button {
 button:focus,
 button:focus-visible {
 	outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-	:root {
-		color: #213547;
-		background-color: #ffffff;
-	}
-	a:hover {
-		color: #747bff;
-	}
-	button {
-		background-color: #f9f9f9;
-	}
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,4 +5,9 @@ import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
 // https://vitejs.dev/config/
 export default defineConfig({
 	plugins: [react(), vanillaExtractPlugin()],
+
+	build: {
+		chunkSizeWarningLimit:
+			process.env.NODE_ENV === "development" ? 2000 : undefined,
+	},
 });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #215

## 📝 작업 내용

- [x] 라이트모드 스타일 제거
  - 라이트모드에서 일부 콘텐츠가 보이지 않는 문제를 임시로 해결합니다.
- [x] 클라이언트에 `watch` 스크립트 추가 (`client` 디렉터리에서 `npm run watch`)
  - 클라이언트 단의 변경사항을 감지하여 자동으로 빌드하여, 수정 시마다 결과를 확인하기 위해 다시 빌드하는 번거로움을 줄입니다.
  - `development` 모드로 자동 빌드를 수행하여, 문서 구조 파악과 디버깅을 용이하게 합니다. (HTML 엘리먼트의 class 이름이 온전히 표시됩니다.)

### 🖼️ 스크린샷

<img width="412" alt="light-and-dark" src="https://github.com/user-attachments/assets/fd925a44-458d-4aaa-8f15-7419e2c8894d">

## 💬 리뷰 요구사항(선택)

- `color-scheme` 속성에서는 light를 주석 처리했고, `prefers-color-scheme: light` 미디어 쿼리는 제거했습니다. 삭제한 미디어 쿼리 부분 전체를 주석으로 남겼으면 좋겠다거나, 미디어 쿼리에서 중괄호 내부만 삭제했으면 좋겠다거나, 기타 다른 의견 있으면 말씀해 주세요.
- `watch` 스크립트는 HMR이 적용되지 않아서, 빌드 후 수동으로 새로고침을 해 주어야 하는데 괜찮은가요?
