### PR TITLE
[FE/BE] 사용자 접속 목록 

### DIFF
--- a/chat_server/app.ts
+++ b/chat_server/app.ts
@@ -1,23 +1,22 @@
 import dotenv from "dotenv";
-import cookie from "cookie";
 import { createServer } from "http";
-import jwt from "jsonwebtoken";
+
 import { Server } from "socket.io";
 
 import { instrument } from "@socket.io/admin-ui";
 
 import { handleChatConnection } from "./controllers/chat_controller";
 import { handleNotificationConnection } from "./controllers/notification_controller";
-import { Socket } from "dgram";
+import { authMiddleware } from "./middleware/auth";
 
-dotenv.config({ path: "./../.env" });
+dotenv.config();
 
 const httpServer = createServer();
 
 // socket.io 서버 설정
 const io = new Server(httpServer, {
 	cors: {
-		origin: process.env.SERVER_ADDRESS || "http://localhost:8000",
+		origin: process.env.API_SERVER_ADDRESS || "http://localhost:8000",
 		credentials: true,
 	},
 });
@@ -30,23 +29,7 @@ instrument(io, {
 
 // 네임스페이스 설정
 const chatNamespace = io.of("/chat");
-chatNamespace.use((socket, next) => {
-	const cookieString = socket.handshake.headers.cookie;
-
-	if (cookieString === undefined) {
-		socket.disconnect();
-		return;
-	}
-
-	const cookies = cookie.parse(cookieString!) as {
-		refreshToken: string;
-		accessToken: string;
-	};
-
-	const { userId } = jwt.decode(cookies.refreshToken) as { userId: number };
-	(socket as unknown as Socket & { userId: number }).userId = userId;
-	next();
-});
+chatNamespace.use(authMiddleware(io));
 chatNamespace.on("connection", socket => {
 	handleChatConnection(socket);
 });

--- a/chat_server/controllers/chat_controller.ts
+++ b/chat_server/controllers/chat_controller.ts
@@ -1,9 +1,12 @@
 import { Socket } from "socket.io";
 import { handleRoomEvents } from "../events/chatroom_events";
 import { handleMessageEvents } from "../events/message_events";
+import { handleOnlineUserEvents } from "../events/online_user_events";
 
 export const handleChatConnection = (socket: Socket) => {
 	console.log(`새로운 클라이언트 채팅 접속 : ${socket.id}`);
+
+	handleOnlineUserEvents(socket);
 
 	handleRoomEvents(socket);
 	handleMessageEvents(socket);

--- a/chat_server/events/online_user_events.ts
+++ b/chat_server/events/online_user_events.ts
@@ -1,0 +1,32 @@
+import { Socket } from "socket.io";
+
+const onlineUsers = new Set<String>();
+
+export const handleOnlineUserEvents = (socket: Socket) => {
+	socket.on("request_online_users", () => {
+		socket.emit("receive_online_users", Array.from(onlineUsers));
+	});
+
+	socket.on("update_online_users", async (nickname: string) => {
+		console.log("data:", nickname);
+		if (nickname) {
+			onlineUsers.add(nickname);
+			socket.broadcast.emit(
+				"update_online_users",
+				Array.from(onlineUsers)
+			);
+			console.log("online_user_list ", Array.from(onlineUsers));
+		}
+	});
+
+	socket.on("logout", (nickname: string) => {
+		if (nickname && onlineUsers.has(nickname)) {
+			onlineUsers.delete(nickname);
+			socket.emit("update_online_users", Array.from(onlineUsers));
+			socket.broadcast.emit(
+				"update_online_users",
+				Array.from(onlineUsers)
+			);
+		}
+	});
+};

--- a/chat_server/middleware/auth.ts
+++ b/chat_server/middleware/auth.ts
@@ -1,0 +1,44 @@
+import { Socket } from "socket.io";
+import jwt from "jsonwebtoken";
+import cookie from "cookie";
+
+export const onlineUsers = new Set<number>();
+
+export const authMiddleware = (io: any) => (socket: Socket, next: any) => {
+	try {
+		const cookieString = socket.handshake.headers.cookie;
+
+		if (!cookieString) {
+			socket.disconnect;
+			return next(new Error("사용자 쿠키를 찾을 수 없습니다."));
+		}
+
+		const cookies = cookie.parse(cookieString) as {
+			accessToken: string;
+			refreshToken: string;
+		};
+
+		const { userId } = jwt.decode(cookies.refreshToken) as {
+			userId: number;
+		};
+
+		(socket as any).userId = userId;
+
+		onlineUsers.add(userId);
+		io.emit("update_online_users", Array.from(onlineUsers));
+
+		next();
+	} catch (error) {
+		console.error("Authentication error:", error);
+		next(new Error("Authentication error"));
+	}
+};
+
+export const handleUserDisconnection = (io: any, socket: Socket) => {
+	const userId = (socket as any).userId;
+	if (userId) {
+		onlineUsers.delete(userId);
+	}
+
+	io.emit("update_online_users", Array.from(onlineUsers));
+};

--- a/chat_server/middleware/auth.ts
+++ b/chat_server/middleware/auth.ts
@@ -2,8 +2,6 @@ import { Socket } from "socket.io";
 import jwt from "jsonwebtoken";
 import cookie from "cookie";
 
-export const onlineUsers = new Set<number>();
-
 export const authMiddleware = (io: any) => (socket: Socket, next: any) => {
 	try {
 		const cookieString = socket.handshake.headers.cookie;
@@ -24,21 +22,9 @@ export const authMiddleware = (io: any) => (socket: Socket, next: any) => {
 
 		(socket as any).userId = userId;
 
-		onlineUsers.add(userId);
-		io.emit("update_online_users", Array.from(onlineUsers));
-
 		next();
 	} catch (error) {
 		console.error("Authentication error:", error);
 		next(new Error("Authentication error"));
 	}
-};
-
-export const handleUserDisconnection = (io: any, socket: Socket) => {
-	const userId = (socket as any).userId;
-	if (userId) {
-		onlineUsers.delete(userId);
-	}
-
-	io.emit("update_online_users", Array.from(onlineUsers));
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,7 +10,7 @@ import CheckPassword from "./page/User/CheckPassword";
 import ProfileUpdate from "./page/User/ProfileUpdate";
 import clsx from "clsx";
 import { useErrorModal } from "./state/errorModalStore";
-import { useLayoutEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import ErrorModal from "./component/utils/ErrorModal";
 import OAuthRedirectHandler from "./page/OAuth/OAuthRedirectHandler";
 import ChatTestPage from "./page/Chat/ChatPage";
@@ -59,6 +59,7 @@ function App() {
 
 	const isLogin = useUserStore.use.isLogin();
 	const socket = useUserStore.use.socket();
+	const nickname = useUserStore.use.nickname();
 	const { isOpen } = useChatAside();
 
 	const { setSocket } = useUserStore.use.actions();
@@ -84,6 +85,14 @@ function App() {
 			return;
 		}
 	}, []);
+
+	useEffect(() => {
+		// 로그인 성공, 온라인 상태 업데이트
+		if (isLogin && socket) {
+			socket.emit("update_online_users", nickname);
+			return;
+		}
+	}, [socket, isLogin]);
 
 	return (
 		<div className={AppContainer}>

--- a/client/src/component/Header/Header.tsx
+++ b/client/src/component/Header/Header.tsx
@@ -75,6 +75,7 @@ const Header: React.FC = () => {
 		}
 
 		if (socket) {
+			socket.emit("logout", nickname);
 			socket.disconnect();
 			console.log("로그아웃, socket disconnect");
 		}

--- a/client/src/component/OnlineUser/OnlineUserItem/OnlineUserItem.css.ts
+++ b/client/src/component/OnlineUser/OnlineUserItem/OnlineUserItem.css.ts
@@ -1,0 +1,23 @@
+import { style } from "@vanilla-extract/css";
+
+export const onlineUserItem = style({
+	display: "flex",
+	justifyContent: "center",
+	marginBottom: "5px",
+	padding: "8px",
+	borderRadius: "4px",
+});
+
+export const onlineUserStatus = style({
+	fontSize: "14px",
+	fontWeight: "bold",
+});
+
+export const onlineUserDot = style({
+	width: "10px",
+	height: "10px",
+	backgroundColor: "green",
+	borderRadius: "50%",
+	marginTop: "5px",
+	marginRight: "10px",
+});

--- a/client/src/component/OnlineUser/OnlineUserItem/OnlineUserItem.tsx
+++ b/client/src/component/OnlineUser/OnlineUserItem/OnlineUserItem.tsx
@@ -1,0 +1,15 @@
+import { onlineUserItem } from "./OnlineUserItem.css";
+
+interface OnlineUserItemProps {
+	nickname: string;
+}
+
+const OnlineUserItem: React.FC<OnlineUserItemProps> = ({ nickname }) => {
+	return (
+		<div className={onlineUserItem}>
+			<span>{nickname}</span>
+		</div>
+	);
+};
+
+export default OnlineUserItem;

--- a/client/src/component/OnlineUser/OnlineUsers.css.ts
+++ b/client/src/component/OnlineUser/OnlineUsers.css.ts
@@ -1,0 +1,30 @@
+import { style } from "@vanilla-extract/css";
+
+export const onlineUserContainer = style({
+	position: "fixed",
+	left: "50px",
+	top: "300px",
+	transform: "translateY(-50%)",
+	width: "200px",
+	padding: "10px",
+	backgroundColor: "#808080",
+	border: "3px solid white",
+	borderRadius: "5px",
+	color: "f0f0f0",
+	fontWeight: "bold",
+});
+
+export const onlineUserList = style({
+	display: "flex",
+	flexDirection: "column",
+	alignItems: "center",
+	height: "300px",
+	overflowY: "auto",
+	padding: "10px",
+	borderRadius: "4px",
+});
+
+export const onlineUserTitle = style({
+	paddingBottom: "5px",
+	borderBottom: "2px solid white",
+});

--- a/client/src/component/OnlineUser/OnlineUsers.tsx
+++ b/client/src/component/OnlineUser/OnlineUsers.tsx
@@ -1,0 +1,64 @@
+import {
+	onlineUserContainer,
+	onlineUserList,
+	onlineUserTitle,
+} from "./OnlineUsers.css";
+import OnlineUserItem from "./OnlineUserItem/OnlineUserItem";
+import { useUserStore } from "../../state/store";
+import { useEffect, useLayoutEffect, useState } from "react";
+
+const OnlineUsers = () => {
+	const socket = useUserStore.use.socket();
+	const isLogin = useUserStore.use.isLogin();
+	const [onlineUsers, setOnlineUsers] = useState<string[] | null>(null);
+
+	useLayoutEffect(() => {
+		if (socket) {
+			socket.emit("request_online_users");
+
+			socket.on("receive_online_users", (users: string[]) => {
+				console.log("Initial online users:", users);
+				setOnlineUsers(users);
+			});
+		}
+
+		return () => {
+			if (socket) {
+				socket.off("receive_online_users");
+			}
+		};
+	}, [socket]);
+
+	useEffect(() => {
+		if (socket) {
+			socket.on("update_online_users", (res: string[]) => {
+				console.log("res : ", res);
+				setOnlineUsers(res);
+			});
+			console.log("setOnlineUsers : ", onlineUsers);
+
+			return () => {
+				socket.off("update_online_users");
+			};
+		}
+
+		if (!isLogin) {
+			setOnlineUsers(null);
+		}
+	}, [socket, isLogin]);
+
+	return (
+		<div className={onlineUserContainer}>
+			<div className={onlineUserTitle}>접속 현황</div>
+			<div className={onlineUserList}>
+				{onlineUsers?.map((nickname, index) => (
+					<OnlineUserItem
+						key={index}
+						nickname={nickname}
+					/>
+				))}
+			</div>
+		</div>
+	);
+};
+export default OnlineUsers;

--- a/client/src/page/Main/Main.tsx
+++ b/client/src/page/Main/Main.tsx
@@ -15,6 +15,7 @@ import {
 } from "./Main.css";
 import { ApiCall } from "../../api/api";
 import { ClientError } from "../../api/errors";
+import OnlineUsers from "../../component/OnlineUser/OnlineUsers";
 
 const Main = () => {
 	const isLogin = useUserStore(state => state.isLogin);
@@ -99,39 +100,43 @@ const Main = () => {
 	};
 
 	return (
-		<div className={mainPageStyle}>
-			{isModalOpen && <PostModal close={setIsModalOpen} />}
+		<div>
+			<div className={mainPageStyle}>
+				<OnlineUsers />
 
-			<PostList
-				posts={posts}
-				keyword={parsed.keyword}
-				sortBy={parsed.sortBy}
-				onSort={handlePostSort}
-			/>
+				{isModalOpen && <PostModal close={setIsModalOpen} />}
 
-			<Pagination
-				currentPage={parsed.index}
-				totalPosts={totalPosts}
-				perPage={parsed.perPage}
-				onChange={handlePageChange}
-			/>
-
-			<div className={postListActions}>
-				{isLogin && (
-					<div className={createPostButtonWrapper}>
-						<button
-							className={createPostButton}
-							onClick={handleCreatePostClick}
-						>
-							글쓰기
-						</button>
-					</div>
-				)}
-
-				<SearchForm
-					defaultKeyword={parsed.keyword}
-					onSubmit={handleSearchSubmit}
+				<PostList
+					posts={posts}
+					keyword={parsed.keyword}
+					sortBy={parsed.sortBy}
+					onSort={handlePostSort}
 				/>
+
+				<Pagination
+					currentPage={parsed.index}
+					totalPosts={totalPosts}
+					perPage={parsed.perPage}
+					onChange={handlePageChange}
+				/>
+
+				<div className={postListActions}>
+					{isLogin && (
+						<div className={createPostButtonWrapper}>
+							<button
+								className={createPostButton}
+								onClick={handleCreatePostClick}
+							>
+								글쓰기
+							</button>
+						</div>
+					)}
+
+					<SearchForm
+						defaultKeyword={parsed.keyword}
+						onSubmit={handleSearchSubmit}
+					/>
+				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>#208

## 📝 작업 내용

### 사용자 접속 목록 UI
![image](https://github.com/user-attachments/assets/491c3de8-0b75-4269-93f4-05d2f8623872)

![feature_socket_online_users](https://github.com/user-attachments/assets/37585caf-4337-45e0-9339-fd9e5f65efc7)

- [x] 사용자 접속 목록 UI
- [x] (client) 초기 사용자 목록 요청 `request_online_users`
- [x] (client) 로그인, 로그아웃 이벤트 `update_online_users`, `logout`
- [x] (server) 로그인, 로그아웃 이벤트 `update_online_users`, `logout`




## 🔖  향후 수정 계획
- 현재는 기본적인 UI만 작성한 상태입니다. 메인화면 디자인이 완료되면, 맞춰서 스타일링 리팩토링할 예정입니다.
- 사용자 nickname 이외, 필요한 정보가 있을 시 추가할 예정입니다.

## 💬 리뷰 요구사항(선택)
- 코드에 수정/보완해야할 점이 있을까요?
- 현재는 사용자의 nickname만 보여지고 있는데, 추가할 내용이 있을까요?


