### PR TITLE
[BE] 메인페이지 랭킹 추가

### DIFF
--- a/nestjs-migration/src/app.module.ts
+++ b/nestjs-migration/src/app.module.ts
@@ -26,6 +26,7 @@ import { OAuthModule } from "./oauth/oauth.module";
 import { PostModule } from "./post/post.module";
 import { RbacModule } from "./rbac/rbac.module";
 import { UserModule } from "./user/user.module";
+import { RankModule } from "./rank/rank.module";
 
 @Module({
 	imports: [
@@ -68,6 +69,7 @@ import { UserModule } from "./user/user.module";
 		ChatModule,
 		AdminModule,
 		HealthModule,
+		RankModule,
 	],
 	controllers: [AppController],
 	providers: [

--- a/nestjs-migration/src/comment/comment.repository.ts
+++ b/nestjs-migration/src/comment/comment.repository.ts
@@ -136,17 +136,21 @@ export class CommentRepository extends Repository<Comment> {
 		const queryBuilder = this.createQueryBuilder("comment")
 			.leftJoin("comment.author", "user")
 			.leftJoin("comment.comment_likes", "cl")
+			.leftJoin("comment.post", "post")
 			.select([
 				"user.nickname as nickname",
 				"COUNT(*) as likeCount",
-				"comment.id",
+				"comment.id as commentId",
+				"post.id as postId",
 			])
 			.where("comment.is_delete = :isDeleted", { isDeleted: false })
+			.andWhere("post.is_delete = :isDeleted", { isDeleted: false })
 			.andWhere("user.is_delete = :isDeleted", {
 				isDeleted: false,
 			})
 			.groupBy("comment.id")
 			.orderBy("likeCount", "DESC") // 좋아요 수로 정렬
+			.addOrderBy("comment.id", "ASC")
 			.limit(5);
 
 		const results = await queryBuilder.getRawMany();

--- a/nestjs-migration/src/post/post.repository.ts
+++ b/nestjs-migration/src/post/post.repository.ts
@@ -280,6 +280,7 @@ export class PostRepository extends Repository<Post> {
 			.leftJoin("post.likes", "pl")
 			.select([
 				"post.title as title",
+				"post.id as postId",
 				"user.nickname as nickname",
 				"COUNT(*) as likeCount",
 			])
@@ -289,7 +290,8 @@ export class PostRepository extends Repository<Post> {
 			})
 			.groupBy("post.id")
 			.orderBy("likeCount", "DESC")
-			.limit(5); //join에서 쓰지 말라던데
+			.addOrderBy("post.id", "ASC")
+			.limit(5);
 
 		const results = await queryBuilder.getRawMany();
 

--- a/nestjs-migration/src/post/post.repository.ts
+++ b/nestjs-migration/src/post/post.repository.ts
@@ -8,6 +8,7 @@ import { GetPostHeadersDto } from "./dto/get-post-headers.dto";
 import { ReadPostsQuery, SortBy } from "./dto/read-posts-query.dto";
 import { Post } from "./entities/post.entity";
 import { GetPostDto } from "./dto/get-post.dto";
+import { GetTopPostsRes } from "src/rank/dto/get-top-posts.dto";
 
 @Injectable()
 export class PostRepository extends Repository<Post> {
@@ -70,7 +71,7 @@ export class PostRepository extends Repository<Post> {
 
 		queryBuilder
 			.addOrderBy("user.id", "ASC")
-			.limit(perPage)
+			.limit(perPage) //TODO: .vs take, skip
 			.offset(index * perPage);
 
 		const results = await queryBuilder.getRawMany();
@@ -113,6 +114,7 @@ export class PostRepository extends Repository<Post> {
 	async getPost(postId: number, userId: number): Promise<GetPostDto> {
 		const authorId = userId;
 		const queryBuilder = this.createQueryBuilder("post")
+			.leftJoin("post.author", "user")
 			.select([
 				"post.id as id",
 				"title",
@@ -131,15 +133,30 @@ export class PostRepository extends Repository<Post> {
 			])
 			.addSelect(
 				subQuery =>
-					subQuery.select("COUNT(*)").from(Like, "post_likes"),
+					subQuery
+						.select("COUNT(*)")
+						.from(Like, "likes")
+						.where("likes.post_id = post.id"),
 				"likes"
 			)
-			.leftJoin("post.author", "user")
-			.where("post.is_delete = :isPostDeleted", { isPostDeleted: false })
+			.where("post.is_delete = :isDelete", { isDelete: false })
 			.andWhere("user.is_delete = :isUserDeleted", {
 				isUserDeleted: false,
 			})
 			.andWhere("post.id = :postId", { postId: postId })
+			.andWhere(
+				new Brackets(qb => {
+					qb.where("post.is_private = :isPrivateFalse", {
+						isPrivateFalse: false,
+					}).orWhere(
+						"post.is_private = :isPrivateTrue AND post.author_id = :authorId",
+						{
+							isPrivateTrue: true,
+							authorId: userId,
+						}
+					);
+				})
+			)
 			.setParameters({ authorId, userId });
 
 		const result = await queryBuilder.getRawOne();
@@ -255,5 +272,27 @@ export class PostRepository extends Repository<Post> {
 			count: parseInt(result.count, 10),
 			views: parseInt(result.views, 10),
 		};
+	}
+
+	async getTopPosts() {
+		const queryBuilder = this.createQueryBuilder("post")
+			.leftJoin("post.author", "user")
+			.leftJoin("post.likes", "pl")
+			.select([
+				"post.title as title",
+				"user.nickname as nickname",
+				"COUNT(*) as likeCount",
+			])
+			.where("post.is_delete = :isPostDeleted", { isPostDeleted: false })
+			.andWhere("user.is_delete = :isUserDeleted", {
+				isUserDeleted: false,
+			})
+			.groupBy("post.id")
+			.orderBy("likeCount", "DESC")
+			.limit(5); //join에서 쓰지 말라던데
+
+		const results = await queryBuilder.getRawMany();
+
+		return plainToInstance(GetTopPostsRes, results);
 	}
 }

--- a/nestjs-migration/src/rank/constant/rank.constants.ts
+++ b/nestjs-migration/src/rank/constant/rank.constants.ts
@@ -1,0 +1,5 @@
+export const RANK_ERROR_MESSAGES = {
+	GET_TOP_POSTS_ERROR: "좋아요가 많은 상위 5개의 게시물 조회 실패",
+	GET_TOP_COMMENTS_ERROR: "좋아요가 많은 상위 5개의 댓글 조회 실패",
+	GET_TOP_ACTIVITIES_ERROR: "활동이 많은 상위 5개의 게시물 조회 실패",
+};

--- a/nestjs-migration/src/rank/dto/get-top-activities.dto.ts
+++ b/nestjs-migration/src/rank/dto/get-top-activities.dto.ts
@@ -1,0 +1,11 @@
+import { Transform } from "class-transformer";
+
+export class GetTopActivties {
+	nickname: string;
+
+	@Transform(({ value }) => parseInt(value))
+	postCount: number;
+
+	@Transform(({ value }) => parseInt(value))
+	commentCount: number;
+}

--- a/nestjs-migration/src/rank/dto/get-top-comments.dto.ts
+++ b/nestjs-migration/src/rank/dto/get-top-comments.dto.ts
@@ -2,6 +2,8 @@ import { Transform } from "class-transformer";
 
 export class GetTopCommentsRes {
 	nickname: string;
+	postId: number;
+	commentId: number;
 
 	@Transform(({ value }) => parseInt(value))
 	likeCount: number;

--- a/nestjs-migration/src/rank/dto/get-top-comments.dto.ts
+++ b/nestjs-migration/src/rank/dto/get-top-comments.dto.ts
@@ -1,0 +1,8 @@
+import { Transform } from "class-transformer";
+
+export class GetTopCommentsRes {
+	nickname: string;
+
+	@Transform(({ value }) => parseInt(value))
+	likeCount: number;
+}

--- a/nestjs-migration/src/rank/dto/get-top-posts.dto.ts
+++ b/nestjs-migration/src/rank/dto/get-top-posts.dto.ts
@@ -1,0 +1,9 @@
+import { Transform } from "class-transformer";
+
+export class GetTopPostsRes {
+	title: string;
+	nickname: string;
+
+	@Transform(({ value }) => parseInt(value))
+	likeCount: number;
+}

--- a/nestjs-migration/src/rank/dto/get-top-posts.dto.ts
+++ b/nestjs-migration/src/rank/dto/get-top-posts.dto.ts
@@ -3,6 +3,7 @@ import { Transform } from "class-transformer";
 export class GetTopPostsRes {
 	title: string;
 	nickname: string;
+	postId: number;
 
 	@Transform(({ value }) => parseInt(value))
 	likeCount: number;

--- a/nestjs-migration/src/rank/dto/rank-results.dto.ts
+++ b/nestjs-migration/src/rank/dto/rank-results.dto.ts
@@ -1,0 +1,16 @@
+export class TopPostsRes {
+	title: string;
+	nickname: string;
+	likeCount: number;
+}
+
+export class TopCommentsRes {
+	nickname: string;
+	likeCount: number;
+}
+
+export class TopActivitiesRes {
+	nickname: string;
+	postCount: number;
+	commentCount: number;
+}

--- a/nestjs-migration/src/rank/dto/rank-results.dto.ts
+++ b/nestjs-migration/src/rank/dto/rank-results.dto.ts
@@ -1,11 +1,14 @@
 export class TopPostsRes {
 	title: string;
+	postId: number;
 	nickname: string;
 	likeCount: number;
 }
 
 export class TopCommentsRes {
 	nickname: string;
+	commentId: number;
+	postId: number;
 	likeCount: number;
 }
 

--- a/nestjs-migration/src/rank/rank.controller.spec.ts
+++ b/nestjs-migration/src/rank/rank.controller.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { RankController } from "./rank.controller";
+import { RankService } from "./rank.service";
+import { ServerError } from "src/common/exceptions/server-error.exception";
+import { RANK_ERROR_MESSAGES } from "./constant/rank.constants";
+
+describe("RankController", () => {
+	let rankController: RankController;
+	let rankService: RankService;
+
+	const mockRankService = {
+		getTopPosts: jest.fn(),
+		getTopComments: jest.fn(),
+		getTopActivities: jest.fn(),
+	};
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [RankController],
+			providers: [
+				{
+					provide: RankService,
+					useValue: mockRankService,
+				},
+			],
+		}).compile();
+
+		rankController = module.get<RankController>(RankController);
+		rankService = module.get<RankService>(RankService);
+	});
+
+	describe("GET /rank/posts", () => {
+		const mockResult = [
+			{
+				title: "mock title",
+				nickname: "mock nickname",
+				likeCount: 10,
+			},
+			{
+				title: "mock title",
+				nickname: "mock nickname",
+				likeCount: 7,
+			},
+		];
+
+		it("상위 게시글들 조회 성공", async () => {
+			mockRankService.getTopPosts.mockResolvedValue(mockResult);
+
+			const result = await rankController.handleTopPosts();
+
+			expect(rankService.getTopPosts).toHaveBeenCalled();
+			expect(result).toEqual(mockResult);
+		});
+		it("상위 게시글들 조회 실패", async () => {
+			const mockError = ServerError.reference(
+				RANK_ERROR_MESSAGES.GET_TOP_POSTS_ERROR
+			);
+			mockRankService.getTopPosts.mockRejectedValue(mockError);
+
+			await expect(rankController.handleTopPosts()).rejects.toThrow(
+				mockError
+			);
+		});
+	});
+
+	describe("GET /rank/comments", () => {
+		const mockResult = [
+			{
+				nickname: "mock nickname",
+				likeCount: 10,
+			},
+			{
+				nickname: "mock nickname",
+				likeCount: 7,
+			},
+		];
+		it("상위 댓글들 조회 성공", async () => {
+			mockRankService.getTopComments.mockResolvedValue(mockResult);
+
+			const result = await rankController.handleTopComments();
+
+			expect(rankService.getTopComments).toHaveBeenCalled();
+			expect(result).toEqual(mockResult);
+		});
+		it("상위 댓글들 조회 실패", async () => {
+			const mockError = ServerError.reference(
+				RANK_ERROR_MESSAGES.GET_TOP_COMMENTS_ERROR
+			);
+			mockRankService.getTopComments.mockRejectedValue(mockError);
+
+			await expect(rankController.handleTopComments()).rejects.toThrow(
+				mockError
+			);
+		});
+	});
+
+	describe("GET /rank/activities", () => {
+		const mockResult = [
+			{
+				nickname: "mock nickname",
+				postCount: 10,
+				commentCount: 5,
+			},
+			{
+				nickname: "mock nickname",
+				likeCount: 7,
+				commentCount: 2,
+			},
+		];
+		it("상위 활동들 조회 성공", async () => {
+			mockRankService.getTopActivities.mockResolvedValue(mockResult);
+
+			const result = await rankController.handleTopActivators();
+
+			expect(rankService.getTopActivities).toHaveBeenCalled();
+			expect(result).toEqual(mockResult);
+		});
+		it("상위 활동들 조회 실패", async () => {
+			const mockError = ServerError.reference(
+				RANK_ERROR_MESSAGES.GET_TOP_ACTIVITIES_ERROR
+			);
+			mockRankService.getTopActivities.mockRejectedValue(mockError);
+
+			await expect(rankController.handleTopActivators()).rejects.toThrow(
+				mockError
+			);
+		});
+	});
+});

--- a/nestjs-migration/src/rank/rank.controller.ts
+++ b/nestjs-migration/src/rank/rank.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, HttpCode, HttpStatus } from "@nestjs/common";
+import { RankService } from "./rank.service";
+import { ServerError } from "src/common/exceptions/server-error.exception";
+import { RANK_ERROR_MESSAGES } from "./constant/rank.constants";
+import {
+	TopActivitiesRes,
+	TopCommentsRes,
+	TopPostsRes,
+} from "./dto/rank-results.dto";
+
+@Controller("rank")
+export class RankController {
+	constructor(private readonly rankService: RankService) {}
+
+	@Get("/posts")
+	@HttpCode(HttpStatus.OK)
+	async handleTopPosts(): Promise<TopPostsRes[]> {
+		try {
+			const results = await this.rankService.getTopPosts();
+			return results;
+		} catch (err) {
+			throw ServerError.reference(
+				RANK_ERROR_MESSAGES.GET_TOP_POSTS_ERROR
+			);
+		}
+	}
+
+	@Get("/comments")
+	@HttpCode(HttpStatus.OK)
+	async handleTopComments(): Promise<TopCommentsRes[]> {
+		try {
+			const results = await this.rankService.getTopComments();
+			return results;
+		} catch (err) {
+			throw ServerError.reference(
+				RANK_ERROR_MESSAGES.GET_TOP_COMMENTS_ERROR
+			);
+		}
+	}
+
+	@Get("/activities")
+	@HttpCode(HttpStatus.OK)
+	async handleTopActivators(): Promise<TopActivitiesRes[]> {
+		try {
+			const results = await this.rankService.getTopActivities();
+			return results;
+		} catch (err) {
+			throw ServerError.reference(
+				RANK_ERROR_MESSAGES.GET_TOP_ACTIVITIES_ERROR
+			);
+		}
+	}
+}

--- a/nestjs-migration/src/rank/rank.module.ts
+++ b/nestjs-migration/src/rank/rank.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { RankService } from "./rank.service";
+import { RankController } from "./rank.controller";
+import { AdminModule } from "src/admin/admin.module";
+import { UserModule } from "src/user/user.module";
+import { PostModule } from "src/post/post.module";
+import { LogModule } from "src/log/log.module";
+import { CommentModule } from "src/comment/comment.module";
+
+@Module({
+	imports: [UserModule, PostModule, LogModule, CommentModule, AdminModule],
+	controllers: [RankController],
+	providers: [RankService],
+})
+export class RankModule {}

--- a/nestjs-migration/src/rank/rank.service.spec.ts
+++ b/nestjs-migration/src/rank/rank.service.spec.ts
@@ -48,11 +48,13 @@ describe("RankService", () => {
 				title: "mock title",
 				nickname: "mock nickname",
 				likeCount: 10,
+				postId: 1,
 			},
 			{
 				title: "mock title",
 				nickname: "mock nickname",
 				likeCount: 7,
+				postId: 2,
 			},
 		];
 		it("DB에서 게시물 top5를 가져오는데 성공한다", async () => {
@@ -81,10 +83,14 @@ describe("RankService", () => {
 			{
 				nickname: "mock nickname",
 				likeCount: 10,
+				commentId: 1,
+				postId: 2,
 			},
 			{
 				nickname: "mock nickname",
 				likeCount: 7,
+				commentId: 2,
+				postId: 2,
 			},
 		];
 		it("DB에서 댓글 top5를 가져오는데 성공한다", async () => {

--- a/nestjs-migration/src/rank/rank.service.spec.ts
+++ b/nestjs-migration/src/rank/rank.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { RankService } from "./rank.service";
+import { UserRepository } from "src/user/user.repository";
+import { PostRepository } from "src/post/post.repository";
+import { CommentRepository } from "src/comment/comment.repository";
+import { ServerError } from "src/common/exceptions/server-error.exception";
+import { RANK_ERROR_MESSAGES } from "./constant/rank.constants";
+
+describe("RankService", () => {
+	let rankService: RankService;
+	let userRepository: UserRepository;
+	let postRepository: PostRepository;
+	let commentRepository: CommentRepository;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				RankService,
+				{
+					provide: UserRepository,
+					useValue: {
+						getTopUserActivities: jest.fn(),
+					},
+				},
+				{
+					provide: PostRepository,
+					useValue: {
+						getTopPosts: jest.fn(),
+					},
+				},
+				{
+					provide: CommentRepository,
+					useValue: {
+						getTopComments: jest.fn(),
+					},
+				},
+			],
+		}).compile();
+
+		rankService = module.get<RankService>(RankService);
+		userRepository = module.get<UserRepository>(UserRepository);
+		postRepository = module.get<PostRepository>(PostRepository);
+		commentRepository = module.get<CommentRepository>(CommentRepository);
+	});
+	describe("getTopPosts", () => {
+		const mockResult = [
+			{
+				title: "mock title",
+				nickname: "mock nickname",
+				likeCount: 10,
+			},
+			{
+				title: "mock title",
+				nickname: "mock nickname",
+				likeCount: 7,
+			},
+		];
+		it("DB에서 게시물 top5를 가져오는데 성공한다", async () => {
+			jest.spyOn(postRepository, "getTopPosts").mockResolvedValue(
+				mockResult
+			);
+
+			const result = await rankService.getTopPosts();
+
+			expect(result).toEqual(mockResult);
+			expect(postRepository.getTopPosts).toHaveBeenCalled();
+		});
+		it("게시글 top5를 가져오는 도중 에러가 발생한다", async () => {
+			jest.spyOn(postRepository, "getTopPosts").mockRejectedValue(
+				ServerError.reference(RANK_ERROR_MESSAGES.GET_TOP_POSTS_ERROR)
+			);
+
+			await expect(postRepository.getTopPosts).rejects.toThrow(
+				ServerError.reference(RANK_ERROR_MESSAGES.GET_TOP_POSTS_ERROR)
+			);
+		});
+	});
+
+	describe("getTopComments", () => {
+		const mockResult = [
+			{
+				nickname: "mock nickname",
+				likeCount: 10,
+			},
+			{
+				nickname: "mock nickname",
+				likeCount: 7,
+			},
+		];
+		it("DB에서 댓글 top5를 가져오는데 성공한다", async () => {
+			jest.spyOn(commentRepository, "getTopComments").mockResolvedValue(
+				mockResult
+			);
+
+			const result = await rankService.getTopComments();
+
+			expect(result).toEqual(mockResult);
+			expect(commentRepository.getTopComments).toHaveBeenCalled();
+		});
+		it("댓글 top5를 가져오는 도중 에러가 발생한다", async () => {
+			jest.spyOn(commentRepository, "getTopComments").mockRejectedValue(
+				ServerError.reference(
+					RANK_ERROR_MESSAGES.GET_TOP_COMMENTS_ERROR
+				)
+			);
+
+			await expect(commentRepository.getTopComments).rejects.toThrow(
+				ServerError.reference(
+					RANK_ERROR_MESSAGES.GET_TOP_COMMENTS_ERROR
+				)
+			);
+		});
+	});
+
+	describe("getTopActivities", () => {
+		const mockResult = [
+			{
+				nickname: "mock nickname",
+				postCount: 10,
+				commentCount: 5,
+			},
+			{
+				nickname: "mock nickname",
+				postCount: 7,
+				commentCount: 2,
+			},
+		];
+		it("DB에서 활동 top5를 가져오는데 성공한다", async () => {
+			jest.spyOn(
+				userRepository,
+				"getTopUserActivities"
+			).mockResolvedValue(mockResult);
+
+			const result = await rankService.getTopActivities();
+
+			expect(result).toEqual(mockResult);
+			expect(userRepository.getTopUserActivities).toHaveBeenCalled();
+		});
+		it("활동 top5를 가져오는 도중 에러가 발생한다", async () => {
+			jest.spyOn(
+				userRepository,
+				"getTopUserActivities"
+			).mockRejectedValue(
+				ServerError.reference(
+					RANK_ERROR_MESSAGES.GET_TOP_ACTIVITIES_ERROR
+				)
+			);
+
+			await expect(userRepository.getTopUserActivities).rejects.toThrow(
+				ServerError.reference(
+					RANK_ERROR_MESSAGES.GET_TOP_ACTIVITIES_ERROR
+				)
+			);
+		});
+	});
+});

--- a/nestjs-migration/src/rank/rank.service.ts
+++ b/nestjs-migration/src/rank/rank.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from "@nestjs/common";
+import { CommentRepository } from "src/comment/comment.repository";
+import { PostRepository } from "src/post/post.repository";
+import { UserRepository } from "src/user/user.repository";
+import {
+	TopActivitiesRes,
+	TopCommentsRes,
+	TopPostsRes,
+} from "./dto/rank-results.dto";
+
+//try-catch
+@Injectable()
+export class RankService {
+	constructor(
+		private readonly userRepository: UserRepository,
+		private readonly postRepository: PostRepository,
+		private readonly commentRepository: CommentRepository
+	) {}
+
+	async getTopPosts(): Promise<TopPostsRes[]> {
+		const result = await this.postRepository.getTopPosts();
+
+		return result;
+	}
+	async getTopComments(): Promise<TopCommentsRes[]> {
+		const result = await this.commentRepository.getTopComments();
+		return result;
+	}
+
+	async getTopActivities(): Promise<TopActivitiesRes[]> {
+		const result = await this.userRepository.getTopUserActivities();
+
+		return result;
+	}
+}

--- a/nestjs-migration/src/user/user.repository.ts
+++ b/nestjs-migration/src/user/user.repository.ts
@@ -173,6 +173,7 @@ export class UserRepository extends Repository<User> {
 			.groupBy("user.id")
 			.orderBy("postCount", "DESC")
 			.addOrderBy("commentCount", "DESC")
+			.addOrderBy("user.id", "ASC")
 			.limit(5);
 
 		const results = await queryBuilder.getRawMany();

--- a/nestjs-migration/src/user/user.repository.ts
+++ b/nestjs-migration/src/user/user.repository.ts
@@ -3,6 +3,8 @@ import { IUserInfoResponse } from "shared";
 import { DataSource, Repository } from "typeorm";
 import { GetUsersDto } from "../admin/dto/get-users.dto";
 import { User } from "./entities/user.entity";
+import { plainToInstance } from "class-transformer";
+import { GetTopActivties } from "src/rank/dto/get-top-activities.dto";
 @Injectable()
 export class UserRepository extends Repository<User> {
 	constructor(private dataSource: DataSource) {
@@ -155,6 +157,28 @@ export class UserRepository extends Repository<User> {
 		}));
 	}
 
+	async getTopUserActivities() {
+		const queryBuilder = this.createQueryBuilder("user")
+			.leftJoin("user.posts", "post")
+			.leftJoin("user.comments", "comment")
+			.select(
+				`(SELECT COALESCE(COUNT(posts.id), 0) FROM posts WHERE posts.author_id = user.id AND posts.is_delete = false)`,
+				"postCount"
+			)
+			.addSelect(
+				`(SELECT COALESCE(COUNT(comments.id), 0) FROM comments WHERE comments.author_id = user.id AND comments.is_delete = false)`,
+				"commentCount"
+			)
+			.addSelect("user.nickname as nickname")
+			.groupBy("user.id")
+			.orderBy("postCount", "DESC")
+			.addOrderBy("commentCount", "DESC")
+			.limit(5);
+
+		const results = await queryBuilder.getRawMany();
+
+		return plainToInstance(GetTopActivties, results);
+	}
 	//예시 코드
 
 	// async customMethod(id: number): Promise<User> {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* #222 중 랭킹 개발

## 📝 작업 내용

> 메인페이지 랭킹 기능 3가지를 구현했습니다.

### 🖼️ 스크린샷 

### 1. 게시글 좋아요 수 top5
- 좋아요 수 동일 시 오래된 게시물 먼저
- 삭제된 게시물을 포함하지 않습니다
<img width="1010" alt="스크린샷 2024-10-08 오후 5 24 37" src="https://github.com/user-attachments/assets/69190031-6495-4f50-9de3-430fe1b0968c">

### 2. 댓글 좋아요 수 top5
- 좋아요 수 동일 시 오래된 댓글 먼저
- 삭제된 댓글은 포함하지 않습니다
<img width="1010" alt="스크린샷 2024-10-08 오후 5 24 31" src="https://github.com/user-attachments/assets/64fe7fd5-56a0-4c54-92c0-930ad41c4a28">

### 3. 활동량 top5 (게시글+댓글 개수)
- 개수 동일 시 오래된 유저 먼저
- 삭제된 게시물과 댓글은 포함하지 않습니다
<img width="1010" alt="스크린샷 2024-10-08 오후 5 24 25" src="https://github.com/user-attachments/assets/125e526b-024a-4a94-a902-86b49ebe1b53">


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

