### PR TITLE
[FE] 게시글 편집기 및 게시글 열람 페이지

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
 		"react-chartjs-2": "^5.2.0",
 		"react-dom": "^18.3.1",
 		"react-icons": "^5.2.1",
+		"react-quill": "^2.0.0",
 		"react-router-dom": "^6.24.1",
 		"shared": "^1.0.0",
 		"socket.io-client": "^4.7.5",

--- a/client/src/component/Posts/Editer/CustomEditor.tsx
+++ b/client/src/component/Posts/Editer/CustomEditor.tsx
@@ -70,6 +70,10 @@ const CustomEditorBase: React.FC<IProps> = ({
 
 			const url = await upload(file);
 
+			if (!url) {
+				return;
+			}
+
 			const quill = quillRef.current?.getEditor();
 			const selectionIndex =
 				quill?.getSelection()?.index ?? quill?.getLength() ?? 0;

--- a/client/src/component/Posts/Editer/CustomEditor.tsx
+++ b/client/src/component/Posts/Editer/CustomEditor.tsx
@@ -51,7 +51,7 @@ const CustomEditorBase: React.FC<IProps> = ({
 
 			return res.imgUrl as string;
 		},
-		[globalErrorModal]
+		[globalErrorModal.openWithMessageSplit]
 	);
 
 	const handleImageUpload = useCallback(() => {

--- a/client/src/component/Posts/Editer/CustomEditor.tsx
+++ b/client/src/component/Posts/Editer/CustomEditor.tsx
@@ -102,12 +102,12 @@ const CustomEditorBase: React.FC<IProps> = ({
 
 	return (
 		<ReactQuill
-			theme="snow"
 			ref={quillRef}
 			modules={quillModules}
 			value={content}
 			onChange={setContent}
-			className="mb-16 h-96 min-h-96"
+			theme="snow"
+			className="mb-11 h-[calc(100vh-320px)]"
 		/>
 	);
 };

--- a/client/src/component/Posts/Editer/CustomEditor.tsx
+++ b/client/src/component/Posts/Editer/CustomEditor.tsx
@@ -89,6 +89,7 @@ const CustomEditorBase: React.FC<IProps> = ({
 					[{ font: [] }],
 					[{ size: ["small", false, "large", "huge"] }],
 					["bold", "underline", { color: toolbarColors }],
+					["code-block"],
 					["image"],
 					["clean"],
 				],

--- a/client/src/component/Posts/Editer/CustomEditor.tsx
+++ b/client/src/component/Posts/Editer/CustomEditor.tsx
@@ -1,9 +1,10 @@
 import React, { SetStateAction, useCallback, useMemo } from "react";
-import ReactQuill from "react-quill";
+import ReactQuill, { Quill } from "react-quill";
 import "react-quill/dist/quill.snow.css";
 import { ApiCall } from "../../../api/api";
 import { uploadImageRequest } from "../../../api/posts/crud";
 import { useGlobalErrorModal } from "../../../state/GlobalErrorModalStore";
+import { toolbarColors } from "./toolbarColors";
 
 /*
 client
@@ -21,6 +22,10 @@ interface IProps {
 	content: string;
 	setContent: React.Dispatch<SetStateAction<string>>;
 }
+
+// 다크모드 호환을 위해 인라인 스타일 대신 클래스로 컬러 적용
+const ColorClass = Quill.import("attributors/class/color");
+Quill.register(ColorClass, true);
 
 const CustomEditorBase: React.FC<IProps> = ({
 	quillRef,
@@ -83,7 +88,7 @@ const CustomEditorBase: React.FC<IProps> = ({
 				container: [
 					[{ font: [] }],
 					[{ size: ["small", false, "large", "huge"] }],
-					["bold", "underline", { color: [] }],
+					["bold", "underline", { color: toolbarColors }],
 					["image"],
 					["clean"],
 				],

--- a/client/src/component/Posts/Editer/ImageManager.tsx
+++ b/client/src/component/Posts/Editer/ImageManager.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { FiImage, FiTrash2 } from "react-icons/fi";
 import ReactQuill from "react-quill";
 import Button from "../../common/Button";
 
@@ -28,17 +29,46 @@ const ImageManager: React.FC<IProps> = ({ quillRef, editorContents }) => {
 		setImageUrlSet(nextImageUrlSet);
 	}, [quillRef.current, editorContents]);
 
-	return (
-		<div className="text-start">
-			<div>첨부한 이미지</div>
+	// TODO: 이미지 삭제 API 호출
+	const handleDeleteWith = (url: string) => () => {
+		alert(`이미지 삭제: ${url}`);
+	};
 
-			<div>
-				{Array.from(imageUrlSet, url => (
-					<div key={url}>
-						<img src={url} />
-						<Button>삭제</Button>
+	return (
+		<div className="flex w-full flex-col gap-2 text-start">
+			<div className="ml-1 text-sm font-bold text-blue-900">
+				첨부한 이미지
+			</div>
+
+			<div className="grid grid-cols-6 gap-4 rounded-md border border-gray-600 p-4">
+				{imageUrlSet.size === 0 ? (
+					<div className="col-span-full flex items-center justify-center gap-2 p-8 text-center text-xl font-medium opacity-30">
+						<FiImage />
+						<div>첨부한 이미지가 없습니다.</div>
 					</div>
-				))}
+				) : (
+					Array.from(imageUrlSet, url => (
+						<div
+							key={url}
+							className="relative overflow-hidden rounded-md"
+						>
+							<img
+								src={url}
+								className="aspect-square w-auto object-cover"
+							/>
+							<Button
+								size="small"
+								variant="text"
+								onClick={handleDeleteWith(url)}
+								className="absolute right-2 top-2 bg-white/65 p-2 shadow backdrop-blur-sm"
+								// TODO: className 충돌로 인하여 Tailwind Merge 도입 필요
+								style={{ padding: "8px" }}
+							>
+								<FiTrash2 />
+							</Button>
+						</div>
+					))
+				)}
 			</div>
 		</div>
 	);

--- a/client/src/component/Posts/Editer/ImageManager.tsx
+++ b/client/src/component/Posts/Editer/ImageManager.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import ReactQuill from "react-quill";
+import Button from "../../common/Button";
+
+interface IProps {
+	quillRef: React.RefObject<ReactQuill>;
+	editorContents: string;
+}
+
+const ImageManager: React.FC<IProps> = ({ quillRef, editorContents }) => {
+	const [imageUrlSet, setImageUrlSet] = useState(new Set<string>());
+
+	// useMemo로 첫 렌더부터 이미지 목록을 만들면
+	// Quill 초기화 타이밍과 엇나가면서 이미지 목록을 못 만들 때가 있어서
+	// 일부러 useEffect + state로 한 타이밍 늦게 이미지 목록 생성
+	useEffect(() => {
+		// TODO: 정렬: 업로드순, 타임스탬프를 제외한 파일명순 (현재는 본문 순서대로 표시)
+		const delta = quillRef.current?.editor?.getContents();
+		const nextImageUrlSet = new Set<string>();
+
+		for (const op of delta?.ops ?? []) {
+			if (op.insert?.image) {
+				// TODO: S3 URL인지 검사하여 필터
+				nextImageUrlSet.add(op.insert.image);
+			}
+		}
+
+		setImageUrlSet(nextImageUrlSet);
+	}, [quillRef.current, editorContents]);
+
+	return (
+		<div className="text-start">
+			<div>첨부한 이미지</div>
+
+			<div>
+				{Array.from(imageUrlSet, url => (
+					<div key={url}>
+						<img src={url} />
+						<Button>삭제</Button>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+};
+
+export default ImageManager;

--- a/client/src/component/Posts/Editer/toolbarColors.ts
+++ b/client/src/component/Posts/Editer/toolbarColors.ts
@@ -1,0 +1,37 @@
+export const toolbarColors = [
+	// 1행: Primary color row
+	false, // 기본 컬러
+	"red3",
+	"amber3",
+	"emerald3",
+	"blue3",
+	"violet3",
+	"pink3",
+
+	// 2행
+	"gray1",
+	"red1",
+	"amber1",
+	"emerald1",
+	"blue1",
+	"violet1",
+	"pink1",
+
+	// 3행
+	"gray2",
+	"red2",
+	"amber2",
+	"emerald2",
+	"blue2",
+	"violet2",
+	"pink2",
+
+	// 4행
+	"gray3",
+	"red4",
+	"amber4",
+	"emerald4",
+	"blue4",
+	"violet4",
+	"pink4",
+];

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -180,7 +180,7 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 			</div>
 			<div className="flex flex-col">
 				<div
-					className="flex h-full w-[780px] resize-none flex-col text-start"
+					className="post-body h-full w-[780px] resize-none text-start text-base"
 					dangerouslySetInnerHTML={{ __html: content }}
 				/>
 				<div

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -39,11 +39,8 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 	const time = postInfo.updated_at
 		? new Date(postInfo.updated_at)
 		: new Date(postInfo.created_at);
-
 	const updateTxt = postInfo.updated_at ? " (수정됨)" : "";
-
 	const isAuthor = postInfo.is_author;
-
 	const content = postInfo.content;
 
 	const isLogin = useUserStore(state => state.isLogin);
@@ -75,6 +72,12 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 			setLikes(likes + 1);
 			setUserLiked(true);
 		}
+	};
+
+	const handleUpdate = () => {
+		const url = `/post/new?postId=${postInfo.id}&title=${encodeURIComponent(postInfo.title)}&content=${encodeURIComponent(postInfo.content)}`;
+
+		navigate(url);
 	};
 
 	const handlePostDelete = useCallback(async () => {
@@ -109,6 +112,7 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 		<div>
 			{/* 모달 부분 css 수정 x*/}
 			{updateModal.isOpen ? (
+				// TODO: 편집기 작업 완료 후, 도달할 수 없는 분기 제거
 				<PostModal
 					close={() => updateModal.close()}
 					originalPostData={postInfo}
@@ -140,64 +144,58 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 					<div className="text-left text-2xl font-bold">
 						<div className="mb-2 mt-4">{postInfo.title}</div>
 					</div>
+
 					<div className="mb-4 flex items-center justify-between">
 						<div className="flex items-center gap-2 text-lg">
 							<div>{postInfo.author_nickname}</div>
 							<div>{dateToStr(time) + updateTxt}</div>
 						</div>
+
 						<div className="flex items-center gap-2 text-base">
 							<IoEyeOutline />
 							<div>{postInfo.views}</div>
+
 							<FaRegThumbsUp />
 							<div>{postInfo.likes}</div>
+
 							{isAuthor ? (
-								<Button
-									size="small"
-									onClick={() => {
-										navigate(
-											`/post/new?postId=${postInfo.id}&title=${encodeURIComponent(postInfo.title)}&content=${encodeURIComponent(postInfo.content)}`
-										);
-									}}
-									variant="text"
-									color="neutral"
-								>
-									수정
-								</Button>
-							) : null}
-							{isAuthor ? (
-								<Button
-									size="small"
-									onClick={deleteModal.open}
-									variant="text"
-									color="danger"
-								>
-									삭제
-								</Button>
+								<>
+									<Button
+										size="small"
+										onClick={handleUpdate}
+										variant="text"
+										color="neutral"
+									>
+										수정
+									</Button>
+									<Button
+										size="small"
+										onClick={deleteModal.open}
+										variant="text"
+										color="danger"
+									>
+										삭제
+									</Button>
+								</>
 							) : null}
 						</div>
 					</div>
 				</div>
 			</div>
+
 			<div className="flex flex-col">
 				<div
 					className="post-body h-full w-[780px] resize-none text-start text-base"
 					dangerouslySetInnerHTML={{ __html: content }}
 				/>
-				<div
-					className={`mt-10 flex flex-col items-center justify-center`}
-				>
+
+				<div className="mt-10 flex flex-col items-center justify-center">
 					<div
-						className="flex flex-col items-center"
+						className={`flex flex-col items-center ${userLiked ? "text-green-500" : "text-gray-600 dark:text-gray-200"}`}
 						onClick={handleLike}
 					>
-						<FaRegThumbsUp
-							className={`text-3xl ${userLiked ? "text-green-500" : "text-gray-600 dark:text-gray-200"}`}
-						/>
-						<div
-							className={`text-1xl ${userLiked ? "text-green-500" : "text-gray-600 dark:text-gray-200"}`}
-						>
-							{likes}
-						</div>
+						<FaRegThumbsUp className="text-3xl" />
+						<div className="text-xl">{likes}</div>
 					</div>
 				</div>
 			</div>

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -155,7 +155,7 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 									size="small"
 									onClick={() => {
 										navigate(
-											`/post/new?postId=${postInfo.id}&title=${postInfo.title}&content=${postInfo.content}`
+											`/post/new?postId=${postInfo.id}&title=${encodeURIComponent(postInfo.title)}&content=${encodeURIComponent(postInfo.content)}`
 										);
 									}}
 									variant="text"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,40 +1,8 @@
+@import "./style/quill-post.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@layer components {
-	.quill {
-		@apply text-start;
-	}
-
-	:is(.post-body, .ql-editor) {
-		@apply font-sans text-base;
-	}
-
-	:is(.post-body, .ql-editor) :is(b, strong) {
-		@apply font-bold;
-	}
-	:is(.post-body, .ql-editor) u {
-		@apply underline;
-	}
-
-	:is(.post-body, .ql-editor) .ql-font-serif {
-		@apply font-serif;
-	}
-	:is(.post-body, .ql-editor) .ql-font-monospace {
-		@apply font-mono;
-	}
-
-	:is(.post-body, .ql-editor) .ql-size-small {
-		@apply text-sm;
-	}
-	:is(.post-body, .ql-editor) .ql-size-large {
-		@apply text-xl;
-	}
-	:is(.post-body, .ql-editor) .ql-size-huge {
-		@apply text-2xl;
-	}
-}
 
 :root {
 	font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2,6 +2,40 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+	.quill {
+		@apply text-start;
+	}
+
+	:is(.post-body, .ql-editor) {
+		@apply font-sans text-base;
+	}
+
+	:is(.post-body, .ql-editor) :is(b, strong) {
+		@apply font-bold;
+	}
+	:is(.post-body, .ql-editor) u {
+		@apply underline;
+	}
+
+	:is(.post-body, .ql-editor) .ql-font-serif {
+		@apply font-serif;
+	}
+	:is(.post-body, .ql-editor) .ql-font-monospace {
+		@apply font-mono;
+	}
+
+	:is(.post-body, .ql-editor) .ql-size-small {
+		@apply text-sm;
+	}
+	:is(.post-body, .ql-editor) .ql-size-large {
+		@apply text-xl;
+	}
+	:is(.post-body, .ql-editor) .ql-size-huge {
+		@apply text-2xl;
+	}
+}
+
 :root {
 	font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
 	line-height: 1.5;
@@ -10,7 +44,7 @@
 	color-scheme: light dark;
 	color: rgba(255, 255, 255, 0.87);
 	background-color: #ffffff;
-	color: black; 
+	color: black;
 
 	font-synthesis: none;
 	text-rendering: optimizeLegibility;
@@ -19,10 +53,9 @@
 }
 
 .dark {
-	background-color: #242424; 
-	color: #ffffff; 
+	background-color: #242424;
+	color: #ffffff;
 }
-
 
 a {
 	font-weight: 500;
@@ -56,8 +89,6 @@ button {
 }
 
 button:focus,
-
 button:focus-visible {
 	outline: 4px auto -webkit-focus-ring-color;
 }
-

--- a/client/src/page/Posts/UpsertPostPage.tsx
+++ b/client/src/page/Posts/UpsertPostPage.tsx
@@ -119,7 +119,7 @@ const UpsertPostPage: React.FC = () => {
 
 			<ImageManager
 				quillRef={quillRef}
-				editorContents={quillRef.current?.editor?.getText() ?? ""}
+				editorContents={postContent}
 			/>
 
 			<div className="flex w-full items-end justify-end gap-4">

--- a/client/src/page/Posts/UpsertPostPage.tsx
+++ b/client/src/page/Posts/UpsertPostPage.tsx
@@ -120,6 +120,7 @@ const UpsertPostPage: React.FC = () => {
 			<ImageManager
 				quillRef={quillRef}
 				editorContents={postContent}
+				setEditorContents={setPostContent}
 			/>
 
 			<div className="flex w-full items-end justify-end gap-4">

--- a/client/src/page/Posts/UpsertPostPage.tsx
+++ b/client/src/page/Posts/UpsertPostPage.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
+import ReactQuill from "react-quill";
 import TextInput from "../../component/common/TextInput";
 import { useLocation, useNavigate } from "react-router-dom";
 import {
@@ -27,6 +28,8 @@ const UpsertPostPage: React.FC = () => {
 
 	const [postTitle, setPostTitle] = useState<string>(title);
 	const [postContent, setPostContent] = useState<string>(content);
+
+	const quillRef = useRef<ReactQuill>(null);
 
 	const createPost = async () => {
 		const body = {
@@ -135,6 +138,7 @@ const UpsertPostPage: React.FC = () => {
 				<div className={InputContainer}>
 					<div className={InputIndex}>내용</div>
 					<CustomEditor
+						quillRef={quillRef}
 						content={postContent}
 						setContent={setPostContent}
 					/>

--- a/client/src/page/Posts/UpsertPostPage.tsx
+++ b/client/src/page/Posts/UpsertPostPage.tsx
@@ -2,10 +2,6 @@ import React, { useRef, useState } from "react";
 import ReactQuill from "react-quill";
 import TextInput from "../../component/common/TextInput";
 import { useLocation, useNavigate } from "react-router-dom";
-import {
-	InputContainer,
-	InputIndex,
-} from "../../component/Posts/Modal/PostModal.css";
 import CustomEditor from "../../component/Posts/Editer/CustomEditor";
 import Button from "../../component/common/Button";
 import { ApiCall } from "../../api/api";
@@ -100,67 +96,47 @@ const UpsertPostPage: React.FC = () => {
 	// };
 
 	return (
-		<div
-			style={{
-				display: "flex",
-				flexDirection: "column",
-				justifyContent: "center",
-				alignItems: "center",
-				width: "100%",
-				paddingLeft: "50px",
-				paddingRight: "50px",
-				paddingTop: "10px",
-				paddingBottom: "10px",
-			}}
-		>
-			<div
-				style={{
-					display: "flex",
-					flexDirection: "column",
-					justifyContent: "center",
-					alignItems: "center",
-					width: "100%",
-					paddingLeft: "50px",
-					paddingRight: "50px",
-					paddingTop: "30px",
-					paddingBottom: "30px",
-					border: "1px solid #ccc",
-					gap: "20px",
-				}}
-			>
-				<div className={InputContainer}>
-					<div className={InputIndex}>제목</div>
-					<TextInput
-						placeholder="제목을 입력해주세요"
-						value={postTitle}
-						onChange={e => setPostTitle(e.target.value)}
-					/>
-				</div>
+		<div className="flex w-[860px] flex-col items-center justify-center gap-6 px-6 py-6 text-start">
+			<TextInput
+				wrapperClassName="w-full"
+				label="제목"
+				errorMessage="제목이 비었습니다."
+				type="text"
+				id="post-title"
+				placeholder="제목을 입력하세요."
+				value={postTitle}
+				onChange={e => setPostTitle(e.target.value)}
+			/>
 
-				<div className={InputContainer}>
-					<div className={InputIndex}>내용</div>
-					<CustomEditor
-						quillRef={quillRef}
-						content={postContent}
-						setContent={setPostContent}
-					/>
-				</div>
-
-				<ImageManager
+			<div className="flex w-full flex-col gap-1">
+				<div className="ml-1 text-sm font-bold text-blue-900">내용</div>
+				<CustomEditor
 					quillRef={quillRef}
-					editorContents={quillRef.current?.editor?.getText() ?? ""}
+					content={postContent}
+					setContent={setPostContent}
 				/>
+			</div>
 
-				<div>
-					<Button
-						onClick={() => {
-							navigate(-1);
-						}}
-					>
-						취소
-					</Button>
-					<Button onClick={handleUpsertPost}>쓰기</Button>
-				</div>
+			<ImageManager
+				quillRef={quillRef}
+				editorContents={quillRef.current?.editor?.getText() ?? ""}
+			/>
+
+			<div className="flex w-full items-end justify-end gap-4">
+				<Button
+					color="neutral"
+					variant="outline"
+					onClick={() => navigate(-1)}
+				>
+					취소
+				</Button>
+
+				<Button
+					color="primary"
+					onClick={handleUpsertPost}
+				>
+					작성 완료
+				</Button>
 			</div>
 		</div>
 	);

--- a/client/src/page/Posts/UpsertPostPage.tsx
+++ b/client/src/page/Posts/UpsertPostPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../api/posts/crud";
 import { ClientError } from "../../api/errors";
 import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
+import ImageManager from "../../component/Posts/Editer/ImageManager";
 
 const UpsertPostPage: React.FC = () => {
 	const navigate = useNavigate();
@@ -135,6 +136,7 @@ const UpsertPostPage: React.FC = () => {
 						onChange={e => setPostTitle(e.target.value)}
 					/>
 				</div>
+
 				<div className={InputContainer}>
 					<div className={InputIndex}>내용</div>
 					<CustomEditor
@@ -143,6 +145,12 @@ const UpsertPostPage: React.FC = () => {
 						setContent={setPostContent}
 					/>
 				</div>
+
+				<ImageManager
+					quillRef={quillRef}
+					editorContents={quillRef.current?.editor?.getText() ?? ""}
+				/>
+
 				<div>
 					<Button
 						onClick={() => {

--- a/client/src/style/quill-post-color.css
+++ b/client/src/style/quill-post-color.css
@@ -1,0 +1,173 @@
+/* Quill에 적용할 색상 정의 */
+@layer components {
+	/* Quill 내부에서 강제로 적용하는, 툴바 글자색 버튼의 밑줄 색 인라인 스타일 되돌리기 */
+	.ql-snow.ql-toolbar .ql-picker-label.ql-active .ql-stroke {
+		@apply stroke-current !important;
+	}
+
+	/* 글자 색상 커스텀 클래스 (다크모드 호환) */
+	:is(.post-body, .ql-editor) .ql-color-gray1 {
+		@apply text-neutral-300 dark:text-neutral-600;
+	}
+	:is(.post-body, .ql-editor) .ql-color-gray2 {
+		@apply text-neutral-400 dark:text-neutral-500;
+	}
+	:is(.post-body, .ql-editor) .ql-color-gray3 {
+		@apply text-neutral-500 dark:text-neutral-400;
+	}
+	:is(.post-body, .ql-editor) .ql-color-red1 {
+		@apply text-red-200 dark:text-red-800;
+	}
+	:is(.post-body, .ql-editor) .ql-color-red2 {
+		@apply text-red-400 dark:text-red-600;
+	}
+	:is(.post-body, .ql-editor) .ql-color-red3 {
+		@apply text-red-600 dark:text-red-400;
+	}
+	:is(.post-body, .ql-editor) .ql-color-red4 {
+		@apply text-red-800 dark:text-red-200;
+	}
+	:is(.post-body, .ql-editor) .ql-color-amber1 {
+		@apply text-amber-200 dark:text-amber-800;
+	}
+	:is(.post-body, .ql-editor) .ql-color-amber2 {
+		@apply text-amber-400 dark:text-amber-600;
+	}
+	:is(.post-body, .ql-editor) .ql-color-amber3 {
+		@apply text-amber-600 dark:text-amber-400;
+	}
+	:is(.post-body, .ql-editor) .ql-color-amber4 {
+		@apply text-amber-800 dark:text-amber-200;
+	}
+	:is(.post-body, .ql-editor) .ql-color-emerald1 {
+		@apply text-emerald-200 dark:text-emerald-800;
+	}
+	:is(.post-body, .ql-editor) .ql-color-emerald2 {
+		@apply text-emerald-400 dark:text-emerald-600;
+	}
+	:is(.post-body, .ql-editor) .ql-color-emerald3 {
+		@apply text-emerald-600 dark:text-emerald-400;
+	}
+	:is(.post-body, .ql-editor) .ql-color-emerald4 {
+		@apply text-emerald-800 dark:text-emerald-200;
+	}
+	:is(.post-body, .ql-editor) .ql-color-blue1 {
+		@apply text-blue-200 dark:text-blue-800;
+	}
+	:is(.post-body, .ql-editor) .ql-color-blue2 {
+		@apply text-blue-400 dark:text-blue-600;
+	}
+	:is(.post-body, .ql-editor) .ql-color-blue3 {
+		@apply text-blue-600 dark:text-blue-400;
+	}
+	:is(.post-body, .ql-editor) .ql-color-blue4 {
+		@apply text-blue-800 dark:text-blue-200;
+	}
+	:is(.post-body, .ql-editor) .ql-color-violet1 {
+		@apply text-violet-200 dark:text-violet-800;
+	}
+	:is(.post-body, .ql-editor) .ql-color-violet2 {
+		@apply text-violet-400 dark:text-violet-600;
+	}
+	:is(.post-body, .ql-editor) .ql-color-violet3 {
+		@apply text-violet-600 dark:text-violet-400;
+	}
+	:is(.post-body, .ql-editor) .ql-color-violet4 {
+		@apply text-violet-800 dark:text-violet-200;
+	}
+	:is(.post-body, .ql-editor) .ql-color-pink1 {
+		@apply text-pink-200 dark:text-pink-800;
+	}
+	:is(.post-body, .ql-editor) .ql-color-pink2 {
+		@apply text-pink-400 dark:text-pink-600;
+	}
+	:is(.post-body, .ql-editor) .ql-color-pink3 {
+		@apply text-pink-600 dark:text-pink-400;
+	}
+	:is(.post-body, .ql-editor) .ql-color-pink4 {
+		@apply text-pink-800 dark:text-pink-200;
+	}
+
+	/* 글자색 드롭다운 항목 색상 지정 */
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="gray1"] {
+		@apply bg-neutral-300 dark:bg-neutral-600;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="gray2"] {
+		@apply bg-neutral-400 dark:bg-neutral-500;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="gray3"] {
+		@apply bg-neutral-500 dark:bg-neutral-400;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="red1"] {
+		@apply bg-red-200 dark:bg-red-800;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="red2"] {
+		@apply bg-red-400 dark:bg-red-600;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="red3"] {
+		@apply bg-red-600 dark:bg-red-400;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="red4"] {
+		@apply bg-red-800 dark:bg-red-200;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="amber1"] {
+		@apply bg-amber-200 dark:bg-amber-800;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="amber2"] {
+		@apply bg-amber-400 dark:bg-amber-600;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="amber3"] {
+		@apply bg-amber-600 dark:bg-amber-400;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="amber4"] {
+		@apply bg-amber-800 dark:bg-amber-200;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="emerald1"] {
+		@apply bg-emerald-200 dark:bg-emerald-800;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="emerald2"] {
+		@apply bg-emerald-400 dark:bg-emerald-600;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="emerald3"] {
+		@apply bg-emerald-600 dark:bg-emerald-400;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="emerald4"] {
+		@apply bg-emerald-800 dark:bg-emerald-200;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="blue1"] {
+		@apply bg-blue-200 dark:bg-blue-800;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="blue2"] {
+		@apply bg-blue-400 dark:bg-blue-600;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="blue3"] {
+		@apply bg-blue-600 dark:bg-blue-400;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="blue4"] {
+		@apply bg-blue-800 dark:bg-blue-200;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="violet1"] {
+		@apply bg-violet-200 dark:bg-violet-800;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="violet2"] {
+		@apply bg-violet-400 dark:bg-violet-600;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="violet3"] {
+		@apply bg-violet-600 dark:bg-violet-400;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="violet4"] {
+		@apply bg-violet-800 dark:bg-violet-200;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="pink1"] {
+		@apply bg-pink-200 dark:bg-pink-800;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="pink2"] {
+		@apply bg-pink-400 dark:bg-pink-600;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="pink3"] {
+		@apply bg-pink-600 dark:bg-pink-400;
+	}
+	.ql-snow .ql-color-picker.ql-color .ql-picker-item[data-value="pink4"] {
+		@apply bg-pink-800 dark:bg-pink-200;
+	}
+}

--- a/client/src/style/quill-post.css
+++ b/client/src/style/quill-post.css
@@ -38,4 +38,9 @@
 	:is(.post-body, .ql-editor) .ql-size-huge {
 		@apply text-2xl;
 	}
+
+	/* 코드 블록 클래스 */
+	:is(.post-body, .ql-editor) pre.ql-syntax.ql-syntax {
+		@apply mx-0 my-2 rounded-md bg-gray-100 px-3 py-2 font-mono text-sm text-gray-700;
+	}
 }

--- a/client/src/style/quill-post.css
+++ b/client/src/style/quill-post.css
@@ -1,0 +1,41 @@
+@import "./quill-post-color.css";
+
+/* Quill 에디터 및 게시글 내용에 적용하는 스타일 */
+@layer components {
+	/* Quill 에디터 툴바를 포함하는 루트 */
+	.quill {
+		@apply text-start;
+	}
+
+	/* 게시글 본문 영역 및 Quill 에디터 본문 영역 */
+	:is(.post-body, .ql-editor) {
+		@apply font-sans text-base;
+	}
+
+	/* 글자 강조 클래스 */
+	:is(.post-body, .ql-editor) :is(b, strong) {
+		@apply font-bold;
+	}
+	:is(.post-body, .ql-editor) u {
+		@apply underline;
+	}
+
+	/* 서체 클래스 */
+	:is(.post-body, .ql-editor) .ql-font-serif {
+		@apply font-serif;
+	}
+	:is(.post-body, .ql-editor) .ql-font-monospace {
+		@apply font-mono;
+	}
+
+	/* 글자 크기 클래스 */
+	:is(.post-body, .ql-editor) .ql-size-small {
+		@apply text-sm;
+	}
+	:is(.post-body, .ql-editor) .ql-size-large {
+		@apply text-xl;
+	}
+	:is(.post-body, .ql-editor) .ql-size-huge {
+		@apply text-2xl;
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #277
- #279

<br>

## 📝 작업 내용

게시글 편집기와 관련된 클라이언트 작업입니다.

- 글쓰기 페이지에 React Quill 에디터 적용
  - 최소 기능 사용: 굵기, 밑줄, 크기, 폰트, 텍스트 컬러, 이미지
- 게시글 열람 페이지의 게시글 영역 스타일 작성: `ql-`로 시작하는 className
  - 게시글 에디터에서도 게시글 열람 페이지와 동일하게 보이도록 스타일링
  - 다크 모드를 위한 글자색 처리: 에디터 기본값인 인라인 스타일 하드코딩에서 className 부여 방식으로 변경
- 이미지 파일 관리
  - 이미지 첨부 구현: 서버에 이미지 업로드 요청 후 URL을 받아서 본문에 `<img>` 엘리먼트 삽입
  - 업로드한 이미지 목록 — Quill 에디터 객체에 접근하여, S3에 업로드한 이미지 목록 추출

> <details><summary>후속 진행 예정 작업</summary>
>
> - 업로드한 이미지 삭제: 서버로 삭제 요청 후 에디터에 반영
> - 이미지 편집: 크기 조정
>
> </details>

<br>

### 🖼️ 스크린샷

#### 게시글 에디터 (React Quill)

에디터 폭을 게시글 열람 페이지의 너비와 맞췄습니다.

![post-summary](https://github.com/user-attachments/assets/06adbce9-7994-4529-afd6-37db845b9456)

#### 글자색 라이트모드/다크모드 견본

"같은 자리 = 같은 className"입니다.

<img width="368" alt="라이트모드 글자색" src="https://github.com/user-attachments/assets/f72931a0-30c4-429b-8c60-cc205316129c">
<img width="368" alt="다크모드 글자색" src="https://github.com/user-attachments/assets/2b64e34a-8c3c-4c76-ac65-e7314b156a8b">

<br>

<br>

## 💬 리뷰 요구사항

- 업로드한 이미지 목록을 게시글 내용에서 추출했는데, 이렇게 구현해도 괜찮을까요?
  - 이렇게 하면 나중에 이미지 삭제 기능을 넣었을 때, 다른 유저가 업로드한 이미지를 S3에서 제거할 수 있게 됩니다.
  - 시나리오: 타인의 글에서 첨부 이미지 복사 → 내 글에 붙여넣기 → 첨부한 이미지 목록에 뜨는 타인의 이미지 삭제
- 잘못 구현되었거나 변경했으면 하는 부분 있으면 말씀해 주세요.
  - 에디터 영역 스타일링은(박스, 툴바, 다크모드) 기능 먼저 구현해 놓고 틈틈이 진행하려 합니다.
  - 폼 레이블 다크모드 또한 틈틈이 진행하려 합니다. (`<TextInput>` 컴포넌트와도 관련 있음)