### PR TITLE
[FE] 소셜 로그인 연동 추가/해제

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,7 +12,7 @@ import clsx from "clsx";
 import { useErrorModal } from "./state/errorModalStore";
 import { useLayoutEffect } from "react";
 import ErrorModal from "./component/utils/ErrorModal";
-import OAuthRedirectHandler from "./page/OAuthRedirectHandler";
+import OAuthRedirectHandler from "./page/OAuth/OAuthRedirectHandler";
 import ChatTestPage from "./page/Chat/ChatTestPage";
 import { AdminUserMgmtPage } from "./page/Admin/AdminUserMgmtPage";
 import { AdminPostMgmtPage } from "./page/Admin/AdminPostMgmtPage";

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import NotFound from "./page/error/NotFound";
 import { useUserStore } from "./state/store";
 import { io } from "socket.io-client";
 import { AdminUserLogPage } from "./page/Admin/AdminUserLogPage";
+import OAuthLink from "./page/OAuth/OAuthLink";
 
 function MainContainer({ children }: { children: React.ReactNode }) {
 	const location = useLocation();
@@ -31,6 +32,7 @@ function MainContainer({ children }: { children: React.ReactNode }) {
 		"/join",
 		"/checkPassword",
 		"/profileUpdate",
+		"/oauth",
 	];
 
 	return (
@@ -112,6 +114,10 @@ function App() {
 						<Route
 							path="/profileUpdate"
 							element={<ProfileUpdate />}
+						/>
+						<Route
+							path="/oauth"
+							element={<OAuthLink />}
 						/>
 						<Route
 							path="/post/:id"

--- a/client/src/api/users/crud.ts
+++ b/client/src/api/users/crud.ts
@@ -1,5 +1,9 @@
 import { HttpMethod, convertToBody, httpRequest } from "../api";
 
+export const getUserMyself = async () => {
+	return await httpRequest("user", HttpMethod.GET);
+};
+
 export const sendPostLoginRequest = async (body: object) => {
 	return await httpRequest(
 		"user/login",

--- a/client/src/api/users/oauth.ts
+++ b/client/src/api/users/oauth.ts
@@ -21,3 +21,8 @@ export const sendOAuthLoginRequest = async (
 	const requestBody = convertToBody(body);
 	return await httpRequest(apiPath, HttpMethod.POST, requestBody);
 };
+
+export const deleteOAuthConnection = async (provider: TOAuthProvider) => {
+	const apiPath = `/oauth/link/${provider}`;
+	return await httpRequest(apiPath, HttpMethod.DELETE);
+};

--- a/client/src/component/Header/DropdownMenu.tsx
+++ b/client/src/component/Header/DropdownMenu.tsx
@@ -30,6 +30,10 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
 		navigate(`/checkPassword?next=profileUpdate&final=${currentPath}`);
 	};
 
+	const handleOAuthManageClick = () => {
+		navigate(`/oauth`);
+	};
+
 	const handleWarningCorfirm = () => {
 		warningModal.close();
 		navigate(`/checkPassword?next=accountDelete`);
@@ -49,6 +53,12 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
 				className={dropdownMenuItem}
 			>
 				회원정보 변경
+			</div>
+			<div
+				onClick={handleOAuthManageClick}
+				className={dropdownMenuItem}
+			>
+				소셜 로그인 연동 관리
 			</div>
 			<div
 				onClick={warningModal.open}

--- a/client/src/component/User/OAuthLoginButtons.tsx
+++ b/client/src/component/User/OAuthLoginButtons.tsx
@@ -16,7 +16,7 @@ import {
 	socialLoginButtons,
 	socialLoginItem,
 } from "./css/OAuthLoginButtons.css";
-import { getOAuthLoginUrl } from "../../api/users/oauth";
+import { deleteOAuthConnection, getOAuthLoginUrl } from "../../api/users/oauth";
 import { ApiCall } from "../../api/api";
 import { getUserMyself } from "../../api/users/crud";
 
@@ -26,6 +26,12 @@ interface IProps {
 
 type TOAuthLinks = {
 	[provider in TOAuthProvider]?: boolean | null | undefined;
+};
+
+const providerToName: { [provider in TOAuthProvider]: string } = {
+	google: "구글",
+	kakao: "카카오",
+	naver: "네이버",
 };
 
 const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
@@ -80,6 +86,33 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 		window.location.href = response.url;
 	};
 
+	const handleUnlinkClickWith = (provider: TOAuthProvider) => async () => {
+		const confirmed = confirm(
+			`${providerToName[provider]} 로그인 연동을 해제할까요?`
+		);
+
+		if (!confirmed) {
+			return;
+		}
+
+		const response = await ApiCall(
+			() => deleteOAuthConnection(provider),
+			err => {
+				console.error(`${provider} 로그인 연동 해제 실패`, err);
+				alert(`${providerToName[provider]} 로그인 연동 해제 실패`);
+			}
+		);
+
+		if (response instanceof Error) {
+			return;
+		}
+
+		setOAuthConnections({
+			...oAuthConnections,
+			[provider]: false,
+		});
+	};
+
 	return (
 		<div className={socialLoginButtons}>
 			<div className={socialLoginItem}>
@@ -97,7 +130,10 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 				</button>
 
 				{loginType === "link" ? (
-					<button disabled={!oAuthConnections?.google}>
+					<button
+						disabled={!oAuthConnections?.google}
+						onClick={handleUnlinkClickWith("google")}
+					>
 						연동 해제
 					</button>
 				) : null}
@@ -118,7 +154,10 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 				</button>
 
 				{loginType === "link" ? (
-					<button disabled={!oAuthConnections?.naver}>
+					<button
+						disabled={!oAuthConnections?.naver}
+						onClick={handleUnlinkClickWith("naver")}
+					>
 						연동 해제
 					</button>
 				) : null}
@@ -139,7 +178,10 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 				</button>
 
 				{loginType === "link" ? (
-					<button disabled={!oAuthConnections?.kakao}>
+					<button
+						disabled={!oAuthConnections?.kakao}
+						onClick={handleUnlinkClickWith("kakao")}
+					>
 						연동 해제
 					</button>
 				) : null}

--- a/client/src/component/User/css/OAuthLoginButtons.css.ts
+++ b/client/src/component/User/css/OAuthLoginButtons.css.ts
@@ -8,7 +8,15 @@ export const socialLoginButtons = style({
 	width: "100%",
 });
 
+export const socialLoginItem = style({
+	display: "flex",
+	gap: "15px",
+	alignItems: "stretch",
+	justifyContent: "stretch",
+});
+
 const socialButton = style({
+	flexGrow: "1",
 	display: "flex",
 	alignItems: "center",
 	justifyContent: "center",
@@ -20,6 +28,13 @@ const socialButton = style({
 	cursor: "pointer",
 	color: "white",
 	transition: "transform 0.2s, box-shadow 0.2s",
+
+	selectors: {
+		"&:disabled": {
+			opacity: 0.5,
+			filter: "saturate(0.5)",
+		},
+	},
 });
 
 export const googleButton = style([

--- a/client/src/page/OAuth/OAuthLink.css.ts
+++ b/client/src/page/OAuth/OAuthLink.css.ts
@@ -1,0 +1,15 @@
+import { style } from "@vanilla-extract/css";
+
+export const oAuthLinkWrapper = style({
+	position: "relative",
+	width: "460px",
+	height: "100%",
+	boxSizing: "border-box",
+	border: "1px solid #ccc",
+	display: "flex",
+	flexDirection: "column",
+	justifyContent: "center",
+	alignItems: "stretch",
+	padding: "24px",
+	gap: "10px",
+});

--- a/client/src/page/OAuth/OAuthLink.tsx
+++ b/client/src/page/OAuth/OAuthLink.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import OAuthLoginButtons from "../../component/User/OAuthLoginButtons";
+import { oAuthLinkWrapper } from "./OAuthLink.css";
+
+const OAuthLink: React.FC = () => {
+	return (
+		<div className={oAuthLinkWrapper}>
+			<h1>소셜 로그인 연동 관리</h1>
+
+			<OAuthLoginButtons loginType="link" />
+		</div>
+	);
+};
+
+export default OAuthLink;

--- a/client/src/page/OAuth/OAuthRedirectHandler.tsx
+++ b/client/src/page/OAuth/OAuthRedirectHandler.tsx
@@ -6,10 +6,10 @@ import {
 	TOAuthLoginType,
 	TOAuthProvider,
 } from "shared";
-import { sendOAuthLoginRequest } from "../api/users/oauth";
-import { useUserStore } from "../state/store";
-import Loader from "../component/common/Loader/Loader";
-import { ApiCall } from "../api/api";
+import { sendOAuthLoginRequest } from "../../api/users/oauth";
+import { useUserStore } from "../../state/store";
+import Loader from "../../component/common/Loader/Loader";
+import { ApiCall } from "../../api/api";
 
 interface IOAuthLoginDestination {
 	ok: string;

--- a/shared/community/users/users.ts
+++ b/shared/community/users/users.ts
@@ -1,3 +1,5 @@
+import { TOAuthProvider } from "../oauth/oauths";
+
 export interface IUser {
 	id: number;
 	email: string;
@@ -5,6 +7,12 @@ export interface IUser {
 	isDelete: boolean;
 	password: string;
 	salt: string;
+}
+
+export interface INonSensitiveUser {
+	email: string | null;
+	nickname: string;
+	connected_oauth: TOAuthProvider[];
 }
 
 export interface IUserInfo {

--- a/shared/community/users/users_mapper.ts
+++ b/shared/community/users/users_mapper.ts
@@ -1,0 +1,15 @@
+import { TOAuthProvider } from "../oauth/oauths";
+import { INonSensitiveUser } from "./users";
+
+export const mapResponseToNonSensitiveUser = (
+	response: any
+): INonSensitiveUser => {
+	return {
+		email: response.email ?? null,
+		nickname: response.nickname ?? "",
+		connected_oauth:
+			response.connected_oauth instanceof Array
+				? (response.connected_oauth as TOAuthProvider[])
+				: [],
+	};
+};

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -11,6 +11,7 @@ export * from "./community/likes/likes_mapper";
 export * from "./community/posts/posts";
 export * from "./community/posts/post_mapper";
 export * from "./community/users/users";
+export * from "./community/users/users_mapper";
 export * from "./community/oauth/oauths";
 export * from "./community/oauth/oauth_mapper";
 export * from "./community/rbac";


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #214

<br>

## 📝 작업 내용

- [x] 소셜 로그인 연동 관리 페이지 작성
  - 프로바이더별 소셜 로그인 여부에 따라
    - [x] 시각적으로 다르게 표시
    - [x] 소셜 로그인 연동 해제 API 또는 소셜 로그인 연동 추가를 위한 로그인 URL로 연결
- [x] 연동 추가를 위한 소셜 로그인 후 리다이렉션 핸들링
- [x] 연동 해제 요청 전송 및 응답 핸들링
- [x] 헤더의 드롭다운 메뉴에 소셜 로그인 연동 관리 항목 추가

<br>

### 🖼️ 스크린샷

#### 드롭다운 메뉴

> <img width="160" alt="oauth-dropdown" src="https://github.com/user-attachments/assets/8a544994-b924-493a-aca7-1a3d89f94e15">

#### 소셜 로그인 연동 관리 페이지

> <img width="460" alt="oauth-management" src="https://github.com/user-attachments/assets/e729a51f-d710-44d0-9370-fcece9b4ec87">

<br>

## 💬 리뷰 요구사항

- UI 디테일은 UI 수정 작업을 진행할 때 한번에 정리하려 하는데 괜찮은가요?
- 잘못 구현되어서 수정이 필요한 부분이나, 그 외에도 변경했으면 하는 부분 있으면 말씀해 주세요.
