### PR TITLE
[BE] 유저 API 마이그레이션 마무리

### DIFF
--- a/nestjs-migration/src/auth/auth.service.ts
+++ b/nestjs-migration/src/auth/auth.service.ts
@@ -61,6 +61,12 @@ export class AuthService {
 		return verifiedToken;
 	}
 
+	verifyTempToken(tempToken: string) {
+		return this.jwtService.verify(tempToken, {
+			secret: this.configService.get("jwt.temp_token_key"),
+		});
+	}
+
 	private async getRefreshToken(userId: number, token: string) {
 		const refreshToken = await this.refreshTokenRepository.findOne({
 			where: { userId, token },

--- a/nestjs-migration/src/common/decorator/required-password.decorator.ts
+++ b/nestjs-migration/src/common/decorator/required-password.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from "@nestjs/common";
+
+export const RequiredPassword = () => SetMetadata("requiredPassword", true);

--- a/nestjs-migration/src/common/guard/password.guard.ts
+++ b/nestjs-migration/src/common/guard/password.guard.ts
@@ -1,0 +1,52 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { AuthService } from "../../auth/auth.service";
+import { ServerError } from "../exceptions/server-error.exception";
+import { IUserEntity } from "../interface/user-entity.interface";
+
+@Injectable()
+export class PasswordGuard implements CanActivate {
+	constructor(
+		private reflector: Reflector,
+		private authService: AuthService
+	) {}
+
+	canActivate(context: ExecutionContext): boolean {
+		const request = context.switchToHttp().getRequest();
+		const response = context.switchToHttp().getResponse();
+
+		const user: IUserEntity = request.user;
+
+		const requiredPassword = this.reflector.get<string>(
+			"requiredPassword",
+			context.getHandler()
+		);
+
+		if (!requiredPassword) {
+			return true;
+		}
+
+		const tempToken = request.cookies.tempToken;
+		response.clearCookie("tempToken");
+
+		if (!user || !user.userId) {
+			throw ServerError.unauthorized("로그인이 필요합니다.");
+		}
+
+		return this.isTempTokenValid(tempToken, user.userId);
+	}
+
+	isTempTokenValid(tempToken: string, userId: number) {
+		if (!tempToken) {
+			throw ServerError.unauthorized("비밀번호 확인이 필요합니다.");
+		}
+
+		const tempTokenPayload = this.authService.verifyTempToken(tempToken);
+
+		if (tempTokenPayload.userId !== userId) {
+			throw ServerError.forbidden("인증 정보가 일치하지 않습니다.");
+		}
+
+		return true;
+	}
+}

--- a/nestjs-migration/src/oauth/oauth.module.ts
+++ b/nestjs-migration/src/oauth/oauth.module.ts
@@ -19,5 +19,7 @@ import { OAuthProviderRepository } from "./repositories/oauth-provider.repositor
 		OAuthProviderRepository,
 		UserRepository,
 	],
+
+	exports: [OAuthService, OAuthTokenService],
 })
 export class OAuthModule {}

--- a/nestjs-migration/src/oauth/oauth.service.ts
+++ b/nestjs-migration/src/oauth/oauth.service.ts
@@ -396,10 +396,7 @@ export class OAuthService {
 		};
 	}
 
-	private async revokeOAuth(
-		provider: TOAuthProvider,
-		oAuthAccessToken: string
-	) {
+	async revokeOAuth(provider: TOAuthProvider, oAuthAccessToken: string) {
 		const oAuthRevokeResponse = await fetch(
 			...buildRevokeFetchParameters(
 				provider,

--- a/nestjs-migration/src/oauth/repositories/oauth-connection.repository.ts
+++ b/nestjs-migration/src/oauth/repositories/oauth-connection.repository.ts
@@ -51,4 +51,12 @@ export class OAuthConnectionRepository extends Repository<OAuthConnection> {
 			.andWhere("oAuthConnection.userId = :userId", { userId })
 			.getOne();
 	}
+
+	async clearOAuthConnectionByUserId(userId: number) {
+		return this.createQueryBuilder("oAuthConnection")
+			.update()
+			.set({ oAuthRefreshToken: null, isDelete: true })
+			.where("userId = :userId", { userId })
+			.execute();
+	}
 }

--- a/nestjs-migration/src/oauth/repositories/oauth-connection.repository.ts
+++ b/nestjs-migration/src/oauth/repositories/oauth-connection.repository.ts
@@ -31,6 +31,9 @@ export class OAuthConnectionRepository extends Repository<OAuthConnection> {
 				"oAuthProvider"
 			)
 			.where("oAuthConnection.userId = :userId", { userId })
+			.andWhere("oAuthConnection.isDelete = :isDelete", {
+				isDelete: false,
+			})
 			.getMany();
 	}
 

--- a/nestjs-migration/src/user/constant/user.constants.ts
+++ b/nestjs-migration/src/user/constant/user.constants.ts
@@ -14,6 +14,13 @@ export const USER_ERROR_MESSAGES = {
 	INVALID_LOGIN: "이메일 또는 비밀번호가 틀렸습니다.",
 	FAILED_TOKEN_DELETE: "토큰 삭제 실패",
 	INVALID_PASSWORD: "비밀번호가 틀렸습니다.",
+	CANNOT_CHANGE_EMAIL: "한번 등록한 이메일은 변경할 수 없습니다.",
+	SOCIAL_USER_NEED_EMAIL:
+		"소셜 로그인으로 가입한 유저는 최초 정보 수정 시 이메일을 등록해야 합니다.",
+	SAME_PASSWORD: "비밀번호가 현재와 동일합니다.",
+	UPDATE_RESISTER_USER_EMAIL:
+		"소셜 로그인으로 가입한 회원 정보에 이메일 등록 실패",
+	UPDATE_USER_ERROR: "회원정보 수정 실패",
 };
 
 export const PASSWORD_POLICY = {

--- a/nestjs-migration/src/user/constant/user.constants.ts
+++ b/nestjs-migration/src/user/constant/user.constants.ts
@@ -21,6 +21,8 @@ export const USER_ERROR_MESSAGES = {
 	UPDATE_RESISTER_USER_EMAIL:
 		"소셜 로그인으로 가입한 회원 정보에 이메일 등록 실패",
 	UPDATE_USER_ERROR: "회원정보 수정 실패",
+	DELETE_OAUTH_CONNECTION_ERROR: "소셜 로그인 전체 연동 해제 실패",
+	DELETE_USER_ERROR: "사용자 삭제 실패",
 };
 
 export const PASSWORD_POLICY = {

--- a/nestjs-migration/src/user/dto/update-user.dto.ts
+++ b/nestjs-migration/src/user/dto/update-user.dto.ts
@@ -1,0 +1,29 @@
+import {
+	IsEmail,
+	IsNotEmpty,
+	IsOptional,
+	IsStrongPassword,
+	ValidateIf,
+} from "class-validator";
+import {
+	PASSWORD_POLICY,
+	VALIDATION_ERROR_MESSAGES,
+} from "../constant/user.constants";
+
+export class UpdateUserDto {
+	@IsOptional()
+	@ValidateIf(
+		o => o.email !== undefined && o.email !== null && o.email !== ""
+	)
+	@IsEmail({}, { message: VALIDATION_ERROR_MESSAGES.INVALID_EMAIL })
+	email?: string;
+
+	@IsNotEmpty({ message: VALIDATION_ERROR_MESSAGES.PASSWORD_REQUIRED })
+	@IsStrongPassword(PASSWORD_POLICY, {
+		message: VALIDATION_ERROR_MESSAGES.INVALID_PASSWORD,
+	})
+	password: string;
+
+	@IsNotEmpty({ message: VALIDATION_ERROR_MESSAGES.NICKNAME_REQUIRED })
+	nickname: string;
+}

--- a/nestjs-migration/src/user/user.controller.spec.ts
+++ b/nestjs-migration/src/user/user.controller.spec.ts
@@ -28,6 +28,7 @@ describe("UserController", () => {
 		checkPassword: jest.fn(),
 		readUser: jest.fn(),
 		updateUser: jest.fn(),
+		deleteUser: jest.fn(),
 	};
 
 	const mockRbacService = {
@@ -378,6 +379,32 @@ describe("UserController", () => {
 			);
 
 			expect(result).toEqual({ message: "회원정보 수정 성공" });
+		});
+	});
+
+	describe("DELETE /user", () => {
+		it("사용자 탈퇴 성공 시 200 상태 코드와 성공 메시지를 반환한다", async () => {
+			const mockResponse = {
+				clearCookie: jest.fn(),
+			} as unknown as Response;
+
+			jest.spyOn(loginGuard, "canActivate").mockReturnValue(true);
+			jest.spyOn(userService, "deleteUser").mockResolvedValue(undefined);
+
+			const result = await userController.deleteUser(
+				mockUserEntity,
+				mockResponse
+			);
+
+			expect(userService.deleteUser).toHaveBeenCalledWith(1);
+			expect(mockResponse.clearCookie).toHaveBeenCalledTimes(2);
+			expect(mockResponse.clearCookie).toHaveBeenCalledWith(
+				"accessToken"
+			);
+			expect(mockResponse.clearCookie).toHaveBeenCalledWith(
+				"refreshToken"
+			);
+			expect(result).toEqual({ message: "회원탈퇴 성공" });
 		});
 	});
 });

--- a/nestjs-migration/src/user/user.controller.spec.ts
+++ b/nestjs-migration/src/user/user.controller.spec.ts
@@ -1,7 +1,9 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { Response } from "express";
+import { AuthService } from "../auth/auth.service";
 import { ServerError } from "../common/exceptions/server-error.exception";
 import { LoginGuard } from "../common/guard/login.guard";
+import { PasswordGuard } from "../common/guard/password.guard";
 import { IUserEntity } from "../common/interface/user-entity.interface";
 import { OAuthConnection } from "../oauth/entities/oauth-connection.entity";
 import { RbacService } from "../rbac/rbac.service";
@@ -41,11 +43,18 @@ describe("UserController", () => {
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [UserController],
 			providers: [
+				LoginGuard,
+				PasswordGuard,
+
+				{
+					provide: AuthService,
+					useValue: {},
+				},
+
 				{
 					provide: UserService,
 					useValue: mockUserService,
 				},
-				LoginGuard,
 				{
 					provide: RbacService,
 					useValue: mockRbacService,

--- a/nestjs-migration/src/user/user.controller.spec.ts
+++ b/nestjs-migration/src/user/user.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { Response } from "express";
+import { Request, Response } from "express";
 import { AuthService } from "../auth/auth.service";
 import { ServerError } from "../common/exceptions/server-error.exception";
 import { LoginGuard } from "../common/guard/login.guard";
@@ -186,6 +186,12 @@ describe("UserController", () => {
 
 	describe("POST /user/logout", () => {
 		it("로그아웃 성공 시 200 상태 코드와 성공 메시지를 반환한다", async () => {
+			const mockRequest = {
+				cookies: {
+					refreshToken: "mock-refresh-token",
+				},
+			} as unknown as Request;
+
 			const mockResponse = {
 				clearCookie: jest.fn(),
 			} as unknown as Response;
@@ -194,11 +200,15 @@ describe("UserController", () => {
 			jest.spyOn(userService, "logout").mockResolvedValue(undefined);
 
 			const result = await userController.logout(
+				mockRequest,
 				mockUserEntity,
 				mockResponse
 			);
 
-			expect(userService.logout).toHaveBeenCalledWith(1);
+			expect(userService.logout).toHaveBeenCalledWith(
+				1,
+				"mock-refresh-token"
+			);
 			expect(mockResponse.clearCookie).toHaveBeenCalledTimes(2);
 			expect(mockResponse.clearCookie).toHaveBeenCalledWith(
 				"accessToken"

--- a/nestjs-migration/src/user/user.controller.spec.ts
+++ b/nestjs-migration/src/user/user.controller.spec.ts
@@ -10,6 +10,7 @@ import { RbacService } from "../rbac/rbac.service";
 import * as dateUtil from "../utils/date.util";
 import { COOKIE_MAX_AGE, USER_ERROR_MESSAGES } from "./constant/user.constants";
 import { CreateUserDto } from "./dto/create-user.dto";
+import { UpdateUserDto } from "./dto/update-user.dto";
 import { User } from "./entities/user.entity";
 import { UserController } from "./user.controller";
 import { UserService } from "./user.service";
@@ -26,6 +27,7 @@ describe("UserController", () => {
 		logout: jest.fn(),
 		checkPassword: jest.fn(),
 		readUser: jest.fn(),
+		updateUser: jest.fn(),
 	};
 
 	const mockRbacService = {
@@ -86,6 +88,7 @@ describe("UserController", () => {
 
 		checkGuardApplied("logout");
 		checkGuardApplied("readUser");
+		checkGuardApplied("updateUser");
 	});
 
 	describe("POST /user/join", () => {
@@ -341,6 +344,30 @@ describe("UserController", () => {
 				nickname: mockUser.nickname,
 				connected_oauth: ["google"],
 			});
+		});
+	});
+
+	describe("PUT /user", () => {
+		it("사용자 정보 수정 성공 시 200 상태 코드와 성공 메시지를 반환한다", async () => {
+			const updateUserDto: UpdateUserDto = {
+				password: "password123",
+				nickname: "testuser",
+			};
+
+			jest.spyOn(loginGuard, "canActivate").mockReturnValue(true);
+			jest.spyOn(userService, "updateUser").mockResolvedValue(true);
+
+			const result = await userController.updateUser(
+				mockUserEntity,
+				updateUserDto
+			);
+
+			expect(userService.updateUser).toHaveBeenCalledWith(
+				1,
+				updateUserDto
+			);
+
+			expect(result).toEqual({ message: "회원정보 수정 성공" });
 		});
 	});
 });

--- a/nestjs-migration/src/user/user.controller.ts
+++ b/nestjs-migration/src/user/user.controller.ts
@@ -75,7 +75,23 @@ export class UserController {
 		return { message: "로그아웃 성공" };
 	}
 
-	//TODO: 소셜로그인 API 구현 후 유저 정보 읽기 API 구현
+	@UseGuards(LoginGuard)
+	@Get()
+	@HttpCode(HttpStatus.OK)
+	async readUser(@User() userEntity: IUserEntity) {
+		const userId = userEntity.userId;
+
+		const { user, oAuthConnections } =
+			await this.userService.readUser(userId);
+
+		return {
+			email: user.email,
+			nickname: user.nickname,
+			connected_oauth: oAuthConnections.map(
+				({ oAuthProvider }) => oAuthProvider.name
+			),
+		};
+	}
 
 	//TODO: 소셜로그인 API 구현후 유저 정보 수정 API 구현
 

--- a/nestjs-migration/src/user/user.controller.ts
+++ b/nestjs-migration/src/user/user.controller.ts
@@ -5,12 +5,15 @@ import {
 	HttpCode,
 	HttpStatus,
 	Post,
+	Put,
 	Res,
 	UseGuards,
 } from "@nestjs/common";
 import { Response } from "express";
+import { RequiredPassword } from "../common/decorator/required-password.decorator";
 import { User } from "../common/decorator/user.decorator";
 import { LoginGuard } from "../common/guard/login.guard";
+import { PasswordGuard } from "../common/guard/password.guard";
 import { IUserEntity } from "../common/interface/user-entity.interface";
 import { RbacService } from "../rbac/rbac.service";
 import { getKstNow } from "../utils/date.util";
@@ -18,9 +21,11 @@ import { COOKIE_MAX_AGE } from "./constant/user.constants";
 import { CheckPasswordDto } from "./dto/check-password.dto";
 import { CreateUserDto } from "./dto/create-user.dto";
 import { LoginDto } from "./dto/login.dto";
+import { UpdateUserDto } from "./dto/update-user.dto";
 import { UserService } from "./user.service";
 
 @Controller("user")
+@UseGuards(PasswordGuard)
 export class UserController {
 	constructor(
 		private readonly userService: UserService,
@@ -93,7 +98,20 @@ export class UserController {
 		};
 	}
 
-	//TODO: 소셜로그인 API 구현후 유저 정보 수정 API 구현
+	@Put()
+	@HttpCode(HttpStatus.OK)
+	@UseGuards(LoginGuard)
+	@RequiredPassword()
+	async updateUser(
+		@User() userEntity: IUserEntity,
+		@Body() updateUserDto: UpdateUserDto
+	) {
+		const userId = userEntity.userId;
+
+		await this.userService.updateUser(userId, updateUserDto);
+
+		return { message: "회원정보 수정 성공" };
+	}
 
 	//TODO: 소설로그인 API 구현후 유저 탈퇴 API 구현
 

--- a/nestjs-migration/src/user/user.controller.ts
+++ b/nestjs-migration/src/user/user.controller.ts
@@ -1,6 +1,7 @@
 import {
 	Body,
 	Controller,
+	Delete,
 	Get,
 	HttpCode,
 	HttpStatus,
@@ -113,7 +114,23 @@ export class UserController {
 		return { message: "회원정보 수정 성공" };
 	}
 
-	//TODO: 소설로그인 API 구현후 유저 탈퇴 API 구현
+	@Delete()
+	@HttpCode(HttpStatus.OK)
+	@UseGuards(LoginGuard)
+	@RequiredPassword()
+	async deleteUser(
+		@User() userEntity: IUserEntity,
+		@Res({ passthrough: true }) res: Response
+	) {
+		const userId = userEntity.userId;
+
+		await this.userService.deleteUser(userId);
+
+		res.clearCookie("accessToken");
+		res.clearCookie("refreshToken");
+
+		return { message: "회원탈퇴 성공" };
+	}
 
 	@Post("/check-password")
 	@HttpCode(HttpStatus.OK)

--- a/nestjs-migration/src/user/user.controller.ts
+++ b/nestjs-migration/src/user/user.controller.ts
@@ -7,10 +7,11 @@ import {
 	HttpStatus,
 	Post,
 	Put,
+	Req,
 	Res,
 	UseGuards,
 } from "@nestjs/common";
-import { Response } from "express";
+import { Request, Response } from "express";
 import { RequiredPassword } from "../common/decorator/required-password.decorator";
 import { User } from "../common/decorator/user.decorator";
 import { LoginGuard } from "../common/guard/login.guard";
@@ -69,15 +70,17 @@ export class UserController {
 	@Post("logout")
 	@HttpCode(HttpStatus.OK)
 	async logout(
+		@Req() req: Request,
 		@User() user: IUserEntity,
 		@Res({ passthrough: true }) res: Response
 	) {
+		const refreshToken = req.cookies.refreshToken;
 		const userId = user.userId;
 
 		res.clearCookie("accessToken");
 		res.clearCookie("refreshToken");
 
-		await this.userService.logout(userId);
+		await this.userService.logout(userId, refreshToken);
 		return { message: "로그아웃 성공" };
 	}
 

--- a/nestjs-migration/src/user/user.module.ts
+++ b/nestjs-migration/src/user/user.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { AuthModule } from "../auth/auth.module";
 import { RefreshTokensRepository } from "../auth/refresh-tokens.repository";
+import { OAuthConnectionRepository } from "../oauth/repositories/oauth-connection.repository";
 import { RbacModule } from "../rbac/rbac.module";
 import { User } from "./entities/user.entity";
 import { UserController } from "./user.controller";
@@ -15,7 +16,12 @@ import { UserService } from "./user.service";
 		RbacModule,
 	],
 	controllers: [UserController],
-	providers: [UserService, UserRepository, RefreshTokensRepository],
+	providers: [
+		UserService,
+		UserRepository,
+		RefreshTokensRepository,
+		OAuthConnectionRepository,
+	],
 	exports: [UserService, UserRepository],
 })
 export class UserModule {}

--- a/nestjs-migration/src/user/user.module.ts
+++ b/nestjs-migration/src/user/user.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { AuthModule } from "../auth/auth.module";
 import { RefreshTokensRepository } from "../auth/refresh-tokens.repository";
+import { OAuthModule } from "../oauth/oauth.module";
 import { OAuthConnectionRepository } from "../oauth/repositories/oauth-connection.repository";
 import { RbacModule } from "../rbac/rbac.module";
 import { User } from "./entities/user.entity";
@@ -14,6 +15,7 @@ import { UserService } from "./user.service";
 		TypeOrmModule.forFeature([User]),
 		forwardRef(() => AuthModule),
 		RbacModule,
+		OAuthModule,
 	],
 	controllers: [UserController],
 	providers: [

--- a/nestjs-migration/src/user/user.repository.ts
+++ b/nestjs-migration/src/user/user.repository.ts
@@ -48,6 +48,15 @@ export class UserRepository extends Repository<User> {
 			.execute();
 	}
 
+	deleteUser(userId: number) {
+		return this.createQueryBuilder("user")
+			.update()
+			.set({ isDelete: true })
+			.where("id = :userId", { userId })
+			.andWhere("isDelete = :isDelete", { isDelete: false })
+			.execute();
+	}
+
 	//예시 코드
 
 	// async customMethod(id: number): Promise<User> {

--- a/nestjs-migration/src/user/user.repository.ts
+++ b/nestjs-migration/src/user/user.repository.ts
@@ -22,6 +22,32 @@ export class UserRepository extends Repository<User> {
 			.getOne();
 	}
 
+	updateUser(
+		userId: number,
+		updateData: Partial<Pick<User, "nickname" | "password" | "salt">>
+	) {
+		return this.createQueryBuilder("user")
+			.update()
+			.set(updateData)
+			.where("id = :userId", { userId })
+			.andWhere("isDelete = :isDelete", { isDelete: false })
+			.execute();
+	}
+
+	registerUserEmail(
+		userId: number,
+		updateData: Partial<
+			Pick<User, "email" | "nickname" | "password" | "salt">
+		>
+	) {
+		return this.createQueryBuilder("user")
+			.update()
+			.where("id = :userId", { userId })
+			.set(updateData)
+			.andWhere("isDelete = :isDelete", { isDelete: false })
+			.execute();
+	}
+
 	//예시 코드
 
 	// async customMethod(id: number): Promise<User> {

--- a/nestjs-migration/src/user/user.service.ts
+++ b/nestjs-migration/src/user/user.service.ts
@@ -219,13 +219,6 @@ export class UserService {
 		>
 	) {
 		try {
-			if (!updateData.email) {
-				throw ServerError.etcError(
-					500,
-					"서버 로직에서 필수 정보를 누락했습니다."
-				);
-			}
-
 			const result = await this.userRepository.registerUserEmail(
 				userId,
 				updateData

--- a/nestjs-migration/src/user/user.service.ts
+++ b/nestjs-migration/src/user/user.service.ts
@@ -98,14 +98,8 @@ export class UserService {
 		return { tempToken };
 	}
 
-	async logout(userId: number) {
-		const result = await this.refreshTokenRepository.delete({ userId });
-
-		if (result.affected < 1) {
-			throw ServerError.badRequest(
-				USER_ERROR_MESSAGES.FAILED_TOKEN_DELETE
-			);
-		}
+	async logout(userId: number, refreshToken: string) {
+		await this.deleteRefreshToken(userId, refreshToken);
 	}
 
 	async updateUser(userId: number, updateUserDto: UpdateUserDto) {
@@ -285,7 +279,9 @@ export class UserService {
 			await this.refreshTokenRepository.delete(deleteConditions);
 
 		if (result.affected === 0) {
-			throw ServerError.badRequest("토큰 삭제 실패");
+			throw ServerError.badRequest(
+				USER_ERROR_MESSAGES.FAILED_TOKEN_DELETE
+			);
 		}
 	}
 

--- a/nestjs-migration/src/user/user.service.ts
+++ b/nestjs-migration/src/user/user.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { AuthService } from "../auth/auth.service";
 import { RefreshTokensRepository } from "../auth/refresh-tokens.repository";
 import { ServerError } from "../common/exceptions/server-error.exception";
+import { OAuthConnectionRepository } from "../oauth/repositories/oauth-connection.repository";
 import { makeHashedPassword, makeSalt } from "../utils/crypto.util";
 import {
 	USER_ERROR_CODES,
@@ -17,6 +18,7 @@ export class UserService {
 	constructor(
 		private userRepository: UserRepository,
 		private refreshTokenRepository: RefreshTokensRepository,
+		private oAuthConnectionRepository: OAuthConnectionRepository,
 		private readonly authService: AuthService
 	) {}
 
@@ -65,6 +67,16 @@ export class UserService {
 		});
 
 		return { nickname: user.nickname, ...tokens };
+	}
+
+	async readUser(userId: number) {
+		const user = await this.findAndValidateUserById(userId);
+		const oAuthConnections =
+			await this.oAuthConnectionRepository.getOAuthConnectionByUserId(
+				userId
+			);
+
+		return { user, oAuthConnections };
 	}
 
 	async checkPassword(userId: number, password: string) {

--- a/nestjs-migration/src/user/user.service.ts
+++ b/nestjs-migration/src/user/user.service.ts
@@ -178,7 +178,9 @@ export class UserService {
 					userId
 				);
 			if (result.affected === 0) {
-				throw ServerError.badRequest("소셜 로그인 전체 연동 해제 실패");
+				throw ServerError.badRequest(
+					USER_ERROR_MESSAGES.DELETE_OAUTH_CONNECTION_ERROR
+				);
 			}
 		}
 
@@ -289,7 +291,7 @@ export class UserService {
 		const result = await this.userRepository.deleteUser(userId);
 
 		if (result.affected === 0) {
-			throw ServerError.badRequest("사용자 삭제 실패");
+			throw ServerError.badRequest(USER_ERROR_MESSAGES.DELETE_USER_ERROR);
 		}
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #220

## 📝 작업 내용

-  유저 자신의 정보 조회 API
-  비밀번호 확인 기능 가드로 구현
-  유저 정보 수정 API
-  유저 삭제 API

## 💬 리뷰 요구사항

- 잘못 구현된 부분이나 개선이 필요한 부분이 있다면 말씀해 주세요.
