### PR TITLE
[FE] 소셜 로그인 가입 유저의 이메일 등록

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import { useUserStore } from "./state/store";
 import { io } from "socket.io-client";
 import { AdminUserLogPage } from "./page/Admin/AdminUserLogPage";
 import OAuthLink from "./page/OAuth/OAuthLink";
+import EmailRegistration from "./page/User/EmailRegistration";
 
 function MainContainer({ children }: { children: React.ReactNode }) {
 	const location = useLocation();
@@ -32,6 +33,7 @@ function MainContainer({ children }: { children: React.ReactNode }) {
 		"/join",
 		"/checkPassword",
 		"/profileUpdate",
+		"/emailRegistration",
 		"/oauth",
 	];
 
@@ -114,6 +116,10 @@ function App() {
 						<Route
 							path="/profileUpdate"
 							element={<ProfileUpdate />}
+						/>
+						<Route
+							path="/emailRegistration"
+							element={<EmailRegistration />}
 						/>
 						<Route
 							path="/oauth"

--- a/client/src/component/Header/DropdownMenu.tsx
+++ b/client/src/component/Header/DropdownMenu.tsx
@@ -1,7 +1,10 @@
-import { forwardRef, ForwardRefRenderFunction } from "react";
+import { forwardRef, ForwardRefRenderFunction, useLayoutEffect } from "react";
 import { dropdownMenu, dropdownMenuItem } from "./DropdownMenu.css";
 import { NavigateFunction } from "react-router-dom";
 import UserDeleteModal from "./UserDeleteModal";
+import { useUserStore } from "../../state/store";
+import { ApiCall } from "../../api/api";
+import { getUserMyself } from "../../api/users/crud";
 
 interface DropdownMenuProps {
 	navigate: NavigateFunction;
@@ -22,10 +25,33 @@ const DropdownMenu: ForwardRefRenderFunction<
 	HTMLDivElement,
 	DropdownMenuProps
 > = ({ navigate, warningModal }, ref) => {
+	const isEmailRegistered = useUserStore.use.isEmailRegistered();
+	const { setIsEmailRegistered } = useUserStore.use.actions();
+
 	const currentPath = window.location.pathname;
+
+	useLayoutEffect(() => {
+		// TODO: isEmailRegistered를 로그인 시 받아서 저장하도록 서버와 클라이언트 수정 필요
+		ApiCall(
+			() => getUserMyself(),
+			err => {
+				console.error("사용자 정보를 가져올 수 없습니다.", err);
+			}
+		).then(response => {
+			if (response instanceof Error) {
+				return;
+			}
+
+			setIsEmailRegistered(!!response.email);
+		});
+	}, []);
 
 	const handleProfileUpdateClick = () => {
 		navigate(`/checkPassword?next=profileUpdate&final=${currentPath}`);
+	};
+
+	const handleEmailRegistrationClick = () => {
+		navigate(`/checkPassword?next=emailRegistration&final=${currentPath}`);
 	};
 
 	const handleOAuthManageClick = () => {
@@ -52,6 +78,14 @@ const DropdownMenu: ForwardRefRenderFunction<
 			>
 				회원정보 변경
 			</div>
+			{isEmailRegistered || (
+				<div
+					onClick={handleEmailRegistrationClick}
+					className={dropdownMenuItem}
+				>
+					로그인 이메일 등록
+				</div>
+			)}
 			<div
 				onClick={handleOAuthManageClick}
 				className={dropdownMenuItem}

--- a/client/src/component/Header/DropdownMenu.tsx
+++ b/client/src/component/Header/DropdownMenu.tsx
@@ -1,10 +1,9 @@
-import { FC } from "react";
+import { forwardRef, ForwardRefRenderFunction } from "react";
 import { dropdownMenu, dropdownMenuItem } from "./DropdownMenu.css";
 import { NavigateFunction } from "react-router-dom";
 import UserDeleteModal from "./UserDeleteModal";
 
 interface DropdownMenuProps {
-	ref: React.RefObject<HTMLDivElement>;
 	navigate: NavigateFunction;
 	warningModal: { isOpen: boolean; open: () => void; close: () => void };
 }
@@ -19,11 +18,10 @@ const MODAL_CONFIGS = {
 	},
 };
 
-const DropdownMenu: FC<DropdownMenuProps> = ({
-	ref,
-	navigate,
-	warningModal,
-}) => {
+const DropdownMenu: ForwardRefRenderFunction<
+	HTMLDivElement,
+	DropdownMenuProps
+> = ({ navigate, warningModal }, ref) => {
 	const currentPath = window.location.pathname;
 
 	const handleProfileUpdateClick = () => {
@@ -84,4 +82,4 @@ const DropdownMenu: FC<DropdownMenuProps> = ({
 	);
 };
 
-export default DropdownMenu;
+export default forwardRef(DropdownMenu);

--- a/client/src/component/Header/Header.tsx
+++ b/client/src/component/Header/Header.tsx
@@ -148,13 +148,13 @@ const Header: React.FC = () => {
 							/>
 						)}
 					</div>
-					{isUserMenuOpen &&
-						isLogin &&
-						DropdownMenu({
-							ref: dropdownMenuRef,
-							navigate: navigate,
-							warningModal: warningModal,
-						})}
+					{isUserMenuOpen && isLogin && (
+						<DropdownMenu
+							ref={dropdownMenuRef}
+							navigate={navigate}
+							warningModal={warningModal}
+						/>
+					)}
 				</div>
 			</div>
 		</div>

--- a/client/src/hook/useStringWithValidation.ts
+++ b/client/src/hook/useStringWithValidation.ts
@@ -1,0 +1,73 @@
+import { useState } from "react";
+
+type TValidateFn = (
+	value: string,
+	pass: () => void,
+	fail: (message: string) => void
+) => void;
+
+interface IStringWithValidation {
+	value: string;
+	isValid: boolean;
+	errorMessage: string;
+
+	/**
+	 * 주어진 값으로 데이터를 갱신하면서, 그 값으로 유효성 검사를 진행합니다.
+	 * @param value - 새 값
+	 * @param validateFn - 유효성 검사 함수 (기본값: `clearValidation`)
+	 */
+	setValue: (value: string, validateFn?: TValidateFn) => void;
+
+	/**
+	 * 현재 값으로 유효성 검사를 진행합니다.
+	 * @param validateFn - 유효성 검사 함수
+	 */
+	setValidation: (validateFn: TValidateFn) => void;
+
+	/**
+	 * 유효성 검사 정보를 제거합니다.
+	 */
+	clearValidation: () => void;
+}
+
+export const useStringWithValidation = (): IStringWithValidation => {
+	const [text, setText] = useState("");
+	const [isValid, setIsValid] = useState(false);
+	const [errorMessage, setErrorMessage] = useState("");
+
+	const setValidationPass = () => {
+		setIsValid(true);
+		setErrorMessage("");
+	};
+
+	const setValidationFail = (message: string) => {
+		setIsValid(false);
+		setErrorMessage(message);
+	};
+
+	const clearValidation = () => {
+		setIsValid(false);
+		setErrorMessage("");
+	};
+
+	const setValidation = (validateFn: TValidateFn = clearValidation) => {
+		validateFn(text, setValidationPass, setValidationFail);
+	};
+
+	const setValue = (
+		value: string,
+		validateFn: TValidateFn = clearValidation
+	) => {
+		setText(value);
+		validateFn(value, setValidationPass, setValidationFail);
+	};
+
+	return {
+		value: text,
+		isValid,
+		errorMessage,
+		setValue,
+		setValidation,
+		clearValidation,
+	};
+};

--- a/client/src/page/OAuth/OAuthLink.css.ts
+++ b/client/src/page/OAuth/OAuthLink.css.ts
@@ -1,15 +1,15 @@
 import { style } from "@vanilla-extract/css";
 
 export const oAuthLinkWrapper = style({
-	position: "relative",
-	width: "460px",
-	height: "100%",
-	boxSizing: "border-box",
-	border: "1px solid #ccc",
-	display: "flex",
-	flexDirection: "column",
-	justifyContent: "center",
-	alignItems: "stretch",
-	padding: "24px",
-	gap: "10px",
+	width: "100%",
+	maxWidth: "350px",
+	margin: "0 auto",
+	padding: "20px",
+	boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+	borderRadius: "15px",
+	backgroundColor: "#333",
+});
+
+export const oAuthLinkTitle = style({
+	marginBottom: "40px",
 });

--- a/client/src/page/OAuth/OAuthLink.tsx
+++ b/client/src/page/OAuth/OAuthLink.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import OAuthLoginButtons from "../../component/User/OAuthLoginButtons";
-import { oAuthLinkWrapper } from "./OAuthLink.css";
+import { oAuthLinkTitle, oAuthLinkWrapper } from "./OAuthLink.css";
 
 const OAuthLink: React.FC = () => {
 	return (
 		<div className={oAuthLinkWrapper}>
-			<h1>소셜 로그인 연동 관리</h1>
+			<h1 className={oAuthLinkTitle}>소셜 로그인 연동 관리</h1>
 
 			<OAuthLoginButtons loginType="link" />
 		</div>

--- a/client/src/page/OAuth/OAuthRedirectHandler.tsx
+++ b/client/src/page/OAuth/OAuthRedirectHandler.tsx
@@ -35,18 +35,22 @@ const getDestination = (
 		};
 	} else if (loginType === "reconfirm") {
 		const nextAction = prevSearch.get("next");
+		const final = prevSearch.get("final") ?? "/";
 
-		if (nextAction === "profileUpdate") {
-			const search = new URLSearchParams();
-			search.set("final", prevSearch.get("final") ?? "/");
-
+		if (!nextAction) {
+			alert("재인증 후 수행할 동작이 없습니다.");
 			return {
-				ok: `/profileUpdate?${search.toString()}`,
+				ok: prevLocation,
 				err: prevLocation,
 			};
 		} else if (nextAction === "accountDelete") {
 			return {
 				ok: "/checkPassword?next=accountDelete&oAuthConfirmed=true",
+				err: prevLocation,
+			};
+		} else {
+			return {
+				ok: `/${nextAction}?final=${final}`,
 				err: prevLocation,
 			};
 		}

--- a/client/src/page/User/CheckPassword.css.ts
+++ b/client/src/page/User/CheckPassword.css.ts
@@ -10,6 +10,9 @@ export const checkPasswordWrapper = style({
 	backgroundColor: "#333",
 });
 
-export const noPasswordMessage = style({
-	margin: "24px 0 0 0",
+export const labelWithoutPassword = style({
+	margin: "0",
+	textAlign: "left",
+	fontSize: "15px",
+	fontWeight: "700",
 });

--- a/client/src/page/User/CheckPassword.css.ts
+++ b/client/src/page/User/CheckPassword.css.ts
@@ -1,17 +1,13 @@
 import { style } from "@vanilla-extract/css";
 
 export const checkPasswordWrapper = style({
-	position: "relative",
-	width: "460px",
-	height: "100%",
-	boxSizing: "border-box",
-	border: "1px solid #ccc",
-	display: "flex",
-	flexDirection: "column",
-	justifyContent: "center",
-	alignItems: "stretch",
-	padding: "24px",
-	gap: "10px",
+	width: "100%",
+	maxWidth: "350px",
+	margin: "0 auto",
+	padding: "20px",
+	boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+	borderRadius: "15px",
+	backgroundColor: "#333",
 });
 
 export const noPasswordMessage = style({

--- a/client/src/page/User/CheckPassword.tsx
+++ b/client/src/page/User/CheckPassword.tsx
@@ -6,7 +6,10 @@ import {
 } from "../../api/users/crud";
 import PasswordForm from "../../component/User/PasswordForm";
 import SubmitButton from "../../component/User/SubmitButton";
-import { checkPasswordWrapper, noPasswordMessage } from "./CheckPassword.css";
+import {
+	checkPasswordWrapper,
+	labelWithoutPassword,
+} from "./CheckPassword.css";
 import { REGEX } from "./constants/constants";
 import { useModal } from "../../hook/useModal";
 import UserDeleteModal from "../../component/Header/UserDeleteModal";
@@ -35,6 +38,7 @@ const CheckPassword: FC = () => {
 	const oAuthConfirmed = searchParams.get("oAuthConfirmed");
 
 	const { setLogoutUser } = useUserStore.use.actions();
+	const isEmailRegistered = useUserStore.use.isEmailRegistered();
 
 	const finalModal = useModal();
 
@@ -120,17 +124,23 @@ const CheckPassword: FC = () => {
 	return (
 		<>
 			<div className={checkPasswordWrapper}>
-				<PasswordForm
-					labelText="비밀번호 재확인"
-					password={password}
-					onChange={handlePasswordChange}
-				/>
-				<SubmitButton onClick={handleSubmit}>확인</SubmitButton>
-
-				<p className={noPasswordMessage}>
-					소셜 로그인으로 가입해서 비밀번호가 없다면
-				</p>
-				<OAuthLoginButtons loginType="reconfirm" />
+				{isEmailRegistered ? (
+					<>
+						<PasswordForm
+							labelText="비밀번호 재확인"
+							password={password}
+							onChange={handlePasswordChange}
+						/>
+						<SubmitButton onClick={handleSubmit}>확인</SubmitButton>
+					</>
+				) : (
+					<>
+						<p className={labelWithoutPassword}>
+							소셜 로그인으로 계정 소유 확인
+						</p>
+						<OAuthLoginButtons loginType="reconfirm" />
+					</>
+				)}
 			</div>
 
 			<UserDeleteModal

--- a/client/src/page/User/CheckPassword.tsx
+++ b/client/src/page/User/CheckPassword.tsx
@@ -31,7 +31,7 @@ const CheckPassword: FC = () => {
 
 	const searchParams = new URLSearchParams(location.search);
 	const next = searchParams.get("next");
-	const final = searchParams.get("final");
+	const final = searchParams.get("final") || "/";
 	const oAuthConfirmed = searchParams.get("oAuthConfirmed");
 
 	const { setLogoutUser } = useUserStore.use.actions();
@@ -82,7 +82,11 @@ const CheckPassword: FC = () => {
 			return;
 		}
 
-		if (next === "accountDelete") {
+		if (!next) {
+			alert("비밀번호 재확인 이후 진행할 동작이 없습니다.");
+			navigate("/");
+			return;
+		} else if (next === "accountDelete") {
 			finalModal.open();
 			return;
 		}

--- a/client/src/page/User/Join.css.ts
+++ b/client/src/page/User/Join.css.ts
@@ -10,6 +10,12 @@ export const joinWrapper = style({
 	backgroundColor: "#333",
 });
 
+export const joinForm = style({
+	display: "flex",
+	flexDirection: "column",
+	gap: "10px",
+});
+
 export const passwordReqStyle = style({
 	color: "gray",
 	fontSize: "12px",

--- a/client/src/page/User/Join.tsx
+++ b/client/src/page/User/Join.tsx
@@ -4,7 +4,7 @@ import PasswordForm from "../../component/User/PasswordForm";
 import SubmitButton from "../../component/User/SubmitButton";
 import NicknameForm from "../../component/User/NicknameForm";
 import { ERROR_MESSAGE, REGEX } from "./constants/constants";
-import { joinWrapper } from "./Join.css";
+import { joinForm, joinWrapper } from "./Join.css";
 import {
 	applySubmitButtonStyle,
 	submitButtonStyle,
@@ -136,13 +136,7 @@ const Join: FC = () => {
 	return (
 		<div className={joinWrapper}>
 			<h1>회원가입</h1>
-			<div
-				style={{
-					display: "flex",
-					flexDirection: "column",
-					gap: "10px",
-				}}
-			>
+			<div className={joinForm}>
 				<EmailForm
 					email={email.value}
 					onChange={handleEmail}

--- a/client/src/page/User/Join.tsx
+++ b/client/src/page/User/Join.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useMemo } from "react";
 import EmailForm from "../../component/User/EmailForm";
 import PasswordForm from "../../component/User/PasswordForm";
 import SubmitButton from "../../component/User/SubmitButton";
@@ -21,8 +21,6 @@ const Join: FC = () => {
 	const nickname = useStringWithValidation();
 	const password = useStringWithValidation();
 	const requiredPassword = useStringWithValidation();
-
-	const [btnApply, setBtnApply] = useState<boolean>(false);
 
 	const handleEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
 		email.setValue(e.target.value);
@@ -62,23 +60,19 @@ const Join: FC = () => {
 		});
 	};
 
-	useEffect(() => {
-		if (
+	const btnApply = useMemo(
+		() =>
 			email.isValid &&
 			nickname.isValid &&
 			password.isValid &&
-			requiredPassword.isValid
-		) {
-			setBtnApply(true);
-		} else {
-			setBtnApply(false);
-		}
-	}, [
-		email.isValid,
-		nickname.isValid,
-		password.isValid,
-		requiredPassword.isValid,
-	]);
+			requiredPassword.isValid,
+		[
+			email.isValid,
+			nickname.isValid,
+			password.isValid,
+			requiredPassword.isValid,
+		]
+	);
 
 	const checkEmailDuplication = () => {
 		email.setValidation((value, pass, fail) => {

--- a/client/src/page/User/Login.css.ts
+++ b/client/src/page/User/Login.css.ts
@@ -10,6 +10,12 @@ export const loginContainer = style({
 	backgroundColor: "#333",
 });
 
+export const loginForm = style({
+	display: "flex",
+	flexDirection: "column",
+	gap: "10px",
+});
+
 export const loginButton = style({
 	padding: "12px",
 	backgroundColor: "#444",
@@ -20,6 +26,10 @@ export const loginButton = style({
 	cursor: "pointer",
 });
 
+export const joinText = style({
+	marginBottom: "0",
+});
+
 export const joinLink = style({
 	marginTop: "10px",
 	textAlign: "center",
@@ -27,27 +37,3 @@ export const joinLink = style({
 	color: "#007BFF",
 	cursor: "pointer",
 });
-
-// export const loginWrapper = style({
-// 	position: "relative",
-// 	width: "460px",
-// 	height: "100%",
-// 	boxSizing: "border-box",
-// 	border: "1px solid #ccc",
-// 	display: "flex",
-// 	flexDirection: "column",
-// 	justifyContent: "center",
-// 	alignItems: "center",
-// 	padding: "24px",
-// 	gap: "10px",
-// });
-
-// export const joinLink = style({
-// 	width: "100%",
-// 	padding: "0px",
-// 	cursor: "pointer",
-// 	":hover": {
-// 		textDecoration: "underline",
-// 		color: "blue",
-// 	},
-// });

--- a/client/src/page/User/Login.tsx
+++ b/client/src/page/User/Login.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { loginContainer, joinLink } from "../../page/User/Login.css";
+import {
+	loginContainer,
+	joinLink,
+	loginForm,
+	joinText,
+} from "../../page/User/Login.css";
 import { REGEX } from "./constants/constants";
 import EmailForm from "../../component/User/EmailForm";
 import PasswordForm from "../../component/User/PasswordForm";
@@ -90,7 +95,7 @@ const Login: React.FC = () => {
 	return (
 		<div className={loginContainer}>
 			<h1>로그인</h1>
-			<div>
+			<div className={loginForm}>
 				<EmailForm
 					email={email.value}
 					onChange={handleEmailChange}
@@ -110,7 +115,7 @@ const Login: React.FC = () => {
 				<SubmitButton onClick={handleLoginButton}>
 					로그인 버튼
 				</SubmitButton>
-				<p>
+				<p className={joinText}>
 					계정이 없으신가요?
 					<a
 						href="/join"

--- a/client/src/page/User/Login.tsx
+++ b/client/src/page/User/Login.tsx
@@ -81,6 +81,8 @@ const Login: React.FC = () => {
 			return;
 		}
 
+		// TODO: isEmailRegistered를 로그인 시 받아서 저장하도록 수정 필요.
+		//       수정 후 DropdownMenu 컴포넌트의 유저 정보 조회 API 호출 제거.
 		if (result.result) {
 			const { nickname, loginTime } = result.result;
 

--- a/client/src/page/User/Login.tsx
+++ b/client/src/page/User/Login.tsx
@@ -9,21 +9,13 @@ import { useUserStore } from "../../state/store";
 import { ApiCall } from "../../api/api";
 import { ClientError } from "../../api/errors";
 import { sendPostLoginRequest } from "../../api/users/crud";
-import { ValidateText } from "./Join";
 import ErrorMessageForm from "../../component/User/ErrorMessageForm";
 import OAuthLoginButtons from "../../component/User/OAuthLoginButtons";
+import { useStringWithValidation } from "../../hook/useStringWithValidation";
 
 const Login: React.FC = () => {
-	const [email, setEmail] = useState<ValidateText>({
-		text: "",
-		isValid: false,
-		errorMessage: "",
-	});
-	const [password, setPassword] = useState<ValidateText>({
-		text: "",
-		isValid: false,
-		errorMessage: "",
-	});
+	const email = useStringWithValidation();
+	const password = useStringWithValidation();
 
 	const [errorMessage, setErrorMessage] = useState<string>("");
 
@@ -38,33 +30,33 @@ const Login: React.FC = () => {
 	const location = useLocation();
 
 	const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const isValid = REGEX.EMAIL.test(e.target.value);
-
 		setErrorMessage("");
-		setEmail({
-			...email,
-			text: e.target.value,
-			isValid: isValid,
-			errorMessage: "",
+
+		email.setValue(e.target.value, (value, pass, fail) => {
+			if (REGEX.EMAIL.test(value)) {
+				pass();
+			} else {
+				fail("");
+			}
 		});
 	};
 
 	const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const isValid = REGEX.PASSWORD.test(e.target.value);
-
 		setErrorMessage("");
-		setPassword({
-			...password,
-			text: e.target.value,
-			isValid: isValid,
-			errorMessage: "",
+
+		password.setValue(e.target.value, (value, pass, fail) => {
+			if (REGEX.PASSWORD.test(value)) {
+				pass();
+			} else {
+				fail("");
+			}
 		});
 	};
 
 	const handleLoginButton = async () => {
 		const body = {
-			email: email.text,
-			password: password.text,
+			email: email.value,
+			password: password.value,
 		};
 
 		const errorHandle = (err: ClientError) => {
@@ -100,13 +92,13 @@ const Login: React.FC = () => {
 			<h1>로그인</h1>
 			<div>
 				<EmailForm
-					email={email.text}
+					email={email.value}
 					onChange={handleEmailChange}
 					isValid={email.isValid}
 					errorMessage={email.errorMessage}
 				/>
 				<PasswordForm
-					password={password.text}
+					password={password.value}
 					onChange={handlePasswordChange}
 					labelText="비밀번호"
 					isValid={password.isValid}

--- a/client/src/page/User/ProfileUpdate.css.ts
+++ b/client/src/page/User/ProfileUpdate.css.ts
@@ -1,16 +1,18 @@
 import { style } from "@vanilla-extract/css";
 
 export const profileUpdateWrapper = style({
-	position: "relative",
-	width: "460px",
-	height: "100%",
-	boxSizing: "border-box",
-	border: "1px solid #ccc",
+	width: "100%",
+	maxWidth: "350px",
+	margin: "0 auto",
+	padding: "20px",
+	boxShadow: "0 4px 8px rgba(0, 0, 0, 0.1)",
+	borderRadius: "15px",
+	backgroundColor: "#333",
+});
+
+export const profileUpdateForm = style({
 	display: "flex",
 	flexDirection: "column",
-	justifyContent: "center",
-	alignItems: "stretch",
-	padding: "24px",
 	gap: "10px",
 });
 

--- a/client/src/page/User/ProfileUpdate.tsx
+++ b/client/src/page/User/ProfileUpdate.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useEffect, useState } from "react";
+import { ChangeEvent, FC, useEffect, useMemo, useState } from "react";
 import { mapResponseToNonSensitiveUser } from "shared";
 import NicknameForm from "../../component/User/NicknameForm";
 import PasswordForm from "../../component/User/PasswordForm";
@@ -8,7 +8,7 @@ import {
 	profileUpdateWrapper,
 } from "./ProfileUpdate.css";
 import SubmitButton from "../../component/User/SubmitButton";
-import { REGEX } from "./constants/constants";
+import { ERROR_MESSAGE, REGEX } from "./constants/constants";
 import ErrorMessageForm from "../../component/User/ErrorMessageForm";
 import { getUserMyself, sendPutUpdateUserRequest } from "../../api/users/crud";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -16,6 +16,11 @@ import { useUserStore } from "../../state/store";
 import { ApiCall } from "../../api/api";
 import { ClientError } from "../../api/errors";
 import EmailForm from "../../component/User/EmailForm";
+import { useStringWithValidation } from "../../hook/useStringWithValidation";
+import {
+	applySubmitButtonStyle,
+	submitButtonStyle,
+} from "../../component/User/css/SubmitButton.css";
 
 interface IProfileUpdatePayload {
 	email?: string | undefined;
@@ -36,10 +41,10 @@ const ProfileUpdate: FC = () => {
 	const final = searchParams.get("final");
 
 	const [hasEmail, setHasEmail] = useState(true);
-	const [email, setEmail] = useState("");
-	const [nickname, setNickname] = useState("");
-	const [password, setPassword] = useState("");
-	const [requiredPassword, setRequiredPassword] = useState("");
+	const email = useStringWithValidation();
+	const nickname = useStringWithValidation();
+	const password = useStringWithValidation();
+	const requiredPassword = useStringWithValidation();
 	const [errorMessage, setErrorMessage] = useState("");
 
 	const { setNickName: storeSetNickName } = useUserStore.use.actions();
@@ -59,44 +64,6 @@ const ProfileUpdate: FC = () => {
 			setHasEmail(!!user.email);
 		});
 	}, []);
-
-	const validateProfileUpdate = (): boolean => {
-		if (!hasEmail && !email) {
-			setErrorMessage("이메일을 입력하세요.");
-			return false;
-		}
-
-		if (!nickname) {
-			setErrorMessage("닉네임을 입력하세요.");
-			return false;
-		}
-
-		if (nickname === storeNickName) {
-			setErrorMessage("기존 닉네임과 동일합니다.");
-			return false;
-		}
-
-		if (!password) {
-			setErrorMessage("비밀번호를 입력하세요.");
-			return false;
-		}
-		if (!requiredPassword) {
-			setErrorMessage("비밀번호가 서로 다릅니다.");
-			return false;
-		}
-		if (password !== requiredPassword) {
-			setErrorMessage("비밀번호가 일치하지 않습니다.");
-			return false;
-		}
-
-		if (!REGEX.PASSWORD.test(password)) {
-			setErrorMessage(
-				"비밀번호: 10자 이상의 영문 대/소문자, 숫자를 사용해 주세요."
-			);
-			return false;
-		}
-		return true;
-	};
 
 	const handleError = (err: ClientError) => {
 		if (err.code === 400) {
@@ -123,31 +90,98 @@ const ProfileUpdate: FC = () => {
 	};
 
 	const handleEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
-		setEmail(e.target.value);
+		email.setValue(e.target.value);
 	};
 
 	const handleNicknameChange = (e: ChangeEvent<HTMLInputElement>) => {
-		setNickname(e.target.value);
+		nickname.setValue(e.target.value, (value, _pass, fail) => {
+			if (value === storeNickName) {
+				fail("현재 닉네임과 동일합니다.");
+			} else {
+				fail("");
+			}
+		});
 	};
 
 	const handlePasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
-		setPassword(e.target.value);
+		password.setValue(e.target.value, (value, pass, fail) => {
+			if (REGEX.PASSWORD.test(value)) {
+				pass();
+			} else {
+				fail(ERROR_MESSAGE.PASSWORD_REGEX);
+			}
+		});
+
+		requiredPassword.setValidation((value, pass, fail) => {
+			if (!value) {
+				fail("");
+			} else if (e.target.value === value) {
+				pass();
+			} else {
+				fail(ERROR_MESSAGE.PASSWORD_MISMATCH);
+			}
+		});
 	};
 
 	const handleRequiredPasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
-		setRequiredPassword(e.target.value);
+		requiredPassword.setValue(e.target.value, (value, pass, fail) => {
+			if (password.value === value) {
+				pass();
+			} else {
+				fail(ERROR_MESSAGE.PASSWORD_MISMATCH);
+			}
+		});
+	};
+
+	const btnApply = useMemo(
+		() =>
+			email.isValid &&
+			nickname.isValid &&
+			password.isValid &&
+			requiredPassword.isValid,
+		[
+			email.isValid,
+			nickname.isValid,
+			password.isValid,
+			requiredPassword.isValid,
+		]
+	);
+
+	const checkEmailDuplication = () => {
+		email.setValidation((value, pass, fail) => {
+			if (!REGEX.EMAIL.test(value)) {
+				fail(ERROR_MESSAGE.EMAIL_REGEX);
+				return;
+			}
+
+			// TODO : api 호출해서 중복 확인
+
+			pass();
+		});
+	};
+
+	const checkNicknameDuplication = () => {
+		nickname.setValidation((value, pass, fail) => {
+			if (!REGEX.NICKNAME.test(value)) {
+				fail(ERROR_MESSAGE.NICKNAME_REGEX);
+				return;
+			}
+
+			// TODO : api 호출해서 중복 확인
+
+			pass();
+		});
 	};
 
 	const handleSubmit = async () => {
-		if (!validateProfileUpdate()) {
-			return;
-		}
-
 		const result: IProfileUpdateResult = await ApiCall(() => {
-			const payload: IProfileUpdatePayload = { nickname, password };
+			const payload: IProfileUpdatePayload = {
+				nickname: nickname.value,
+				password: password.value,
+			};
 
 			if (!hasEmail) {
-				payload.email = email;
+				payload.email = email.value;
 			}
 
 			return sendPutUpdateUserRequest(payload);
@@ -159,7 +193,7 @@ const ProfileUpdate: FC = () => {
 
 		navigate(final || "/");
 
-		storeSetNickName(nickname);
+		storeSetNickName(nickname.value);
 
 		alert("유저 정보가 변경되었습니다.");
 	};
@@ -173,26 +207,37 @@ const ProfileUpdate: FC = () => {
 			<h1>유저 정보 수정</h1>
 			{hasEmail || (
 				<EmailForm
-					email={email}
+					email={email.value}
 					onChange={handleEmailChange}
-					isValid={false}
+					errorMessage={email.errorMessage}
+					isValid={email.isValid}
+					isDuplicateCheck={true}
+					duplicationCheckFunc={checkEmailDuplication}
 				/>
 			)}
 			<NicknameForm
 				labelText="변경할 닉네임"
-				nickname={nickname}
+				nickname={nickname.value}
 				onChange={handleNicknameChange}
+				errorMessage={nickname.errorMessage}
+				isValid={nickname.isValid}
+				isDuplicateCheck={true}
+				duplicationCheckFunc={checkNicknameDuplication}
 			/>
 			<PasswordForm
 				labelText={"변경할 비밀번호"}
-				password={password}
+				password={password.value}
 				onChange={handlePasswordChange}
+				errorMessage={password.errorMessage}
+				isValid={password.isValid}
 			/>
 			<PasswordForm
 				labelText={"비밀번호 확인"}
 				id="requiredPassword"
-				password={requiredPassword}
+				password={requiredPassword.value}
 				onChange={handleRequiredPasswordChange}
+				errorMessage={requiredPassword.errorMessage}
+				isValid={requiredPassword.isValid}
 			/>
 			{errorMessage && (
 				<ErrorMessageForm>{errorMessage}</ErrorMessageForm>
@@ -204,7 +249,13 @@ const ProfileUpdate: FC = () => {
 				>
 					취소
 				</button>
-				<SubmitButton onClick={handleSubmit}>
+				<SubmitButton
+					className={
+						btnApply ? applySubmitButtonStyle : submitButtonStyle
+					}
+					onClick={handleSubmit}
+					apply={btnApply}
+				>
 					유저 정보 변경
 				</SubmitButton>
 			</div>

--- a/client/src/page/User/ProfileUpdate.tsx
+++ b/client/src/page/User/ProfileUpdate.tsx
@@ -5,6 +5,7 @@ import PasswordForm from "../../component/User/PasswordForm";
 import {
 	buttonsWrapper,
 	cancleButton,
+	profileUpdateForm,
 	profileUpdateWrapper,
 } from "./ProfileUpdate.css";
 import SubmitButton from "../../component/User/SubmitButton";
@@ -205,59 +206,65 @@ const ProfileUpdate: FC = () => {
 	return (
 		<div className={profileUpdateWrapper}>
 			<h1>유저 정보 수정</h1>
-			{hasEmail || (
-				<EmailForm
-					email={email.value}
-					onChange={handleEmailChange}
-					errorMessage={email.errorMessage}
-					isValid={email.isValid}
+
+			<div className={profileUpdateForm}>
+				{hasEmail || (
+					<EmailForm
+						email={email.value}
+						onChange={handleEmailChange}
+						errorMessage={email.errorMessage}
+						isValid={email.isValid}
+						isDuplicateCheck={true}
+						duplicationCheckFunc={checkEmailDuplication}
+					/>
+				)}
+				<NicknameForm
+					labelText="변경할 닉네임"
+					nickname={nickname.value}
+					onChange={handleNicknameChange}
+					errorMessage={nickname.errorMessage}
+					isValid={nickname.isValid}
 					isDuplicateCheck={true}
-					duplicationCheckFunc={checkEmailDuplication}
+					duplicationCheckFunc={checkNicknameDuplication}
 				/>
-			)}
-			<NicknameForm
-				labelText="변경할 닉네임"
-				nickname={nickname.value}
-				onChange={handleNicknameChange}
-				errorMessage={nickname.errorMessage}
-				isValid={nickname.isValid}
-				isDuplicateCheck={true}
-				duplicationCheckFunc={checkNicknameDuplication}
-			/>
-			<PasswordForm
-				labelText={"변경할 비밀번호"}
-				password={password.value}
-				onChange={handlePasswordChange}
-				errorMessage={password.errorMessage}
-				isValid={password.isValid}
-			/>
-			<PasswordForm
-				labelText={"비밀번호 확인"}
-				id="requiredPassword"
-				password={requiredPassword.value}
-				onChange={handleRequiredPasswordChange}
-				errorMessage={requiredPassword.errorMessage}
-				isValid={requiredPassword.isValid}
-			/>
-			{errorMessage && (
-				<ErrorMessageForm>{errorMessage}</ErrorMessageForm>
-			)}
-			<div className={buttonsWrapper}>
-				<button
-					className={cancleButton}
-					onClick={handleCancle}
-				>
-					취소
-				</button>
-				<SubmitButton
-					className={
-						btnApply ? applySubmitButtonStyle : submitButtonStyle
-					}
-					onClick={handleSubmit}
-					apply={btnApply}
-				>
-					유저 정보 변경
-				</SubmitButton>
+				<PasswordForm
+					labelText={"변경할 비밀번호"}
+					password={password.value}
+					onChange={handlePasswordChange}
+					errorMessage={password.errorMessage}
+					isValid={password.isValid}
+				/>
+				<PasswordForm
+					labelText={"비밀번호 확인"}
+					id="requiredPassword"
+					password={requiredPassword.value}
+					onChange={handleRequiredPasswordChange}
+					errorMessage={requiredPassword.errorMessage}
+					isValid={requiredPassword.isValid}
+				/>
+				{errorMessage && (
+					<ErrorMessageForm>{errorMessage}</ErrorMessageForm>
+				)}
+
+				<div className={buttonsWrapper}>
+					<button
+						className={cancleButton}
+						onClick={handleCancle}
+					>
+						취소
+					</button>
+					<SubmitButton
+						className={
+							btnApply
+								? applySubmitButtonStyle
+								: submitButtonStyle
+						}
+						onClick={handleSubmit}
+						apply={btnApply}
+					>
+						유저 정보 변경
+					</SubmitButton>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/src/page/User/ProfileUpdate.tsx
+++ b/client/src/page/User/ProfileUpdate.tsx
@@ -136,11 +136,12 @@ const ProfileUpdate: FC = () => {
 
 	const btnApply = useMemo(
 		() =>
-			email.isValid &&
+			(hasEmail || email.isValid) &&
 			nickname.isValid &&
 			password.isValid &&
 			requiredPassword.isValid,
 		[
+			hasEmail,
 			email.isValid,
 			nickname.isValid,
 			password.isValid,

--- a/client/src/state/store.ts
+++ b/client/src/state/store.ts
@@ -7,6 +7,7 @@ interface IUserState {
 	nickname: string;
 	loginTime: string;
 	isLogin: boolean;
+	isEmailRegistered: boolean;
 	socket: Socket | null;
 }
 
@@ -14,6 +15,7 @@ interface IUserActions {
 	setNickName: (nickName: string) => void;
 	setLoginTime: (loginTime: string) => void;
 	setIsLogin: (isLogin: boolean) => void;
+	setIsEmailRegistered: (isEmailRegistered: boolean) => void;
 	setSocket: (socket: Socket | null) => void;
 	setLoginUser: (nickname: string, loginTime: string) => void;
 	setLogoutUser: () => void;
@@ -28,6 +30,7 @@ const useUserStoreBase = create<TUserStore>()(
 				nickname: "",
 				loginTime: "",
 				isLogin: false,
+				isEmailRegistered: false,
 				socket: null,
 
 				actions: {
@@ -36,6 +39,8 @@ const useUserStoreBase = create<TUserStore>()(
 					setLoginTime: (loginTime: string) => set({ loginTime }),
 					setIsLogin: (isLogin: boolean) => set({ isLogin }),
 					setSocket: socket => set({ socket }),
+					setIsEmailRegistered: (isEmailRegistered: boolean) =>
+						set({ isEmailRegistered }),
 					setLoginUser: (nickname: string, loginTime: string) =>
 						set({
 							nickname,
@@ -64,6 +69,7 @@ const useUserStoreBase = create<TUserStore>()(
 				nickname: state.nickname,
 				loginTime: state.loginTime,
 				isLogin: state.isLogin,
+				isEmailRegistered: state.isEmailRegistered,
 			}),
 		}
 	)

--- a/server/db/context/users_context.ts
+++ b/server/db/context/users_context.ts
@@ -81,7 +81,7 @@ export const addUser = async (userData: IUserRegData) => {
 		return rows;
 	} catch (err: any) {
 		if (err.code === "ER_DUP_ENTRY") {
-			handleDupEntry(err.sqlMessage as string, userData.email);
+			await handleDupEntry(err.sqlMessage as string, userData.email);
 		}
 
 		throw err;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #214

<br>

## 📝 작업 내용

- [x] 유저 정보 수정 페이지에 이메일 필드 추가
  - 이메일을 등록하지 않은 유저에게만 이메일 필드 노출 (즉, 최초 1회만 이메일 등록 가능)
- [x] 회원가입 유효성 검사의 공통 동작 추출
- [x] 유저 정보 수정 페이지의 폼 검증 방법을 회원가입과 비슷하게 변경
- [x] 회원 DB 등록 중 이메일 중복 발생 시 서버 에러 수정
  - 이메일 중복 발생 시 Express 서버가 아예 죽어 버려서 일단 수정했습니다.

<br>

### 🖼️ 스크린샷

https://github.com/user-attachments/assets/077072f9-863a-4839-99d3-2cf97c6e67ed

<br>

## 💬 리뷰 요구사항

- 잘못 구현되어서 수정이 필요한 부분이나, 그 외에도 변경했으면 하는 부분 있으면 말씀해 주세요.