### PR TITLE
🐛 [fix] : role_permission 테이블 생성 안되는 오류 수정

### DIFF
--- a/sql/09_role_permission.sql
+++ b/sql/09_role_permission.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS role_permission (
     role_id INTEGER,
     permission_id INTEGER,
-    PRIMARY KEY (role_id, permission_id) ON DELETE CASCADE,
+    PRIMARY KEY (role_id, permission_id),
     FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
     FOREIGN KEY (permission_id) REFERENCES permissions(id) ON DELETE CASCADE
 );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #203

## 📝 작업 내용

- role_permission 테이블이 생성시 오류가 발생하여 그 뒤의 테이블이 생성되지 않던 오류 수정
  - PRIMARY KEY 정의에서 잘못된 'ON DELETE CASCADE' 구문 제거


### 🖼️ 스크린샷

![image](https://github.com/user-attachments/assets/57035ed3-7ddf-498e-a111-5a139d3fa524)


## 💬 리뷰 요구사항

- 프로젝트 db세팅하고 관련된 사항인거같아서 전체 팀원에게 reviewers를 남겼습니다.

