### PR TITLE
[DB] posts 테이블 CREATE 문 오류 해결

### DIFF
--- a/sql/04_posts.sql
+++ b/sql/04_posts.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS posts (
     is_delete Boolean NOT NULL DEFAULT FALSE,
     is_private Boolean NOT NULL DEFAULT FALSE,
     FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (category_id) REFERENCES post_categories(id) ON DELETE SET DEFAULT
+    FOREIGN KEY (category_id) REFERENCES post_categories(id) ON DELETE SET DEFAULT,
     INDEX idx_category_id (category_id)
 );
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- N/A

## 📝 작업 내용

- `posts` 테이블 생성 시 발생하는 오류를 해결합니다.
  - 필요한 자리에 누락된 `,` 보충

## 💬 기타

- 이 PR은 바로 머지하겠습니다.