### PR TITLE
[FE] 게시글 카테고리 기능

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,6 +32,7 @@ import { AdminPage } from "./page/Admin/AdminPage";
 import UpsertPostPage from "./page/Posts/UpsertPostPage";
 import ProfilePage from "./page/Profile/ProfilePage";
 import { Rank } from "./page/Rank/Rank";
+import useCategory from "./hook/useCategory";
 
 function MainContainer({ children }: { children: React.ReactNode }) {
 	const location = useLocation();
@@ -71,6 +72,8 @@ function App() {
 	const { isOpen } = useChatAside();
 
 	const { setSocket } = useUserStore.use.actions();
+
+	const { categories } = useCategory();
 
 	useLayoutEffect(() => {
 		// 로그인은 되어 있으나 소켓이 없는 경우
@@ -184,14 +187,12 @@ function App() {
 							path="*"
 							element={<NotFound />}
 						/>
-						<Route
-							path="/category/community"
-							element={<Community categoryId={1} />}
-						/>
-						<Route
-							path="/category/qna"
-							element={<Community categoryId={3} />}
-						/>
+						{categories.map(category => (
+							<Route
+								path={`/category/${category.subPath}`}
+								element={<Community categoryId={category.id} />}
+							/>
+						))}
 						<Route
 							path="/post/new"
 							element={<UpsertPostPage />}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -186,7 +186,11 @@ function App() {
 						/>
 						<Route
 							path="/category/community"
-							element={<Community />}
+							element={<Community categoryId={1} />}
+						/>
+						<Route
+							path="/category/qna"
+							element={<Community categoryId={3} />}
 						/>
 						<Route
 							path="/post/new"

--- a/client/src/api/posts/crud.ts
+++ b/client/src/api/posts/crud.ts
@@ -1,9 +1,34 @@
 import { HttpMethod, convertToBody, httpRequest } from "../api";
 
-export const sendGetPostsRequest = async (query?: string) => {
-	const url = query ? `post${query}` : `post`;
+export type TPostListClientSearchParams = {
+	index: number;
+	perPage: number;
+	sortBy: number;
+	keyword: string;
+};
 
-	return await httpRequest(url, HttpMethod.GET);
+type TPostListRequestSearchParams = TPostListClientSearchParams & {
+	category_id: number;
+};
+
+export const sendGetPostsRequest = async (
+	param: Partial<TPostListRequestSearchParams>
+) => {
+	const stringified: Record<string, string> = {
+		index: "1",
+		perPage: "10",
+	};
+
+	for (const key in param) {
+		const value = param[key as keyof TPostListRequestSearchParams];
+
+		if (value !== undefined) {
+			stringified[key] = String(value);
+		}
+	}
+
+	const searchParams = new URLSearchParams(stringified);
+	return await httpRequest(`post?${searchParams.toString()}`, HttpMethod.GET);
 };
 
 export const sendGetPostRequest = async (param: string) => {

--- a/client/src/component/Header/Header.tsx
+++ b/client/src/component/Header/Header.tsx
@@ -18,6 +18,7 @@ import { isDevMode } from "../../utils/detectMode"; // TODO: UI 리팩터링 완
 import { MdDarkMode } from "react-icons/md";
 import useThemeStore from "../../state/ThemeStore";
 import { MdLightMode } from "react-icons/md";
+import useCategory from "../../hook/useCategory";
 
 const Header: React.FC = () => {
 	const navigate = useNavigate();
@@ -30,6 +31,7 @@ const Header: React.FC = () => {
 	const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
 	const dropdownMenuRef = useRef<HTMLDivElement>(null);
 	const { isDarkMode, toggleDarkMode } = useThemeStore();
+	const { headerCategories } = useCategory();
 
 	// 드랍다운 메뉴 이외 클릭시 드랍다운 메뉴 닫기
 	useEffect(() => {
@@ -107,25 +109,14 @@ const Header: React.FC = () => {
 
 					<div className="flex-1 justify-between sm:flex">
 						<div className="hidden overflow-hidden whitespace-nowrap text-white hover:text-gray-300 sm:flex sm:items-center sm:gap-x-4 xl:gap-x-6">
-							<Link
-								to="/category/community"
-								className="text-white hover:text-gray-300"
-							>
-								자유게시판
-							</Link>
-
-							<a className="text-white hover:text-gray-300">
-								QnA
-							</a>
-							<a className="text-white hover:text-gray-300">
-								팀원모집
-							</a>
-							<a className="text-white hover:text-gray-300">
-								도전과제
-							</a>
-							<a className="text-white hover:text-gray-300">
-								공지
-							</a>
+							{headerCategories.map(category => (
+								<Link
+									to={`/category/${category.subPath}`}
+									className="text-white hover:text-gray-300"
+								>
+									{category.name}
+								</Link>
+							))}
 						</div>
 					</div>
 

--- a/client/src/component/Posts/Editer/ImageManager.tsx
+++ b/client/src/component/Posts/Editer/ImageManager.tsx
@@ -120,9 +120,7 @@ const ImageManager: React.FC<IProps> = ({
 				</AlertModal.Body>
 			</AlertModal>
 
-			<div className="ml-1 text-sm font-bold text-blue-900">
-				첨부한 이미지
-			</div>
+			<div className="ml-1 text-sm font-bold">첨부한 이미지</div>
 
 			<div className="grid grid-cols-6 gap-4 rounded-md border border-gray-600 p-4">
 				{imageUrlSet.size === 0 ? (

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -2,7 +2,6 @@ import { dateToStr } from "../../utils/date-to-str";
 import { IPostInfo } from "shared";
 import { useCallback, useLayoutEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import PostModal from "./Modal/PostModal";
 import {
 	sendCreatePostLikeRequest,
 	sendDeletePostLikeRequest,
@@ -16,6 +15,7 @@ import { FaRegThumbsUp } from "react-icons/fa6";
 import ConfirmModal from "../common/Modal/ConfirmModal";
 import { sendDeletePostRequest } from "../../api/posts/crud";
 import { useModal } from "../../hook/useModal";
+import useCategory from "../../hook/useCategory";
 
 interface IPostInfoProps {
 	postInfo: IPostInfo;
@@ -24,7 +24,8 @@ interface IPostInfoProps {
 const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 	const navigate = useNavigate();
 
-	const updateModal = useModal();
+	const { currentCategory } = useCategory(postInfo.category);
+
 	const deleteModal = useModal();
 	const globalErrorModal = useGlobalErrorModal();
 
@@ -47,7 +48,11 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 
 	const handleLike = async () => {
 		if (!isLogin) {
-			alert("로그인이 필요합니다!");
+			globalErrorModal.open({
+				title: "오류",
+				message: "로그인이 필요합니다.",
+				callback: () => navigate("/login"),
+			});
 			return;
 		}
 
@@ -105,20 +110,11 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 
 		deleteModal.close();
 		alert("삭제에 성공했습니다.");
-		navigate("/category/community");
+		navigate(`/category/${currentCategory?.subPath}`);
 	}, [isAuthor]);
 
 	return (
 		<div>
-			{/* 모달 부분 css 수정 x*/}
-			{updateModal.isOpen ? (
-				// TODO: 편집기 작업 완료 후, 도달할 수 없는 분기 제거
-				<PostModal
-					close={() => updateModal.close()}
-					originalPostData={postInfo}
-				/>
-			) : null}
-
 			<ConfirmModal
 				variant="warning"
 				isOpen={deleteModal.isOpen}
@@ -136,7 +132,7 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 			<div className="flex w-[800px] flex-col pb-2.5 pt-2.5">
 				<div className="dark:bg-customGray relative mb-4 mt-4 flex flex-col justify-between rounded-lg bg-blue-900 text-left">
 					<span className="m-5 text-lg font-bold text-white">
-						자유게시판
+						{currentCategory?.name}
 					</span>
 				</div>
 

--- a/client/src/hook/useCategory.ts
+++ b/client/src/hook/useCategory.ts
@@ -72,12 +72,18 @@ const getCategoryByName = (name: string): TCategory | null =>
 const getCategoryBySubPath = (subpath: string): TCategory | null =>
 	categories.find(category => category.subPath === subpath) ?? null;
 
-const useCategory = (categoryId?: number) => {
-	const currentCategory: TCategory | null = useMemo(
-		() =>
-			typeof categoryId === "number" ? getCategoryById(categoryId) : null,
-		[categoryId]
-	);
+const useCategory = (categoryIdOrName?: number | string) => {
+	const currentCategory: TCategory | null = useMemo(() => {
+		if (typeof categoryIdOrName === "number") {
+			return getCategoryById(categoryIdOrName);
+		}
+
+		if (typeof categoryIdOrName === "string") {
+			return getCategoryByName(categoryIdOrName);
+		}
+
+		return null;
+	}, [categoryIdOrName]);
 
 	return {
 		currentCategory,

--- a/client/src/hook/useCategory.ts
+++ b/client/src/hook/useCategory.ts
@@ -1,0 +1,93 @@
+import { useMemo } from "react";
+
+export type TCategory = {
+	/** @property DB상의 카테고리 ID. */
+	id: number;
+
+	/** @property DB상의 카테고리 이름. */
+	name: string;
+
+	/**
+	 * @property
+	 * - URL 공통 라우팅 이하의 경로.
+	 * - 예를 들어, `/category` 이하에 공통으로 라우팅하기로 했을 때
+	 * 이 필드를 `community`로 세팅했다면 `/category/community`로 라우팅됨.
+	 */
+	subPath: string;
+
+	/** @property 헤더 노출 순서. 정의하지 않으면 노출하지 않음. */
+	headerOrder?: number;
+
+	/** @property 카테고리 소개/설명 문구. 정의하지 않으면 카테고리 이름만 노출. */
+	description?: string;
+};
+
+const categories: TCategory[] = [
+	{
+		id: 1,
+		name: "자유게시판",
+		subPath: "community",
+		headerOrder: 1,
+		description: "자유롭게 글을 작성해 보세요.",
+	},
+	{
+		id: 2,
+		name: "공지",
+		subPath: "notice",
+		headerOrder: 5,
+	},
+	{
+		id: 3,
+		name: "QnA",
+		subPath: "qna",
+		headerOrder: 2,
+		description: "질문을 작성하고 다른 사람의 질문에 답변해 보세요.",
+	},
+	{
+		id: 4,
+		name: "팀원모집",
+		subPath: "crew",
+		headerOrder: 3,
+	},
+	{
+		id: 5,
+		name: "도전과제",
+		subPath: "achievement",
+		headerOrder: 4,
+	},
+];
+
+const headerCategories = (
+	categories.filter(
+		item => typeof item.headerOrder === "number"
+	) as Required<TCategory>[]
+).sort((a, b) => a.headerOrder - b.headerOrder);
+
+const getCategoryById = (id: number): TCategory | null =>
+	categories.find(category => category.id === id) ?? null;
+
+const getCategoryByName = (name: string): TCategory | null =>
+	categories.find(category => category.name === name) ?? null;
+
+const getCategoryBySubPath = (subpath: string): TCategory | null =>
+	categories.find(category => category.subPath === subpath) ?? null;
+
+const useCategory = (categoryId?: number) => {
+	const currentCategory: TCategory | null = useMemo(
+		() =>
+			typeof categoryId === "number" ? getCategoryById(categoryId) : null,
+		[categoryId]
+	);
+
+	return {
+		currentCategory,
+
+		categories,
+		headerCategories,
+		getCategoryById,
+		getCategoryByName,
+		getCategoryBySubPath,
+	};
+};
+
+export default useCategory;

--- a/client/src/hook/useParsedSearchParams.ts
+++ b/client/src/hook/useParsedSearchParams.ts
@@ -1,0 +1,69 @@
+import { useCallback, useMemo } from "react";
+import { useLocation, useSearchParams } from "react-router-dom";
+
+type TSearchParamType = string | number | boolean;
+type TSearchParamTypeMap<T> = Record<keyof T, "string" | "number" | "boolean">;
+
+/**
+ * URL 파라미터를 객체로 관리합니다.
+ * @template T - 키-값 쌍 객체 타입
+ * @param types - URL 파라미터의 각 키별 타입
+ * @returns `[searchParamsObject, setSearchParamsObject]`
+ */
+const useParsedSearchParams = <T extends Record<string, TSearchParamType> = {}>(
+	types: TSearchParamTypeMap<T>
+): [Partial<T>, (diff: Partial<T>) => void] => {
+	const { search } = useLocation();
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	const searchParamsObject: Partial<T> = useMemo(() => {
+		const result: any = {};
+
+		searchParams.forEach((value, key) => {
+			if (key in result) {
+				return;
+			}
+
+			if (types[key] === "boolean") {
+				result[key] = value === "true";
+				return;
+			}
+
+			if (types[key] === "number") {
+				const parsed = parseInt(value, 10);
+
+				if (!isNaN(parsed)) {
+					result[key] = parsed;
+				}
+
+				return;
+			}
+
+			result[key] = value;
+		});
+
+		return result as Partial<T>;
+	}, [search]);
+
+	const setSearchParamsObject = useCallback(
+		(diff: Partial<T>) =>
+			setSearchParams(prev => {
+				const next = new URLSearchParams(prev);
+
+				for (const key in diff) {
+					if (diff[key] === undefined || diff[key] === null) {
+						next.delete(key);
+					} else {
+						next.set(key, String(diff[key]));
+					}
+				}
+
+				return next;
+			}),
+		[setSearchParams]
+	);
+
+	return [searchParamsObject as Partial<T>, setSearchParamsObject];
+};
+
+export default useParsedSearchParams;

--- a/client/src/hook/usePostList.ts
+++ b/client/src/hook/usePostList.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from "react";
+import { IPostHeader, mapDBToPostHeaders } from "shared";
+import { ApiCall } from "../api/api";
+import {
+	sendGetPostsRequest,
+	TPostListClientSearchParams,
+} from "../api/posts/crud";
+
+type TPostListHookProps = Partial<
+	TPostListClientSearchParams & {
+		categoryId: number;
+	}
+>;
+
+const usePostList = ({
+	index = 1,
+	perPage = 10,
+	sortBy,
+	keyword,
+	categoryId,
+}: TPostListHookProps) => {
+	const [postList, setPostList] = useState<IPostHeader[] | null>([]);
+	const [totalPosts, setTotalPosts] = useState(0);
+	const [actualIndex, setActualIndex] = useState(1);
+
+	const fetchPostList = useCallback(() => {
+		ApiCall(
+			() =>
+				sendGetPostsRequest({
+					index,
+					perPage,
+					sortBy,
+					keyword,
+					category_id: categoryId,
+				}),
+			() => setPostList(null)
+		).then(res => {
+			if (res instanceof Error) {
+				return;
+			}
+
+			const total = parseInt(res.total, 10) || 0;
+			const pageCount = Math.ceil(total / perPage);
+
+			if (pageCount > 0 && index > pageCount) {
+				setActualIndex(pageCount);
+			} else {
+				setPostList(mapDBToPostHeaders(res.postHeaders));
+				setTotalPosts(total);
+			}
+		});
+	}, [index, perPage, sortBy, keyword, categoryId]);
+
+	useEffect(() => {
+		fetchPostList();
+	}, [index, perPage, sortBy, keyword, categoryId]);
+
+	return {
+		postList,
+		totalPosts,
+		actualIndex,
+		fetchPostList,
+	};
+};
+
+export default usePostList;

--- a/client/src/page/Category/Community.tsx
+++ b/client/src/page/Category/Community.tsx
@@ -17,6 +17,7 @@ import { ApiCall } from "../../api/api";
 import { UserRank } from "../../component/Posts/Rank/UserRank";
 import { useNavigate } from "react-router-dom";
 import useParsedSearchParams from "../../hook/useParsedSearchParams";
+import useCategory from "../../hook/useCategory";
 
 interface IProps {
 	categoryId?: number;
@@ -25,6 +26,8 @@ interface IProps {
 const Community: React.FC<IProps> = ({ categoryId }) => {
 	const navigate = useNavigate();
 	const isLogin = useUserStore(state => state.isLogin);
+
+	const { currentCategory } = useCategory(categoryId);
 
 	const [posts, setPosts] = useState<IPostHeader[] | null>([]);
 	const [totalPosts, setTotalPosts] = useState(0);
@@ -103,13 +106,17 @@ const Community: React.FC<IProps> = ({ categoryId }) => {
 			<div className="mx-auto mt-2 w-full max-w-7xl px-4 lg:mt-[18px] lg:px-0">
 				<div className="ml-4 flex lg:space-x-10">
 					<UserRank />
+
 					<div className={mainPageStyle}>
 						<div className="dark:bg-customGray relative mt-4 flex flex-col justify-between rounded-lg bg-blue-900 text-left">
 							<span className="ml-5 mt-5 text-lg font-bold text-white">
-								자유게시판
+								{currentCategory?.name ?? "모든 글 모아 보기"}
 							</span>
+
 							<span className="mb-5 ml-5 mt-1 text-sm text-gray-200">
-								자유롭게 글을 작성해보세요
+								{currentCategory
+									? currentCategory?.description
+									: "모든 게시글을 한번에 모아 보세요."}
 							</span>
 						</div>
 
@@ -120,7 +127,7 @@ const Community: React.FC<IProps> = ({ categoryId }) => {
 							/>
 
 							<div className={postListActions}>
-								{isLogin && (
+								{isLogin && currentCategory && (
 									<div className={createPostButtonWrapper}>
 										<button
 											className="dark:bg-customGray bg-blue-900 text-white"
@@ -132,7 +139,9 @@ const Community: React.FC<IProps> = ({ categoryId }) => {
 								)}
 							</div>
 						</div>
+
 						<hr className="bg-customGray h-0.5 border-none" />
+
 						<div className="dark:bg-customGray m-2 flex h-10 items-center gap-2 rounded-md bg-blue-100">
 							<div className="border-b-customDarkGray border-spacing-2 items-center bg-none">
 								<div className="dark:bg-customDarkGray m-2 rounded-md bg-white">

--- a/client/src/page/Main/Main.tsx
+++ b/client/src/page/Main/Main.tsx
@@ -1,48 +1,32 @@
 import { UserRank } from "../../component/Posts/Rank/UserRank";
 import { Link } from "react-router-dom";
 import { IPostHeader, mapDBToPostHeaders } from "shared";
-import { useLayoutEffect, useState } from "react";
-import useMainPageSearchParams from "../../hook/useMainPageSearchParams";
+import { useEffect, useState } from "react";
 import { ApiCall } from "../../api/api";
-import { ClientError } from "../../api/errors";
 import { sendGetPostsRequest } from "../../api/posts/crud";
 import MainPortList from "../../component/Posts/PostList/MainPostList";
 
 const Main = () => {
 	const [posts, setPosts] = useState<IPostHeader[] | null>([]);
-	const { searchParams, setSearchParams, parsed } = useMainPageSearchParams();
 
-	useLayoutEffect(() => {
-		const queryString = `?${searchParams.toString()}`;
-
+	useEffect(() => {
 		ApiCall(
-			() => sendGetPostsRequest(queryString),
-			() => {
-				setPosts(null);
-			}
+			() =>
+				sendGetPostsRequest({
+					index: 1,
+					perPage: 5,
+					// TODO: 카테고리 지정
+					// category_id?: number | undefined,
+				}),
+			() => setPosts(null)
 		).then(res => {
-			if (res instanceof ClientError) {
+			if (res instanceof Error) {
 				return;
 			}
 
-			const total = parseInt(res.total, 10);
-
-			if (isNaN(total)) {
-				// TODO: 에러 핸들링
-				return;
-			}
-
-			const pageCount = Math.ceil(total / parsed.perPage);
-
-			if (pageCount > 0 && parsed.index > pageCount) {
-				const nextSearchParams = new URLSearchParams(searchParams);
-				nextSearchParams.set("index", String(pageCount));
-				setSearchParams(nextSearchParams);
-			} else {
-				setPosts(mapDBToPostHeaders(res.postHeaders));
-			}
+			setPosts(mapDBToPostHeaders(res.postHeaders));
 		});
-	}, [parsed.index, parsed.perPage, parsed.keyword, parsed.sortBy]);
+	}, []);
 
 	return (
 		<div>
@@ -67,7 +51,7 @@ const Main = () => {
 									</div>
 									<MainPortList
 										posts={posts ? posts.slice(0, 5) : []}
-										keyword={parsed.keyword}
+										// keyword={parsed.keyword}
 									/>
 								</div>
 								<div className="w-full">
@@ -84,7 +68,7 @@ const Main = () => {
 									</div>
 									<MainPortList
 										posts={posts ? posts.slice(0, 5) : []}
-										keyword={parsed.keyword}
+										// keyword={parsed.keyword}
 									/>
 								</div>
 							</div>
@@ -104,7 +88,7 @@ const Main = () => {
 									</div>
 									<MainPortList
 										posts={posts ? posts.slice(0, 5) : []}
-										keyword={parsed.keyword}
+										// keyword={parsed.keyword}
 									/>
 								</div>
 								<div className="w-full">
@@ -121,7 +105,7 @@ const Main = () => {
 									</div>
 									<MainPortList
 										posts={posts ? posts.slice(0, 5) : []}
-										keyword={parsed.keyword}
+										// keyword={parsed.keyword}
 									/>
 								</div>
 							</div>

--- a/client/src/page/Main/Main.tsx
+++ b/client/src/page/Main/Main.tsx
@@ -1,32 +1,38 @@
-import { UserRank } from "../../component/Posts/Rank/UserRank";
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { IPostHeader, mapDBToPostHeaders } from "shared";
-import { useEffect, useState } from "react";
-import { ApiCall } from "../../api/api";
-import { sendGetPostsRequest } from "../../api/posts/crud";
 import MainPortList from "../../component/Posts/PostList/MainPostList";
+import { UserRank } from "../../component/Posts/Rank/UserRank";
+import useCategory from "../../hook/useCategory";
+import usePostList from "../../hook/usePostList";
 
 const Main = () => {
-	const [posts, setPosts] = useState<IPostHeader[] | null>([]);
+	const { postList: communityPosts } = usePostList({
+		categoryId: 1,
+		perPage: 5,
+	});
+	const { postList: qnaPosts } = usePostList({
+		categoryId: 3,
+		perPage: 5,
+	});
+	const { postList: crewPosts } = usePostList({
+		categoryId: 4,
+		perPage: 5,
+	});
+	const { postList: achievementPosts } = usePostList({
+		categoryId: 5,
+		perPage: 5,
+	});
 
-	useEffect(() => {
-		ApiCall(
-			() =>
-				sendGetPostsRequest({
-					index: 1,
-					perPage: 5,
-					// TODO: 카테고리 지정
-					// category_id?: number | undefined,
-				}),
-			() => setPosts(null)
-		).then(res => {
-			if (res instanceof Error) {
-				return;
-			}
-
-			setPosts(mapDBToPostHeaders(res.postHeaders));
-		});
-	}, []);
+	const { getCategoryById } = useCategory();
+	const categoriesByName = useMemo(
+		() => ({
+			community: getCategoryById(1),
+			qna: getCategoryById(3),
+			crew: getCategoryById(4),
+			achievement: getCategoryById(5),
+		}),
+		[]
+	);
 
 	return (
 		<div>
@@ -40,36 +46,30 @@ const Main = () => {
 								<div className="w-full">
 									<div className="dark:bg-customGray relative mb-2 flex h-14 items-center justify-between rounded-lg bg-blue-900">
 										<span className="m-4 text-lg font-bold text-white">
-											자유게시판
+											{categoriesByName.community?.name}
 										</span>
 										<Link
 											className="m-4 justify-end text-base text-gray-300 hover:text-gray-500"
-											to="/category/community"
+											to={`/category/${categoriesByName.community?.subPath}`}
 										>
 											바로가기
 										</Link>
 									</div>
-									<MainPortList
-										posts={posts ? posts.slice(0, 5) : []}
-										// keyword={parsed.keyword}
-									/>
+									<MainPortList posts={communityPosts} />
 								</div>
 								<div className="w-full">
 									<div className="dark:bg-customGray relative mb-2 flex h-14 items-center justify-between rounded-lg bg-blue-900">
 										<span className="m-4 text-lg font-bold text-white">
-											QnA
+											{categoriesByName.qna?.name}
 										</span>
 										<Link
 											className="m-4 justify-end text-base text-gray-300 hover:text-gray-500"
-											to="/category/community"
+											to={`/category/${categoriesByName.qna?.subPath}`}
 										>
 											바로가기
 										</Link>
 									</div>
-									<MainPortList
-										posts={posts ? posts.slice(0, 5) : []}
-										// keyword={parsed.keyword}
-									/>
+									<MainPortList posts={qnaPosts} />
 								</div>
 							</div>
 
@@ -77,36 +77,30 @@ const Main = () => {
 								<div className="w-full">
 									<div className="dark:bg-customGray relative mb-2 flex h-14 items-center justify-between rounded-lg bg-blue-900">
 										<span className="m-4 text-lg font-bold text-white">
-											팀원모집
+											{categoriesByName.crew?.name}
 										</span>
 										<Link
 											className="m-4 justify-end text-base text-gray-300 hover:text-gray-500"
-											to="/category/community"
+											to={`/category/${categoriesByName.crew?.subPath}`}
 										>
 											바로가기
 										</Link>
 									</div>
-									<MainPortList
-										posts={posts ? posts.slice(0, 5) : []}
-										// keyword={parsed.keyword}
-									/>
+									<MainPortList posts={crewPosts} />
 								</div>
 								<div className="w-full">
 									<div className="dark:bg-customGray relative mb-2 flex h-14 items-center justify-between rounded-lg bg-blue-900">
 										<span className="m-4 text-lg font-bold text-white">
-											도전과제
+											{categoriesByName.achievement?.name}
 										</span>
 										<Link
 											className="m-4 justify-end text-base text-gray-300 hover:text-gray-500"
-											to="/category/community"
+											to={`/category/${categoriesByName.achievement?.subPath}`}
 										>
 											바로가기
 										</Link>
 									</div>
-									<MainPortList
-										posts={posts ? posts.slice(0, 5) : []}
-										// keyword={parsed.keyword}
-									/>
+									<MainPortList posts={achievementPosts} />
 								</div>
 							</div>
 						</div>

--- a/shared/community/posts/post_mapper.ts
+++ b/shared/community/posts/post_mapper.ts
@@ -5,6 +5,7 @@ export const mapDBToPostInfo = (data: any): IPostInfo => {
 		id: data.id,
 		title: data.title,
 		content: data.content,
+		category: data.category,
 		author_id: data.author_id,
 		author_nickname: data.author_nickname,
 		is_author: !!data.is_author,

--- a/shared/community/posts/posts.ts
+++ b/shared/community/posts/posts.ts
@@ -7,6 +7,7 @@ export interface IPostInfo {
 	id: number;
 	title: string;
 	content: string;
+	category: string;
 	author_id: number;
 	author_nickname: string;
 	is_author: boolean;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #288
- #224

## 📝 작업 내용

- #224 의 선행 작업으로 클라이언트의 게시글 기능을 확장하여 카테고리를 구현합니다.
- 게시글 목록 조회 시 클라이언트와 서버에서 사용하는 서치 파라미터 훅 구조 변경
  - 파싱된 개별 값, 개별 값 갱신 함수만을 노출하고, 다음 searchParams를 생성하고 갱신하는 처리는 훅 내부로 이동 (바깥 코드를 간결하게)
- 카테고리 메타데이터 정리 (ID에 따른 카테고리 이름, 카테고리 설명, 클라이언트 라우팅 경로 등)
- 카테고리 ID로 게시판 구분
- 게시글 작성 페이지 및 게시글 생성 요청에 카테고리 ID 적용

### 🖼️ 스크린샷

#### 메인 페이지 (제목, 링크, 글 목록 연결 작업만 진행)

<img width="1268" alt="메인 페이지" src="https://github.com/user-attachments/assets/b8c00518-7be0-498f-a08e-893a92c17bab">

#### QnA 게시판 (상단 제목/설명란 및 게시글 목록)

<img width="808" alt="QnA 게시판 글 목록" src="https://github.com/user-attachments/assets/d1abccb6-4133-4bd2-b412-94b1c0074ed6">

#### 글쓰기 페이지 (새 글 작성 시 카테고리 ID 연결)

<img width="879" alt="글쓰기 페이지" src="https://github.com/user-attachments/assets/881acd8a-d0bf-4b0b-ba89-20c51c6d2b8d">

## 💬 리뷰 요구사항

- 잘못 구현되었거나 수정 필요한 부분 있으면 말씀해 주세요!