### PR TITLE
[BE] 게시물 API 마이그레이션 수정

### DIFF
--- a/nestjs-migration/src/post/dto/delete-post.dto.ts
+++ b/nestjs-migration/src/post/dto/delete-post.dto.ts
@@ -1,0 +1,6 @@
+import { User } from "src/user/entities/user.entity";
+
+export class DeletePostDto {
+    postId: number;
+    authorId: number;
+}

--- a/nestjs-migration/src/post/dto/get-post-headers.dto.ts
+++ b/nestjs-migration/src/post/dto/get-post-headers.dto.ts
@@ -10,7 +10,3 @@ export class getPostHeadersDto {
     @Transform(({value})=> parseInt(value))
     likes: number;
 }
-export class asdf {
-    
-
-}

--- a/nestjs-migration/src/post/dto/get-post-headers.dto.ts
+++ b/nestjs-migration/src/post/dto/get-post-headers.dto.ts
@@ -1,11 +1,14 @@
+import { Transform } from "class-transformer";
 
 export class getPostHeadersDto {
-    id;
-    title;
-    nickname;
-    created_at
-    views
-    likes
+    id: number;
+    title: string;
+    nickname: string;
+    created_at: Date;
+    views: number;
+
+    @Transform(({value})=> parseInt(value))
+    likes: number;
 }
 export class asdf {
     

--- a/nestjs-migration/src/post/dto/update-post.dto.ts
+++ b/nestjs-migration/src/post/dto/update-post.dto.ts
@@ -3,12 +3,12 @@ import { POST_ERROR_MESSAGES } from "../constant/post.constants";
 
 
 export class UpdatePostBodyDto {
+	@ValidateIf(p => p.content == "" && p.title == "")
 	@IsNotEmpty({ message : POST_ERROR_MESSAGES.NOCHANGE })
-	@ValidateIf(p => p.content === undefined)
     title: string;
 
+	@ValidateIf(p => p.content == "" && p.title == "")
     @IsNotEmpty({ message: POST_ERROR_MESSAGES.NOCHANGE})
-	@ValidateIf(p => p.title === undefined)
     content: string;
 
 	doFilter: boolean;

--- a/nestjs-migration/src/post/dto/update-post.dto.ts
+++ b/nestjs-migration/src/post/dto/update-post.dto.ts
@@ -1,5 +1,6 @@
 import { IsNotEmpty, ValidateIf } from "class-validator";
 import { POST_ERROR_MESSAGES } from "../constant/post.constants";
+import { User } from "src/user/entities/user.entity";
 
 
 export class UpdatePostBodyDto {

--- a/nestjs-migration/src/post/entities/post.entity.ts
+++ b/nestjs-migration/src/post/entities/post.entity.ts
@@ -14,19 +14,19 @@ export class Post {
     @Column()
     content: string
     
-    @CreateDateColumn({ name: "created_at", default: false })
+    @CreateDateColumn({ name: "created_at"})
     createdAt: Date
 
-    @UpdateDateColumn({ name: "updated_at", default: false })
+    @UpdateDateColumn({ name: "updated_at"})
     updatedAt: Date
 
-    @Column()
+    @Column({default: 0})
     views: number
 
-    @Column({ name: "is_delete" })
+    @Column({ name: "is_delete" ,default: 0})
     isDelete: number
 
-    @Column({ name: "is_private"})
+    @Column({ name: "is_private", default: 0})
     isPrivate: number
 
     @ManyToOne(type=> User, user => user.posts)

--- a/nestjs-migration/src/post/post.controller.spec.ts
+++ b/nestjs-migration/src/post/post.controller.spec.ts
@@ -81,11 +81,7 @@ describe("PostController", () => {
 			);
 			jest.spyOn(postService, "createPost").mockRejectedValue(error);
 
-      const result = await postController.handlePostCreate(invalidPostDto, mockReq);
-
-			expect(result).toEqual({
-        message: `${error.name}: ${error.message}`,
-      });
+			await expect(postController.handlePostCreate(invalidPostDto, mockReq)).rejects.toThrow(error);
 	});
 
 	describe("GET /post", () => {
@@ -181,11 +177,8 @@ describe("PostController", () => {
 			const error = ServerError.badRequest("잘못된 입력입니다");
 			jest.spyOn(mockPostService, "updatePost").mockRejectedValue(error);
 
-      const result = await postController.handlePostUpdate(mockPostId, updateBodyDto, mockReq);
-      console.log(result)
-      expect(result).toEqual({
-        message: `${error.name}: ${error.message}`
-		  });
+			await expect(postController.handlePostUpdate(mockPostId, updateBodyDto, mockReq)).rejects.toThrow(error);
+
     });
 	});
 	describe("DELETE /post/:post_id", () => {
@@ -205,10 +198,7 @@ describe("PostController", () => {
 			const error = ServerError.badRequest("잘못된 입력입니다");
 			jest.spyOn(mockPostService, "deletePost").mockRejectedValue(error);
 
-      const result = await postController.handlePostDelete(mockPostId, mockReq);
-      expect(result).toEqual({
-        message: `${error.name}: ${error.message}`
-		  });
+			await expect(postController.handlePostDelete(mockPostId, mockReq)).rejects.toThrow(error);
 		});
 	});
 });

--- a/nestjs-migration/src/post/post.controller.spec.ts
+++ b/nestjs-migration/src/post/post.controller.spec.ts
@@ -4,6 +4,7 @@ import { PostService } from "./post.service";
 import {  CreatePostDto } from "./dto/create-post.dto";
 import { ServerError } from "../common/exceptions/server-error.exception";
 import { POST_ERROR_MESSAGES } from "./constant/post.constants";
+import { ReadPostsQueryDto } from "./dto/read-posts-query.dto";
 
 describe("PostController", () => {
 	let postController: PostController;
@@ -21,6 +22,11 @@ describe("PostController", () => {
 	let mockReq: any;
 	let mockUserId: number;
 	let mockPostId: number;
+	mockUserId = 1;
+	mockPostId = 9;
+	mockReq = {
+		user: { userId: mockUserId },
+	} as any;
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
@@ -35,26 +41,21 @@ describe("PostController", () => {
 
 		postController = module.get<PostController>(PostController);
 		postService = module.get<PostService>(PostService);
-
-		mockUserId = 1;
-		mockPostId = 9;
-		mockReq = {
-			user: { userId: mockUserId },
-		} as any;
 	});
 
 	describe("POST /post", () => {
 		const mockCreatePostDto: CreatePostDto = {
 			title: "Test Title",
 			content: "Test Content",
-      authorId: mockUserId,
+     		authorId: mockUserId,
 			doFilter: true,
 		};
 
 		it("게시물 생성 성공", async () => {
-			jest.spyOn(mockPostService, "createPost").mockResolvedValue(
+			mockPostService.createPost.mockResolvedValue(
 				mockPostId
 			);
+			
 			const result = await postController.handlePostCreate(
 				mockCreatePostDto,
 				mockReq
@@ -79,24 +80,30 @@ describe("PostController", () => {
 			const error = ServerError.badRequest(
 				POST_ERROR_MESSAGES.REQUIRE_CONTENT
 			);
-			jest.spyOn(postService, "createPost").mockRejectedValue(error);
+			mockPostService.createPost.mockRejectedValue(error);
 
 			await expect(postController.handlePostCreate(invalidPostDto, mockReq)).rejects.toThrow(error);
+		});
 	});
 
 	describe("GET /post", () => {
-		const mockReadPostsQueryDto = {};
+		const mockReadPostsQueryDto: ReadPostsQueryDto = {};
 
 		it("전체 게시물 조회 성공", async () => {
 			const mockTotalPosts = 5;
-			const mockPostHeaders = [];
-
-			jest.spyOn(mockPostService, "findPostHeaders").mockResolvedValue(
-				mockPostHeaders
-			);
-			jest.spyOn(mockPostService, "findPostTotal").mockResolvedValue(
-				mockTotalPosts
-			);
+			const mockPostHeaders = [
+						{
+								"id": 32,
+								"title": "finally",
+								"author_nickname": "moon",
+								"created_at": "2024-09-18T17:46:59.000Z",
+								"views": 0,
+								"likes": "0"
+						}
+			];
+			
+			mockPostService.findPostHeaders.mockResolvedValue(mockPostHeaders);
+			mockPostService.findPostTotal.mockResolvedValue(mockTotalPosts);
 
 			expect(
 				await postController.handlePostsRead(
@@ -112,36 +119,44 @@ describe("PostController", () => {
 		it("전체 게시물 조회 실패 시 에러를 반환한다.", async () => {
 			const error = ServerError.badRequest("잘못된 입력입니다");
 
-			jest.spyOn(mockPostService, "findPostHeaders").mockRejectedValue(
-				error
-			);
-			jest.spyOn(mockPostService, "findPostTotal").mockRejectedValue(
-				error
-			);
+			mockPostService.findPostHeaders.mockRejectedValue(error);
+			mockPostService.findPostTotal.mockRejectedValue(error);
 
 			await expect(
 				postController.handlePostsRead(mockReadPostsQueryDto, mockReq)
 			).rejects.toThrow(error);
 		});
 	});
+
 	describe("GET /post/:post_id", () => {
-		const mockPostId = 1;
 
 		it("개별 게시물 조회 성공", async () => {
-			const mockEachPost = [];
-			jest.spyOn(mockPostService, "findPost").mockResolvedValue(
-				mockEachPost
-			);
+			const mockEachPost =  {
+						"id": 17,
+						"title": "5번째 게시물",
+						"content": "게시물 내용을 입력",
+						"author_id": 1,
+						"author_nickname": "moon",
+						"is_author": 0,
+						"created_at": "2024-09-18T02:00:07.000Z",
+						"updated_at": null,
+						"views": 0,
+						"user_liked": 0,
+						"likes": "3"
+				};
+
+			mockPostService.findPost.mockResolvedValue(mockEachPost);
 
 			expect(
 				await postController.handlePostRead(mockPostId, mockReq)
 			).toEqual({
-				post: [],
+				post: mockEachPost,
 			});
 		});
+		
 		it("개별 게시물 조회 실패 시 에러를 반환한다.", async () => {
 			const error = ServerError.badRequest("잘못된 입력입니다");
-			jest.spyOn(mockPostService, "findPost").mockRejectedValue(error);
+			mockPostService.findPost.mockRejectedValue(error);
 
 			await expect(
 				postController.handlePostRead(mockPostId, mockReq)
@@ -150,56 +165,56 @@ describe("PostController", () => {
 	});
 
 	describe("PATCH /post/:post_id", () => {
-		const mockPostId = 1;
 		const updateBodyDto = {
 			title: "title",
 			content: "content",
 			doFilter: true,
 		};
 		it("게시물 수정 성공", async () => {
-			mockPostService.updatePost.mockResolvedValue([]);
+			mockPostService.updatePost.mockResolvedValue(undefined);
 
-      const result = await postController.handlePostUpdate(
-        mockPostId,
-        updateBodyDto,
-        mockReq
-      );
+			const result = await postController.handlePostUpdate(
+				mockPostId,
+				updateBodyDto,
+				mockReq
+			);
 
-      expect(postService.updatePost).toHaveBeenCalledWith(mockPostId, {
-        ...updateBodyDto,
-        authorId: mockUserId,
-      });
+			expect(postService.updatePost).toHaveBeenCalledWith(mockPostId, {
+				...updateBodyDto,
+				authorId: mockUserId,
+			});
 			expect(result).toEqual({
 				message: "게시글 수정 success",
 			});
 		});
 		it("게시물 수정 실패 시 에러를 반환한다.", async () => {
 			const error = ServerError.badRequest("잘못된 입력입니다");
-			jest.spyOn(mockPostService, "updatePost").mockRejectedValue(error);
+			mockPostService.updatePost.mockRejectedValue(error);
 
 			await expect(postController.handlePostUpdate(mockPostId, updateBodyDto, mockReq)).rejects.toThrow(error);
-
-    });
+    	});
 	});
-	describe("DELETE /post/:post_id", () => {
-		const mockPostId = 1;
-		it("게시물 삭제 성공", async () => {
-			mockPostService.deletePost.mockResolvedValue([]);
-			jest.spyOn(mockPostService, "deletePost").mockResolvedValue([]);
 
-      const result = await postController.handlePostDelete(mockPostId, mockReq);
-      
-      expect(postService.deletePost).toHaveBeenCalledWith(mockPostId, mockUserId);
+	describe("DELETE /post/:post_id", () => {
+		const deletePostDto = {
+			authorId: mockUserId,
+			postId: mockPostId
+		}
+		it("게시물 삭제 성공", async () => {
+			mockPostService.deletePost.mockResolvedValue(undefined);
+			const result = await postController.handlePostDelete(mockPostId, mockReq);
+
+			expect(postService.deletePost).toHaveBeenCalledWith(deletePostDto);
 			expect(result).toEqual({
 				message: "게시글 삭제 success",
 			});
 		});
+
 		it("게시물 삭제 실패 시 에러를 반환한다.", async () => {
 			const error = ServerError.badRequest("잘못된 입력입니다");
-			jest.spyOn(mockPostService, "deletePost").mockRejectedValue(error);
+			mockPostService.deletePost.mockRejectedValue(error);
 
 			await expect(postController.handlePostDelete(mockPostId, mockReq)).rejects.toThrow(error);
 		});
 	});
-});
 });

--- a/nestjs-migration/src/post/post.controller.ts
+++ b/nestjs-migration/src/post/post.controller.ts
@@ -104,6 +104,7 @@ export class PostController {
 		};
 	};
 
+	//?userID: admin때문인 것 같은데..
   	@UseGuards(LoginGuard)
 	@Delete(":postId")
 	@HttpCode(HttpStatus.OK)
@@ -113,7 +114,11 @@ export class PostController {
 	) {
 		try {
 			const userId = req.user["userId"];
-			await this.postService.deletePost( userId, postId );
+			const deletePostDto = {
+				postId,
+				authorId: userId,
+			}
+			await this.postService.deletePost( deletePostDto );
 			return {  message: "게시글 삭제 success" };
 		} catch (err) {
 			throw err;

--- a/nestjs-migration/src/post/post.controller.ts
+++ b/nestjs-migration/src/post/post.controller.ts
@@ -33,11 +33,11 @@ export class PostController {
 	) {
 		try {
 			const authorId = req.user["userId"];
-			const values = {
+			const createPostDto = {
 				...createPostBodyDto,
 				authorId,
 			};
-			const postId = await this.postService.createPost(values);
+			const postId = await this.postService.createPost(createPostDto);
 			return { postId, message: "게시글 생성 success" };
 
 		} catch (err) {

--- a/nestjs-migration/src/post/post.module.ts
+++ b/nestjs-migration/src/post/post.module.ts
@@ -3,12 +3,13 @@ import { PostService } from './post.service';
 import { PostController } from './post.controller';
 import { UserRepository } from 'src/user/user.repository';
 import { PostRepository } from './post.repository';
+import { Post } from './entities/post.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [],
+  imports: [TypeOrmModule.forFeature([Post])],
   controllers: [PostController],
-  providers: [PostService,
-             UserRepository,
-            PostRepository],
+  providers: [PostService,PostRepository],
+  exports: [PostService, PostRepository]
 })
 export class PostModule {}

--- a/nestjs-migration/src/post/post.repository.ts
+++ b/nestjs-migration/src/post/post.repository.ts
@@ -4,6 +4,7 @@ import { Post } from "./entities/post.entity";
 import { ReadPostsQueryDto, SortBy } from "./dto/read-posts-query.dto";
 import { getPostHeadersDto } from "./dto/get-post-headers.dto";
 import { Like } from "../like/entities/like.entity";
+import { plainToInstance } from "class-transformer";
 
 @Injectable()
 export class PostRepository extends Repository<Post> {
@@ -63,7 +64,9 @@ export class PostRepository extends Repository<Post> {
 			.limit(perPage)
 			.offset(index * perPage);
 
-		return await queryBuilder.getRawMany();
+		const results = await queryBuilder.getRawMany();
+
+		return plainToInstance(getPostHeadersDto, results);
 	}
 
 	async getPostTotal(readPostsQueryDto: ReadPostsQueryDto, userId: number) : Promise<number> {

--- a/nestjs-migration/src/post/post.repository.ts
+++ b/nestjs-migration/src/post/post.repository.ts
@@ -66,7 +66,7 @@ export class PostRepository extends Repository<Post> {
 		return await queryBuilder.getRawMany();
 	}
 
-	async getPostTotal(readPostsQueryDto: ReadPostsQueryDto, userId: number) {
+	async getPostTotal(readPostsQueryDto: ReadPostsQueryDto, userId: number) : Promise<number> {
 		let { keyword } = readPostsQueryDto;
 		userId ? userId : 0;
 
@@ -89,7 +89,7 @@ export class PostRepository extends Repository<Post> {
 		return await queryBuilder.getCount();
 	}
 
-	async getPostHeader(postId, userId) {
+	async getPostHeader(postId: number, userId: number) : Promise<Post> {
 		const authorId = userId;
 		const queryBuilder = this.createQueryBuilder("post")
 			.select([

--- a/nestjs-migration/src/post/post.service.spec.ts
+++ b/nestjs-migration/src/post/post.service.spec.ts
@@ -1,22 +1,26 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { PostService } from "./post.service";
-import { PostRepository } from "./post.repository";
 import { CreatePostDto } from "./dto/create-post.dto";
-import { UserRepository } from "../user/user.repository";
-import { LogRepository } from "../log/log.repository";
-import { DataSource } from "typeorm";
+import { DataSource, Repository } from "typeorm";
 import { Post } from "./entities/post.entity";
 import { UpdatePostDto } from "./dto/update-post.dto";
 import { User } from "../user/entities/user.entity";
 import { ServerError } from "../common/exceptions/server-error.exception";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { Log } from "../log/entity/log.entity";
+import { PostRepository } from "./post.repository";
+import { LogRepository } from "../log/log.repository";
 
 describe("PostService", () => {
+
 	let postService: PostService;
 	let postRepository: PostRepository;
-	let userRepository: UserRepository;
 	let logRepository: LogRepository;
 	let dataSource: DataSource;
-	let mockQueryRunner: any;
+
+	let mockUserId: number;
+	let mockUser: Partial<User>;
+	let mockPostId: number;
 
 	const mockPostRepository = {
 		getPostHeaders: jest.fn(),
@@ -28,19 +32,12 @@ describe("PostService", () => {
 		update: jest.fn(),
 		findOne: jest.fn(),
 	};
-	const mockUserRepository = {
-		findOne: jest.fn(),
-	};
 	const mockDataSource = {
 		createQueryRunner: jest.fn(),
 	};
 	const mockLogRepository = {
 		save: jest.fn(),
 	};
-
-	let mockUserId: number;
-	let mockUser: Partial<User>;
-	let mockPostId: number;
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
@@ -49,10 +46,6 @@ describe("PostService", () => {
 				{
 					provide: PostRepository,
 					useValue: mockPostRepository,
-				},
-				{
-					provide: UserRepository,
-					useValue: mockUserRepository,
 				},
 				{
 					provide: LogRepository,
@@ -67,19 +60,19 @@ describe("PostService", () => {
 
 		postService = module.get<PostService>(PostService);
 		postRepository = module.get<PostRepository>(PostRepository);
-		userRepository = module.get<UserRepository>(UserRepository);
-		dataSource = module.get<DataSource>(DataSource);
 		logRepository = module.get<LogRepository>(LogRepository);
+		dataSource = module.get<DataSource>(DataSource);
 
 		mockUser = {
 			id: 1,
+			nickname: "Author",
 		};
-		mockUserId = mockUser.id;
+		mockUserId = mockUser.id
 		mockPostId = 2;
 	});
 
 	describe("createPost", () => {
-		mockQueryRunner = {
+		const mockQueryRunner = {
 			connect: jest.fn(),
 			startTransaction: jest.fn(),
 			commitTransaction: jest.fn(),
@@ -89,89 +82,62 @@ describe("PostService", () => {
 				save: jest.fn(),
 				getRepository: jest.fn().mockReturnValue({
 					save: jest.fn(),
-				}),
+				  }),
 			},
 		};
 		mockDataSource.createQueryRunner.mockReturnValue(mockQueryRunner);
 
-		const mockUser = { id: 1, name: "Author" };
-		const mockPostId = 1;
+		const mockCreatePostDto: CreatePostDto = {
+			title: "title",
+			content: "content",
+			doFilter: false,
+			authorId: mockUserId,
+		};
 
+		it("게시물 생성 성공 시 postId를 반환한다.", async () => {
+			mockQueryRunner.manager.save.mockResolvedValue({
+				id: mockPostId,
+			});
 
-    const mockCreatePostDto: CreatePostDto = {
-      title: "title",
-      content: "content",
-      doFilter: false,
-      authorId: mockUser.id,
-    };
-    it("게시물 생성 성공 시 postId를 반환한다.", async () => {
-      jest.spyOn(mockUserRepository, "findOne").mockResolvedValue(
-        mockUser
-      );
-      jest.spyOn(mockQueryRunner.manager, "save").mockResolvedValue({
-        id: mockPostId,
-      });
+			const result = await postService.createPost(mockCreatePostDto);
 
-      const result = await postService.createPost(mockCreatePostDto);
+			expect(mockQueryRunner.connect).toHaveBeenCalled();
+			expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
+			expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
+			expect(mockQueryRunner.release).toHaveBeenCalled();
 
-      expect(mockQueryRunner.connect).toHaveBeenCalled();
-      expect(mockQueryRunner.startTransaction).toHaveBeenCalled();
-      expect(mockQueryRunner.commitTransaction).toHaveBeenCalled();
-      expect(mockQueryRunner.release).toHaveBeenCalled();
+			expect(result).toBe(mockPostId);
+		});
+		
+		it("게시물 생성 중 오류 발생 시 롤백된다.", async () => {
+			const mockError = new Error("트랜잭션 중 에러 발생");
+			jest.spyOn(mockQueryRunner.manager, "save").mockResolvedValue({
+				id: mockPostId,
+			});
+			mockQueryRunner.manager.getRepository().save.mockRejectedValue(mockError);
 
-      expect(userRepository.findOne).toHaveBeenCalledWith({
-        where: { id: 1 },
-      });
-      expect(result).toBe(mockPostId);
-    });
-    it("존재하지 않는 user일 시 에러를 반환한다.", async () => {
-      jest.spyOn(mockUserRepository, "findOne").mockResolvedValue(
-        null
-      );
+			await expect(
+				postService.createPost(mockCreatePostDto)
+			).rejects.toThrow(mockError);
 
-      await expect(
-        postService.createPost(mockCreatePostDto)
-      ).rejects.toThrow(
-        ServerError.notFound("존재하지 않는 유저입니다")
-      );
-      expect(
-        mockQueryRunner.rollbackTransaction
-      ).not.toHaveBeenCalled();
-      expect(mockQueryRunner.release).toHaveBeenCalled();
-    });
-
-    it("게시물 생성 중 오류 발생 시 롤백된다.", async () => {
-      const mockError = new Error("트랜잭션 중 에러 발생");
-      jest.spyOn(mockUserRepository, "findOne").mockResolvedValue(
-        mockUser
-      );
-      jest.spyOn(mockQueryRunner.manager, "save").mockRejectedValue(
-        mockError
-      );
-
-      await expect(
-        postService.createPost(mockCreatePostDto)
-      ).rejects.toThrow(mockError);
-
-      expect(mockQueryRunner.connect).toHaveBeenCalled();
-      expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
-      expect(mockQueryRunner.release).toHaveBeenCalled();
-    });
+			expect(mockQueryRunner.connect).toHaveBeenCalled();
+			expect(mockQueryRunner.rollbackTransaction).toHaveBeenCalled();
+			expect(mockQueryRunner.release).toHaveBeenCalled();
+		});
 	});
 
 	describe("findPostHeaders", () => {
 		const mockReadPostsQueryDto = {};
 		it("게시물 전체 조회 성공 시 게시물들을 반환한다.", async () => {
-			jest.spyOn(mockPostRepository, "getPostHeaders").mockResolvedValue(
+			mockPostRepository.getPostHeaders.mockResolvedValue(
 				{}
 			);
-
 			const result = await postService.findPostHeaders(
 				mockReadPostsQueryDto,
 				mockUserId
 			);
 
-			expect(postRepository.getPostHeaders).toHaveBeenCalledWith(
+			expect(mockPostRepository.getPostHeaders).toHaveBeenCalledWith(
 				mockReadPostsQueryDto,
 				mockUserId
 			);
@@ -192,26 +158,23 @@ describe("PostService", () => {
 		const mockReadPostsQueryDto = {};
 		it("게시물 개수 조회 성공 시 개수를 반환한다.", async () => {
 			const mockTotal = 10;
-			jest.spyOn(mockPostRepository, "getPostTotal").mockResolvedValue(
-				mockTotal
-			);
+			mockPostRepository.getPostTotal.mockResolvedValue(mockTotal);
 
 			const result = await postService.findPostTotal(
 				mockReadPostsQueryDto,
 				mockUserId
 			);
 
-			expect(postRepository.getPostHeaders).toHaveBeenCalledWith(
+			expect(mockPostRepository.getPostHeaders).toHaveBeenCalledWith(
 				mockReadPostsQueryDto,
 				mockUserId
 			);
 			expect(result).toEqual(mockTotal);
 		});
+
 		it("게시물 개수 조회 도중 에러 발생 시 에러를 반환한다.", async () => {
 			const mockError = new Error("게시물 개수 조회 중 오류 발생");
-			jest.spyOn(mockPostRepository, "getPostTotal").mockRejectedValue(
-				mockError
-			);
+			mockPostRepository.getPostTotal.mockRejectedValue(mockError);
 
 			await expect(
 				postService.findPostTotal(mockReadPostsQueryDto, mockUserId)
@@ -222,10 +185,10 @@ describe("PostService", () => {
 	describe("findPost", () => {
 		it("게시물 상세 조회 성공 시 게시물을 반환한다.", async () => {
 			const mockPost = {id:1, title: "title", content: "content"}
-			jest.spyOn(mockPostRepository, "getPostHeader").mockResolvedValue(mockPost);
+			mockPostRepository.getPostHeader.mockResolvedValue(mockPost);
 			const result = await postService.findPost(mockPostId, mockUserId);
 
-			expect(postRepository.getPostHeader).toHaveBeenCalledWith(
+			expect(mockPostRepository.getPostHeader).toHaveBeenCalledWith(
 				mockPostId,
 				mockUserId
 			);
@@ -233,7 +196,7 @@ describe("PostService", () => {
 		});
 		it("게시물 상세 조회 중 에러 발생 시 에러를 반환한다", async () => {
 			const mockError = new Error("게시물 상세 조회 중 오류 발생");
-			jest.spyOn(mockPostRepository, "getPostHeader").mockRejectedValue(
+			mockPostRepository.getPostHeader.mockRejectedValue(
 				mockError
 			);
 
@@ -250,18 +213,14 @@ describe("PostService", () => {
 			mockUpdateDto = {
 				title: "New Title",
 				content: "New Content",
-				authorId: mockUserId,
+				authorId: mockUser.id,
 				doFilter: true,
 			};
 		});
 		it("게시물 업데이트 성공", async () => {
-			jest.spyOn(mockUserRepository, "findOne").mockResolvedValue(
-				mockUserId
-			);
-			jest.spyOn(mockPostRepository, "findOne").mockResolvedValue(
-				mockPostId
-			);
-			jest.spyOn(mockPostRepository, "update").mockResolvedValue({
+
+			mockPostRepository.findOne.mockResolvedValue(mockPostId);
+			mockPostRepository.update.mockResolvedValue({
 				affected: 1,
 			});
 
@@ -269,33 +228,22 @@ describe("PostService", () => {
 				mockPostId,
 				mockUpdateDto
 			);
-			expect(userRepository.findOne).toHaveBeenCalledWith({
-				where: { id: mockUserId },
-			});
+
 			expect(postRepository.findOne).toHaveBeenCalledWith({
 				where: { id: mockPostId },
 			});
 			expect(postRepository.update).toHaveBeenCalledWith(
-				{ id: mockPostId },
+				{ id: mockPostId, author: {id: mockUserId} },
 				{ title: "New Title", content: "New Content" }
 			);
 			expect(result).toEqual(true);
 		});
 
-		it("존재하지 않는 user 시 에러를 반환한다", async () => {
-			jest.spyOn(mockUserRepository, "findOne").mockResolvedValue(null);
-
-			await expect(
-				postService.updatePost(mockPostId, mockUpdateDto)
-			).rejects.toThrow(ServerError.notFound("없는 유저이거나 존재하지 않는 게시물입니다."));
-
-			expect(postRepository.update).not.toHaveBeenCalled();
-		});
 		it("존재하지 않는 post 시 에러를 반환한다", async () => {
-			jest.spyOn(mockPostRepository, "findOne").mockResolvedValue(null);
+			mockPostRepository.findOne.mockResolvedValue(null);
 			await expect(
 				postService.updatePost(mockPostId, mockUpdateDto)
-			).rejects.toThrow(ServerError.notFound("없는 유저이거나 존재하지 않는 게시물입니다."));
+			).rejects.toThrow(ServerError.notFound("게시물 수정 실패: 존재하지 않는 게시물입니다."));
 
 			expect(postRepository.update).not.toHaveBeenCalled();
 		});
@@ -305,20 +253,20 @@ describe("PostService", () => {
 			jest.clearAllMocks();
 		});
 		it("게시물 삭제 성공", async () => {
-			jest.spyOn(mockPostRepository, "findOne").mockResolvedValue(
+			mockPostRepository.findOne.mockResolvedValue(
 				mockPostId
 			);
-			jest.spyOn(mockPostRepository, "delete").mockResolvedValue({
+			mockPostRepository.delete.mockResolvedValue({
 				affected: 1,
 			});
 
-			const result = await postService.deletePost(mockUserId, mockPostId);
+			const result = await postService.deletePost({authorId: mockUserId, postId: mockPostId});
 
 			expect(postRepository.findOne).toHaveBeenCalledWith({
 				where: { id: mockPostId },
 			});
 			expect(postRepository.update).toHaveBeenCalledWith(
-				{ id: mockPostId, isDelete: 0, author: mockUserId },
+				{ id: mockPostId, isDelete: 0, author: {id : mockUserId} },
 				{ isDelete: 1 }
 			);
 			expect(result).toEqual(true);
@@ -335,8 +283,8 @@ describe("PostService", () => {
 			);
 
 			await expect(
-				postService.deletePost(mockPostId, mockUserId)
-			).rejects.toThrow(ServerError.reference("게시글 삭제 실패"));
+				postService.deletePost({authorId: mockUserId, postId: mockPostId})
+			).rejects.toThrow(ServerError.notFound("게시글 삭제 실패: 존재하지 않는 게시물입니다."));
 
 			expect(postRepository.update).not.toHaveBeenCalled();
 		});


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* #248 
* #235 

## 📝 작업 내용

1. (코드오류수정) 게시물 조회: 쿼리 파라미터 keyword 적용 안되는 오류 ⇒ new Bracket를 추가해서 수정
2. (sql문 삭제) 게시물 생성 및 업데이트 findOne-author 코드삭제: 로그인 가드로 검사하므로 필요없는 조건이라 생각하여 삭제
3. new object.assign 리팩토링
4. update where 조건에 빼먹은 authorId 추가

### 참고사항
게시물 조회 시 likes string으로 나옴 
<img width="400" alt="스크린샷 2024-09-22 오전 12 28 15" src="https://github.com/user-attachments/assets/d000c8fa-3b60-4033-b8ba-ad04a90ce6bd">
`likes: "0"`

-> 이 부분 아직 해결을 못했습니다.

