### PR TITLE
✨ [feat] DOCKER + NGINX 통합 배포

### DIFF
--- a/chat_server/Dockerfile
+++ b/chat_server/Dockerfile
@@ -10,7 +10,7 @@ COPY ./shared ./shared
 
 COPY ./package*.json ./
 
-COPY ./nginx/chat/.env ./chat_server
+COPY ./nginx/.env ./
 
 RUN npm install
 

--- a/chat_server/Dockerfile
+++ b/chat_server/Dockerfile
@@ -10,6 +10,8 @@ COPY ./shared ./shared
 
 COPY ./package*.json ./
 
+COPY ./nginx/chat/.env ./chat_server
+
 RUN npm install
 
 CMD npm run dev --workspace=chat_server

--- a/chat_server/app.ts
+++ b/chat_server/app.ts
@@ -10,14 +10,14 @@ import { handleChatConnection } from "./controllers/chat_controller";
 import { handleNotificationConnection } from "./controllers/notification_controller";
 import { Socket } from "dgram";
 
-dotenv.config();
+dotenv.config({ path: "./../.env" });
 
 const httpServer = createServer();
 
 // socket.io 서버 설정
 const io = new Server(httpServer, {
 	cors: {
-		origin: process.env.CORS_SERVER_ADDRESS || "http://localhost:8000",
+		origin: process.env.SERVER_ADDRESS || "http://localhost:8000",
 		credentials: true,
 	},
 });

--- a/chat_server/index.ts
+++ b/chat_server/index.ts
@@ -5,7 +5,7 @@ import { getRedisAPI, initRedisAPI } from "./config/redis_config";
 import { getKafkaAPI, initKafkaAPI } from "./config/kafka_config";
 import { getProducer, initProducer } from "./services/kafka_service";
 
-dotenv.config();
+dotenv.config({ path: "./../.env" });
 
 async function startServer() {
 	// 호스트 IP

--- a/chat_server/utils/api.ts
+++ b/chat_server/utils/api.ts
@@ -7,10 +7,10 @@ import {
 	IReadRoomRequest,
 } from "shared";
 
-dotenv.config();
+dotenv.config({ path: "./../.env" });
 
 const apiClient = axios.create({
-	baseURL: process.env.API_SERVER_ADDRESS || "http://localhost:8000",
+	baseURL: process.env.SERVER_ADDRESS || "http://localhost:8000",
 	timeout: 5000,
 	headers: {
 		"Content-Type": "application/json",

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update -y
 COPY ./client ./client
 COPY ./shared ./shared
 COPY ./package*.json ./
+COPY ./nginx/client/.env ./client
 
 RUN npm install
 RUN npm run build --workspace=client

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:latest AS build
+
+WORKDIR /app/community_board
+
+RUN apt-get update -y
+
+COPY ./client ./client
+COPY ./shared ./shared
+COPY ./package*.json ./
+
+RUN npm install
+RUN npm run build --workspace=client
+
+RUN ls -la ./client/dist
+
+# 빌드된 파일을 복사할 경로 수정
+FROM nginx:latest
+
+COPY ./nginx/default.conf /etc/nginx/conf.d
+COPY ./nginx/nginx.conf /etc/nginx
+
+# 빌드된 클라이언트 파일을 Nginx의 루트 디렉토리로 복사
+COPY --from=build /app/community_board/client/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y
 COPY ./client ./client
 COPY ./shared ./shared
 COPY ./package*.json ./
-COPY ./nginx/client/.env ./client
+COPY ./nginx/.env ./
 
 RUN npm install
 RUN npm run build --workspace=client

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
+import dotenv from "dotenv";
+
+// .env 파일 로드
+dotenv.config({ path: "./../.env" });
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,5 +13,9 @@ export default defineConfig({
 	build: {
 		chunkSizeWarningLimit:
 			process.env.NODE_ENV === "development" ? 2000 : undefined,
+	},
+
+	define: {
+		"process.env": process.env,
 	},
 });

--- a/consumer-server/Dockerfile
+++ b/consumer-server/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -y
 
 COPY ./consumer-server ./consumer-server
 COPY ./shared ./shared
-
 COPY ./package*.json ./
+COPY ./nginx/consumer/.env ./consumer-server
 
 RUN npm install
 

--- a/consumer-server/Dockerfile
+++ b/consumer-server/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y
 COPY ./consumer-server ./consumer-server
 COPY ./shared ./shared
 COPY ./package*.json ./
-COPY ./nginx/consumer/.env ./consumer-server
+COPY ./nginx/.env ./
 
 RUN npm install
 

--- a/consumer-server/src/config/dbConfig.ts
+++ b/consumer-server/src/config/dbConfig.ts
@@ -1,7 +1,7 @@
 import dotenv from "dotenv";
 import mariaDB, { Pool, PoolOptions } from "mysql2/promise";
 
-dotenv.config();
+dotenv.config({ path: "./../.env" });
 
 /**
  * DB Pool 객체

--- a/consumer-server/src/index.ts
+++ b/consumer-server/src/index.ts
@@ -1,5 +1,5 @@
 import dotenv from "dotenv";
-dotenv.config();
+dotenv.config({ path: "./../.env" });
 
 import { getDBPool, initDBPool } from "./config/dbConfig";
 import { getKafkaAPI, initKafkaAPI } from "./config/kafkaConfig";

--- a/docker-command.sh
+++ b/docker-command.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ $1 == "ka" ]; then
+    docker-compose -f docker-compose-kafka.yaml -p kafka up -d
+elif [ $1 == "co" ]; then
+    docker-compose -f docker-compose-server.yaml -p community up -d
+elif [ $1 == "del-ka" ]; then
+    docker-compose -f docker-compose-kafka.yaml -p kafka down
+elif [ $1 == "del-co" ]; then
+    docker-compose -f docker-compose-server.yaml -p community down
+elif [ $1 == "del-cache" ]; then
+    docker system prune --all --volumes
+elif [ $1 == "push" ]; then
+  docker push hungkunge/community_board;
+else
+    echo "wrong command!";
+fi

--- a/docker-command.sh
+++ b/docker-command.sh
@@ -4,6 +4,10 @@ if [ $1 == "ka" ]; then
     docker-compose -f docker-compose-kafka.yaml -p kafka up -d
 elif [ $1 == "co" ]; then
     docker-compose -f docker-compose-server.yaml -p community up -d
+elif [ $1 == "db" ]; then
+    cd sql;
+    docker-compose -f docker-compose.yaml up -d;
+    cd ..;
 elif [ $1 == "del-ka" ]; then
     docker-compose -f docker-compose-kafka.yaml -p kafka down
 elif [ $1 == "del-co" ]; then

--- a/docker-compose-server.yaml
+++ b/docker-compose-server.yaml
@@ -1,4 +1,13 @@
 services:
+    client:
+        build:
+            dockerfile: ./client/Dockerfile
+        container_name: client
+        ports:
+            - 80:80
+        networks:
+            - app-network
+
     api-server:
         build:
             dockerfile: ./server/Dockerfile

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api {
+        proxy_pass http://api-server:9000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -14,4 +14,15 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    location /socket.io {
+            proxy_pass http://chat-server:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,15 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,16 +4,12 @@ WORKDIR /app/community_board
 
 RUN apt-get update -y
 
-COPY ./client ./client
 COPY ./server ./server
-# COPY ./chat_server ./chat_server
-# COPY ./consumer-server ./consumer-server
+
 COPY ./shared ./shared
 
 COPY ./package*.json ./
 
 RUN npm install
-
-RUN npm run build --workspace=client
 
 CMD npm run dev --workspace=server

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,10 +5,9 @@ WORKDIR /app/community_board
 RUN apt-get update -y
 
 COPY ./server ./server
-
 COPY ./shared ./shared
-
 COPY ./package*.json ./
+COPY ./nginx/server/.env ./server
 
 RUN npm install
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y
 COPY ./server ./server
 COPY ./shared ./shared
 COPY ./package*.json ./
-COPY ./nginx/server/.env ./server
+COPY ./nginx/.env ./
 
 RUN npm install
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -9,7 +9,7 @@ import { errorHandler } from "./middleware/errors";
 import cookieParser from "cookie-parser";
 import { authToken } from "./middleware/auth";
 
-dotenv.config();
+dotenv.config({ path: "./../.env" });
 const app = express();
 // app 등록
 app.use(cookieParser());

--- a/server/db/connect.ts
+++ b/server/db/connect.ts
@@ -1,7 +1,7 @@
 import mariaDB from "mysql2/promise";
 import dotenv from "dotenv";
 
-dotenv.config();
+dotenv.config({ path: "./../.env" });
 
 const port = process.env.DB_PORT ? parseInt(process.env.DB_PORT) : 3306;
 const config = {

--- a/server/utils/token.ts
+++ b/server/utils/token.ts
@@ -3,7 +3,7 @@ import dotenv from "dotenv";
 import { ServerError } from "../middleware/errors";
 import { getRefreshToken } from "../db/context/token_context";
 
-dotenv.config();
+dotenv.config({ path: "./../.env" });
 
 interface IToken extends jwt.JwtPayload {
 	userId: number;

--- a/shared/package.json
+++ b/shared/package.json
@@ -2,5 +2,8 @@
 	"name": "shared",
 	"version": "1.0.0",
 	"main": "index.ts",
-	"types": "index.ts"
+	"types": "index.ts",
+	"dependencies": {
+		"mysql2": "^3.10.2"
+	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#209

## 📝 작업 내용

### NGINX와 아키텍쳐
- 아키텍쳐 수정
> 흰 박스는 docker container를 의미함 
> <img width="600" alt="스크린샷 2024-09-12 오후 11 27 43" src="https://github.com/user-attachments/assets/658acb42-b569-4a9a-b817-348d5ea7c95b">
> [미리캔버스 주소](https://www.miricanvas.com/v2/design/13incan)

- static 파일 요청 시, react build 파일 제공 (web server 역할)
> 실제 코드
```
     location / {
        root /usr/share/nginx/html;
        index index.html;
        try_files $uri $uri/ /index.html;
    }
```

- 서버 연결 요청을 관리 (proxy server 역할)
> 실제 코드
```
    location /api {
        proxy_pass http://api-server:9000;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }

    location /socket.io {
            proxy_pass http://chat-server:3000;
            proxy_http_version 1.1;
            proxy_set_header Upgrade $http_upgrade;
            proxy_set_header Connection "Upgrade";
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
    }
```

### docker 빌드 관련 처리

- 각 디렉토리마다 Dockerfile 추가
- docker-compose 파일 분리
- 빌드에 사용하는 명령어를 모아놓은 docker-command.sh 추가

### .env 통합

- 기존에는 각 디렉토리마다 env파일이 있어 세팅이 불편했음
- 따라서 env파일 하나만 관리하도록 참조 코드를 변경함.

## 세팅 (필수)

### env 파일 생성 (필수) + 기존 env 삭제
- project의 root 디렉토리에 .env 생성
- 아래와 같은 환경 변수 정의하기 (요청 시, 제공)
```
# Database
DB_HOST
DB_NAME
DB_USER
DB_PSWORD
DB_PORT

# Docker (+redis, kafka)
DOCKER_HOST_IP
REDIS_PORT
KAFKA_PORT_1
KAFKA_PORT_2
KAFKA_PORT_3

# Server
PORT

ACCESS_TOKEN_KEY
REFRESH_TOKEN_KEY
TEMP_TOKEN_KEY

# Chat
SERVER_ADDRESS
CHAT_PORT
HTTP_PORT

# Consumer
API_SERVER_ADDRESS

# Client
VITE_SERVER_ADDRESS
VITE_CHAT_ADDRESS
```

## 세팅 (nginx 해보실 분만)

### 1. nginx 디렉토리에도 .env 추가
- 기존 env 환경 변수에서 localhost -> host.docker.internal로 변경
- ADDRESS가 붙은 환경변수는 모두 http://client:80으로 변경
- 단, VITE가 붙은 환경변수는 http://localhost:80으로 변경
- 잘 안되면 알려주세요!

### 2. docker-command 권한부여
```sh
    chmod 777 docker-command.sh
```

### 3. 명령어를 통해서 docker-compose 빌드하기 (순서대로)
```sh
# mariadb 빌드
./docker-command.sh db

# kafka 빌드
./docker-command.sh ka

# community_board 빌드
./docker-command.sh co
```

### 4. localhost:80에 접속하기

## 💬 리뷰 요구사항(선택)

> 해보시고 안되면 알려주세요
> 머지 되면 멀티 플랫폼 이미지 빌드로 넘어갈 예정입니다
