### PR TITLE
[FE] 모달 컴포넌트 추출

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -103,6 +103,7 @@ function App() {
 				<MainContainer>
 					<GlobalErrorModal
 						isOpen={globalErrorModal.isOpen}
+						variant={globalErrorModal.variant}
 						callback={globalErrorModal.callback}
 						onClose={globalErrorModal.close}
 					>

--- a/client/src/component/Admin/PostMgmt/PostMgmt.tsx
+++ b/client/src/component/Admin/PostMgmt/PostMgmt.tsx
@@ -14,6 +14,8 @@ import {
 } from "../../../api/admin/post_crud";
 import TextInput from "../../common/TextInput";
 import Button from "../../common/Button";
+import { useModal } from "../../../hook/useModal";
+import ConfirmModal from "../../common/Modal/ConfirmModal";
 
 const PostList = () => {
 	const initialPage = 1;
@@ -24,6 +26,12 @@ const PostList = () => {
 	});
 	const [currentPage, setCurrentPage] = useState<number>(initialPage);
 	const [keyword, setKeyword] = useState<string>("");
+
+	const confirmModal = useModal();
+	const [confirmModalDetails, setConfirmModalDetails] = useState({
+		content: "",
+		updateFunction: async () => {},
+	});
 
 	const fetchPosts = () => {
 		ApiCall(
@@ -56,12 +64,31 @@ const PostList = () => {
 	};
 
 	const handlePostUpdate = async (updateFunction: () => Promise<void>) => {
+		confirmModal.close();
+		setConfirmModalDetails({
+			content: "",
+			updateFunction: async () => {},
+		});
+
 		await updateFunction();
 		fetchPosts();
 	};
 
 	return (
 		<div className="mx-auto mt-2 w-full max-w-7xl px-4 lg:mt-[18px] lg:px-0">
+			<ConfirmModal
+				isOpen={confirmModal.isOpen}
+				onAccept={() =>
+					handlePostUpdate(confirmModalDetails.updateFunction)
+				}
+				onClose={confirmModal.close}
+			>
+				<ConfirmModal.Title>동작 확인</ConfirmModal.Title>
+				<ConfirmModal.Body>
+					{confirmModalDetails.content}
+				</ConfirmModal.Body>
+			</ConfirmModal>
+
 			<div className="mb-6 flex flex-row items-center justify-between">
 				<h2 className="text-xl font-bold">게시물 목록</h2>
 
@@ -101,10 +128,15 @@ const PostList = () => {
 					posts.postHeaders.map(post => (
 						<div key={post.id}>
 							<div className="my-2 grid w-full grid-cols-[3fr_4fr_2fr_1fr_1fr] items-center">
-								<Link to={`/post/${post.id}`}>
+								<Link
+									to={`/post/${post.id}`}
+									className="break-words break-all"
+								>
 									{post.title}
 								</Link>
-								<div>{post.author}</div>
+								<div className="break-words break-all">
+									{post.author}
+								</div>
 								<div>
 									{dateToStr(new Date(post.createdAt), true)}
 								</div>
@@ -114,17 +146,15 @@ const PostList = () => {
 											color="neutral"
 											variant="solid"
 											onClick={() => {
-												if (
-													window.confirm(
-														"해당 게시물을 공개하시겠습니까?"
-													)
-												) {
-													handlePostUpdate(() =>
+												setConfirmModalDetails({
+													content:
+														"해당 게시물을 공개하시겠습니까?",
+													updateFunction: () =>
 														handleAdminPostPublic(
 															post.id
-														)
-													);
-												}
+														),
+												});
+												confirmModal.open();
 											}}
 										>
 											공개
@@ -134,17 +164,15 @@ const PostList = () => {
 											color="action"
 											variant="solid"
 											onClick={() => {
-												if (
-													window.confirm(
-														"해당 게시물을 비공개하시겠습니까?"
-													)
-												) {
-													handlePostUpdate(() =>
+												setConfirmModalDetails({
+													content:
+														"해당 게시물을 비공개하시겠습니까?",
+													updateFunction: () =>
 														handleAdminPostPrivate(
 															post.id
-														)
-													);
-												}
+														),
+												});
+												confirmModal.open();
 											}}
 										>
 											비공개
@@ -157,17 +185,15 @@ const PostList = () => {
 											color="neutral"
 											variant="solid"
 											onClick={() => {
-												if (
-													window.confirm(
-														"해당 게시물을 복구하시겠습니까?"
-													)
-												) {
-													handlePostUpdate(() =>
+												setConfirmModalDetails({
+													content:
+														"해당 게시물을 복구하시겠습니까?",
+													updateFunction: () =>
 														handleRestoreAdminPost(
 															post.id
-														)
-													);
-												}
+														),
+												});
+												confirmModal.open();
 											}}
 										>
 											복구
@@ -177,17 +203,15 @@ const PostList = () => {
 											color="danger"
 											variant="solid"
 											onClick={() => {
-												if (
-													window.confirm(
-														"해당 게시물을 삭제하시겠습니까?"
-													)
-												) {
-													handlePostUpdate(() =>
+												setConfirmModalDetails({
+													content:
+														"해당 게시물을 삭제하시겠습니까?",
+													updateFunction: () =>
 														handleDeleteAdminPost(
 															post.id
-														)
-													);
-												}
+														),
+												});
+												confirmModal.open();
 											}}
 										>
 											삭제

--- a/client/src/component/Admin/UserMgmt/UserList.tsx
+++ b/client/src/component/Admin/UserMgmt/UserList.tsx
@@ -12,6 +12,8 @@ import {
 } from "../../../api/admin/user_crud";
 import TextInput from "../../common/TextInput";
 import Button from "../../common/Button";
+import { useModal } from "../../../hook/useModal";
+import ConfirmModal from "../../common/Modal/ConfirmModal";
 
 const UserList = () => {
 	const initialPage = 1;
@@ -23,6 +25,12 @@ const UserList = () => {
 	const [currentPage, setCurrentPage] = useState<number>(initialPage);
 	const nickname = "";
 	const [email, setEmail] = useState<string>("");
+
+	const confirmModal = useModal();
+	const [confirmModalDetails, setConfirmModalDetails] = useState({
+		content: "",
+		updateFunction: async () => {},
+	});
 
 	const fetchUsers = () => {
 		ApiCall(
@@ -59,13 +67,33 @@ const UserList = () => {
 		setCurrentPage(1);
 		fetchUsers();
 	};
+
 	const handleUserUpdate = async (updateFunction: () => Promise<void>) => {
+		confirmModal.close();
+		setConfirmModalDetails({
+			content: "",
+			updateFunction: async () => {},
+		});
+
 		await updateFunction();
 		fetchUsers();
 	};
 
 	return (
 		<div className="mx-auto mt-2 w-full max-w-7xl px-4 lg:mt-[18px] lg:px-0">
+			<ConfirmModal
+				isOpen={confirmModal.isOpen}
+				onAccept={() =>
+					handleUserUpdate(confirmModalDetails.updateFunction)
+				}
+				onClose={confirmModal.close}
+			>
+				<ConfirmModal.Title>동작 확인</ConfirmModal.Title>
+				<ConfirmModal.Body>
+					{confirmModalDetails.content}
+				</ConfirmModal.Body>
+			</ConfirmModal>
+
 			<div className="mb-6 flex flex-row items-center justify-between">
 				<h2 className="text-xl font-bold">사용자 목록</h2>
 
@@ -121,17 +149,15 @@ const UserList = () => {
 											color="action"
 											variant="solid"
 											onClick={() => {
-												if (
-													window.confirm(
-														"해당 사용자를 복구하시겠습니까?"
-													)
-												) {
-													handleUserUpdate(() =>
+												setConfirmModalDetails({
+													content:
+														"해당 사용자를 복구하시겠습니까?",
+													updateFunction: () =>
 														handleRestoreAdminUser(
 															user.id
-														)
-													);
-												}
+														),
+												});
+												confirmModal.open();
 											}}
 										>
 											복구
@@ -141,17 +167,15 @@ const UserList = () => {
 											color="danger"
 											variant="solid"
 											onClick={() => {
-												if (
-													window.confirm(
-														"해당 사용자를 삭제하시겠습니까?"
-													)
-												) {
-													handleUserUpdate(() =>
+												setConfirmModalDetails({
+													content:
+														"해당 사용자를 삭제하시겠습니까?",
+													updateFunction: () =>
 														handleDeleteAdminUser(
 															user.id
-														)
-													);
-												}
+														),
+												});
+												confirmModal.open();
 											}}
 										>
 											삭제

--- a/client/src/component/Chats/ChatAside/ChatAside.css.ts
+++ b/client/src/component/Chats/ChatAside/ChatAside.css.ts
@@ -11,7 +11,6 @@ export const chatAsideStyle = style({
 	minHeight: "200px",
 	zIndex: "2",
 	borderRadius: "20px",
-	color: "black",
 	paddingTop: "20px",
 	paddingBottom: "20px",
 	paddingLeft: "15px",

--- a/client/src/component/Chats/ChatAside/ChatAside.tsx
+++ b/client/src/component/Chats/ChatAside/ChatAside.tsx
@@ -1,9 +1,19 @@
+import { useLayoutEffect, useRef } from "react";
 import ChatPage from "../../../page/Chat/ChatPage";
+import { useChatAside } from "../../../state/ChatAsideStore";
 import { chatAsideStyle } from "./ChatAside.css";
 
 const ChatAside = () => {
+	const { setChatModalContainer } = useChatAside();
+	const chatModalRef = useRef<HTMLDivElement>(null);
+
+	useLayoutEffect(() => {
+		setChatModalContainer(chatModalRef.current);
+	}, [chatModalRef.current]);
+
 	return (
 		<div className={chatAsideStyle}>
+			<div ref={chatModalRef} />
 			<ChatPage />
 		</div>
 	);

--- a/client/src/component/Chats/ChatRooms/ChatRooms.tsx
+++ b/client/src/component/Chats/ChatRooms/ChatRooms.tsx
@@ -13,6 +13,8 @@ import { useUserStore } from "../../../state/store";
 import { useNavigate } from "react-router-dom";
 import ChatFooter from "./ChatFooter";
 import { ChatAsideCategory, useChatAside } from "../../../state/ChatAsideStore";
+import { useModal } from "../../../hook/useModal";
+import Button from "../../common/Button";
 
 export interface RoomsInfo {
 	totalRoomCount: number;
@@ -30,7 +32,7 @@ interface Props {
 const ChatRooms: FC<Props> = ({ setSelectedRoom }) => {
 	const navigate = useNavigate(); // TEST : 채팅방 페이지
 
-	const [isOpen, setIsOpen] = useState(false);
+	const createRoomModal = useModal();
 	const [currentPage, setCurrentPage] = useState<number>(1);
 	// const isAsideOpen = true; // TODO : Aside UI 만들때 State 관리
 
@@ -48,7 +50,7 @@ const ChatRooms: FC<Props> = ({ setSelectedRoom }) => {
 				return (
 					<MyChatRooms
 						currentPage={currentPage}
-						open={setIsOpen}
+						open={createRoomModal.open}
 						setCurrentPage={setCurrentPage}
 						setSelectedRoom={setSelectedRoom}
 					/>
@@ -68,14 +70,22 @@ const ChatRooms: FC<Props> = ({ setSelectedRoom }) => {
 		}
 	}, [currentPage, isLogin, navigate, nickname, socket, category]);
 
+	const handleCreateRoomAccept = (room: {
+		title: string;
+		roomId: number;
+	}) => {
+		setSelectedRoom(room);
+		createRoomModal.close();
+	};
+
 	return (
 		<div className={container}>
 			{isLogin ? (
 				<div className={chatRoomsStyle}>
-					{isOpen ? (
+					{createRoomModal.isOpen ? (
 						<CreateRoomModal
-							close={setIsOpen}
-							setSelectedRoom={setSelectedRoom}
+							onAccept={handleCreateRoomAccept}
+							onClose={createRoomModal.close}
 						/>
 					) : null}
 					{renderChatRoomPage()}
@@ -84,14 +94,16 @@ const ChatRooms: FC<Props> = ({ setSelectedRoom }) => {
 			) : (
 				<div className={loginGuidanceStyle}>
 					<p>로그인 후 이용할 수 있습니다.</p>
-					<button
+					<Button
+						color="action"
+						size="large"
 						onClick={() => {
 							navigate("/login");
 							close();
 						}}
 					>
 						로그인
-					</button>
+					</Button>
 				</div>
 			)}
 		</div>

--- a/client/src/component/Chats/ChatRooms/MyChatRooms.tsx
+++ b/client/src/component/Chats/ChatRooms/MyChatRooms.tsx
@@ -1,10 +1,4 @@
-import {
-	FC,
-	SetStateAction,
-	useEffect,
-	useLayoutEffect,
-	useState,
-} from "react";
+import { FC, useEffect, useLayoutEffect, useState } from "react";
 import { IReadRoomResponse } from "shared";
 import {
 	chatRoomsContainer,
@@ -21,7 +15,7 @@ import { RiChatNewLine } from "react-icons/ri";
 
 interface Props {
 	currentPage: number;
-	open: React.Dispatch<SetStateAction<boolean>>;
+	open: () => void;
 	setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
 	setSelectedRoom: (room: { title: string; roomId: number }) => void;
 }
@@ -99,7 +93,7 @@ const MyChatRooms: FC<Props> = ({
 				<div className={myRoomTitleTextStyle}>내 채팅방</div>
 				<button
 					className={createButton}
-					onClick={() => open(true)}
+					onClick={open}
 				>
 					<RiChatNewLine title="채팅방 생성" />
 				</button>

--- a/client/src/component/Chats/ChatRooms/SearchedChatRooms.tsx
+++ b/client/src/component/Chats/ChatRooms/SearchedChatRooms.tsx
@@ -102,7 +102,10 @@ const SearchedChatRooms: React.FC<Props> = ({ setSelectedRoom }) => {
 			};
 
 			if (!keyword) {
-				alert("검색어를 입력하세요");
+				globalErrorModal.open({
+					title: "오류",
+					message: "검색어를 입력하세요.",
+				});
 				return;
 			}
 

--- a/client/src/component/Comments/CommentForm/CommentForm.tsx
+++ b/client/src/component/Comments/CommentForm/CommentForm.tsx
@@ -3,6 +3,7 @@ import { useUserStore } from "../../../state/store";
 import { commentFormContainer, footer } from "./CommentForm.css";
 import Textarea from "../../common/Textarea";
 import Button from "../../common/Button";
+import { useGlobalErrorModal } from "../../../state/GlobalErrorModalStore";
 
 interface ICommentFormProps {
 	defaultContent?: string;
@@ -17,6 +18,7 @@ const CommentForm = ({
 	onSubmit,
 	onCancel,
 }: ICommentFormProps) => {
+	const globalErrorModal = useGlobalErrorModal();
 	const isLogin = useUserStore(state => state.isLogin);
 
 	const [content, setContent] = useState(defaultContent || "");
@@ -27,7 +29,10 @@ const CommentForm = ({
 
 			const trimmedContent = content.trim();
 			if (!trimmedContent) {
-				alert("댓글 내용을 입력하세요.");
+				globalErrorModal.open({
+					title: "오류",
+					message: "댓글 내용을 입력하세요.",
+				});
 				return;
 			}
 

--- a/client/src/component/Comments/CommentItem/CommentItem.tsx
+++ b/client/src/component/Comments/CommentItem/CommentItem.tsx
@@ -62,7 +62,11 @@ const CommentItem = ({ comment, onUpdate, onDelete }: ICommentItemProps) => {
 			return false;
 		}
 
-		alert("댓글을 수정했습니다.");
+		globalErrorModal.open({
+			variant: "info",
+			title: "댓글 수정 완료",
+			message: "댓글을 수정했습니다.",
+		});
 
 		if (onUpdate) {
 			await onUpdate();

--- a/client/src/component/Comments/CommentLikeButton/CommentLikeButton.tsx
+++ b/client/src/component/Comments/CommentLikeButton/CommentLikeButton.tsx
@@ -30,7 +30,10 @@ const CommentLikeButton = ({
 
 	const handleLikeClick = async () => {
 		if (!isLogin) {
-			alert("로그인이 필요합니다!");
+			globalErrorModal.open({
+				title: "오류",
+				message: "로그인이 필요합니다.",
+			});
 			return;
 		}
 

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -109,7 +109,11 @@ const PostInfo: React.FC<IPostInfoProps> = ({ postInfo }) => {
 		}
 
 		deleteModal.close();
-		alert("삭제에 성공했습니다.");
+		globalErrorModal.open({
+			variant: "info",
+			title: "게시글 삭제 성공",
+			message: "게시글을 성공적으로 삭제했습니다.",
+		});
 		navigate(`/category/${currentCategory?.subPath}`);
 	}, [isAuthor]);
 

--- a/client/src/component/User/OAuthLoginButtons.tsx
+++ b/client/src/component/User/OAuthLoginButtons.tsx
@@ -19,6 +19,9 @@ import {
 import { deleteOAuthConnection, getOAuthLoginUrl } from "../../api/users/oauth";
 import { ApiCall } from "../../api/api";
 import { getUserMyself } from "../../api/users/crud";
+import { useModal } from "../../hook/useModal";
+import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
+import ConfirmModal from "../common/Modal/ConfirmModal";
 
 interface IProps {
 	loginType: TOAuthLoginType;
@@ -37,6 +40,10 @@ const providerToName: { [provider in TOAuthProvider]: string } = {
 const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 	const [oAuthConnections, setOAuthConnections] =
 		useState<TOAuthLinks | null>(null);
+
+	const [unlinkTarget, setUnlinkTarget] = useState<TOAuthProvider | "">("");
+	const unlinkConfirmModal = useModal();
+	const globalErrorModal = useGlobalErrorModal();
 
 	const location = useLocation();
 
@@ -86,12 +93,15 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 		window.location.href = response.url;
 	};
 
-	const handleUnlinkClickWith = (provider: TOAuthProvider) => async () => {
-		const confirmed = confirm(
-			`${providerToName[provider]} 로그인 연동을 해제할까요?`
-		);
+	const handleUnlinkClickWith = (provider: TOAuthProvider) => () => {
+		setUnlinkTarget(provider);
+		unlinkConfirmModal.open();
+	};
 
-		if (!confirmed) {
+	const handleUnlinkAccept = async () => {
+		const provider = unlinkTarget;
+
+		if (provider === "") {
 			return;
 		}
 
@@ -99,7 +109,10 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 			() => deleteOAuthConnection(provider),
 			err => {
 				console.error(`${provider} 로그인 연동 해제 실패`, err);
-				alert(`${providerToName[provider]} 로그인 연동 해제 실패`);
+				globalErrorModal.open({
+					title: "소셜 로그인 연동 해제 실패",
+					message: `${providerToName[provider]} 로그인 연동 해제에 실패했습니다.`,
+				});
 			}
 		);
 
@@ -111,10 +124,28 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 			...oAuthConnections,
 			[provider]: false,
 		});
+		unlinkConfirmModal.close();
+		alert(`${providerToName[provider]} 로그인 연동을 해제했습니다.`);
 	};
 
 	return (
 		<div className={socialLoginButtons}>
+			<ConfirmModal
+				isOpen={unlinkConfirmModal.isOpen}
+				okButtonColor="danger"
+				okButtonLabel="연동 해제"
+				onAccept={handleUnlinkAccept}
+				onClose={unlinkConfirmModal.close}
+			>
+				<ConfirmModal.Title>
+					소셜 로그인 연동 해제 확인
+				</ConfirmModal.Title>
+				<ConfirmModal.Body>
+					{unlinkTarget && providerToName[unlinkTarget]} 로그인 연동을
+					해제할까요?
+				</ConfirmModal.Body>
+			</ConfirmModal>
+
 			<div className={socialLoginItem}>
 				<button
 					className={googleButton}

--- a/client/src/component/User/OAuthLoginButtons.tsx
+++ b/client/src/component/User/OAuthLoginButtons.tsx
@@ -79,7 +79,10 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 			() => getOAuthLoginUrl(loginType, provider),
 			err => {
 				console.error(`${provider} 로그인 URL 조회 에러`, err);
-				alert(`${provider}(으)로 로그인할 수 없습니다.`);
+				globalErrorModal.open({
+					title: "오류",
+					message: `${provider}(으)로 로그인할 수 없습니다.`,
+				});
 			}
 		);
 
@@ -124,8 +127,13 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 			...oAuthConnections,
 			[provider]: false,
 		});
+
 		unlinkConfirmModal.close();
-		alert(`${providerToName[provider]} 로그인 연동을 해제했습니다.`);
+		globalErrorModal.open({
+			variant: "info",
+			title: "소셜 로그인 연동 해제 성공",
+			message: `${providerToName[provider]} 로그인 연동을 해제했습니다.`,
+		});
 	};
 
 	return (

--- a/client/src/component/common/Modal/GlobalErrorModal.tsx
+++ b/client/src/component/common/Modal/GlobalErrorModal.tsx
@@ -29,7 +29,6 @@ const GlobalErrorModalRoot: React.FC<IGlobalErrorModalRootProps> = ({
 	return (
 		<AlertModal
 			{...baseModalProps}
-			variant="error"
 			onClose={handleClose}
 		>
 			{children}

--- a/client/src/component/common/Modal/Modal.tsx
+++ b/client/src/component/common/Modal/Modal.tsx
@@ -13,6 +13,8 @@ export interface IModalRootProps {
 	children: React.ReactNode;
 	variant?: TModalVariant;
 	isOpen?: boolean;
+	/** @property 기본값: `#modal-root`에 해당하는 엘리먼트 */
+	container?: Element;
 	onClose?: () => void;
 }
 
@@ -42,6 +44,7 @@ const ModalRoot: React.FC<IModalRootProps> = ({
 	children,
 	variant = "base",
 	isOpen,
+	container = modalRootElement,
 	onClose,
 }) => {
 	const contextValue: IModalContextValue = useMemo(
@@ -62,7 +65,14 @@ const ModalRoot: React.FC<IModalRootProps> = ({
 			{isOpen &&
 				createPortal(
 					<ModalContext.Provider value={contextValue}>
-						<div className="fixed inset-0 z-50 flex h-full w-full items-center justify-center bg-black/50">
+						<div
+							className={clsx(
+								"inset-0 z-50 flex h-full w-full items-center justify-center bg-black/50",
+								container === modalRootElement
+									? "fixed"
+									: "absolute"
+							)}
+						>
 							<div
 								className="absolute inset-0 -z-10 h-full w-full"
 								onClick={handleClose}
@@ -72,7 +82,7 @@ const ModalRoot: React.FC<IModalRootProps> = ({
 							</section>
 						</div>
 					</ModalContext.Provider>,
-					modalRootElement
+					container
 				)}
 		</>
 	);

--- a/client/src/page/User/CheckPassword.tsx
+++ b/client/src/page/User/CheckPassword.tsx
@@ -14,6 +14,7 @@ import { ClientError } from "../../api/errors";
 import { ApiCall } from "../../api/api";
 import OAuthLoginButtons from "../../component/User/OAuthLoginButtons";
 import ConfirmModal from "../../component/common/Modal/ConfirmModal";
+import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
 
 const CheckPassword: FC = () => {
 	const navigate = useNavigate();
@@ -28,6 +29,7 @@ const CheckPassword: FC = () => {
 	const { setLogoutUser } = useUserStore.use.actions();
 	const isEmailRegistered = useUserStore.use.isEmailRegistered();
 
+	const globalErrorModal = useGlobalErrorModal();
 	const accountDeleteModal = useModal();
 
 	useLayoutEffect(() => {
@@ -42,24 +44,36 @@ const CheckPassword: FC = () => {
 
 	const handleSubmit = async () => {
 		if (!password) {
-			alert("비밀번호를 입력하세요.");
+			globalErrorModal.open({
+				title: "오류",
+				message: "비밀번호를 입력하세요.",
+			});
 			return;
 		}
 		if (REGEX.PASSWORD.test(password) === false) {
-			alert("비밀번호가 일치하지 않습니다.");
+			globalErrorModal.open({
+				title: "오류",
+				message: "비밀번호가 일치하지 않습니다.",
+			});
 			setPassword("");
 			return;
 		}
 
 		const errorHandle = (err: ClientError) => {
 			if (err.code === 400) {
-				alert("비밀번호가 일치하지 않습니다.");
+				globalErrorModal.open({
+					title: "오류",
+					message: "비밀번호가 일치하지 않습니다.",
+				});
 				setPassword("");
 				return;
 			}
 
 			if (err.code === 401) {
-				alert("로그인이 필요합니다.");
+				globalErrorModal.open({
+					title: "오류",
+					message: "로그인이 필요합니다.",
+				});
 				navigate("/login");
 				return;
 			}
@@ -75,7 +89,10 @@ const CheckPassword: FC = () => {
 		}
 
 		if (!next) {
-			alert("비밀번호 재확인 이후 진행할 동작이 없습니다.");
+			globalErrorModal.open({
+				title: "오류",
+				message: "비밀번호 재확인 이후 진행할 동작이 없습니다.",
+			});
 			navigate("/");
 			return;
 		} else if (next === "accountDelete") {
@@ -88,7 +105,10 @@ const CheckPassword: FC = () => {
 
 	const handleAccountDeleteAccept = async () => {
 		const errorHandle = () => {
-			alert("회원 탈퇴에 실패했습니다.");
+			globalErrorModal.open({
+				title: "오류",
+				message: "회원 탈퇴에 실패했습니다.",
+			});
 			navigate(`/`);
 			return;
 		};
@@ -103,7 +123,11 @@ const CheckPassword: FC = () => {
 		}
 
 		accountDeleteModal.close();
-		alert("회원 탈퇴가 완료되었습니다.");
+		globalErrorModal.open({
+			variant: "warning",
+			title: "회원 탈퇴 완료",
+			message: "회원 탈퇴를 완료했습니다.",
+		});
 
 		setLogoutUser();
 		navigate(`/`);

--- a/client/src/page/User/EmailRegistration.tsx
+++ b/client/src/page/User/EmailRegistration.tsx
@@ -20,6 +20,7 @@ import {
 	applySubmitButtonStyle,
 	submitButtonStyle,
 } from "../../component/User/css/SubmitButton.css";
+import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
 
 const EmailRegistration: FC = () => {
 	const navigate = useNavigate();
@@ -32,6 +33,8 @@ const EmailRegistration: FC = () => {
 	const password = useStringWithValidation();
 	const requiredPassword = useStringWithValidation();
 	const [errorMessage, setErrorMessage] = useState("");
+
+	const globalErrorModal = useGlobalErrorModal();
 
 	const { setIsEmailRegistered } = useUserStore.use.actions();
 
@@ -50,13 +53,19 @@ const EmailRegistration: FC = () => {
 			err.code === 401 &&
 			err.message === "Unauthorized: 로그인이 필요합니다."
 		) {
-			alert("로그인이 필요합니다.");
+			globalErrorModal.open({
+				title: "오류",
+				message: "로그인이 필요합니다.",
+			});
 			navigate("/login");
 			return;
 		}
 
 		if (err.code !== 200) {
-			alert("검증되지 않은 유저입니다.");
+			globalErrorModal.open({
+				title: "오류",
+				message: "로그인 정보가 만료되었거나 유효하지 않습니다.",
+			});
 			navigate(`/checkPassword?next=emailRegistration&final=${final}`);
 			return;
 		}
@@ -116,7 +125,10 @@ const EmailRegistration: FC = () => {
 
 	const handleSubmit = async () => {
 		if (isEmailRegistered) {
-			alert(`${storeNickName} 님은 이미 이메일을 등록하셨습니다.`);
+			globalErrorModal.open({
+				title: "오류",
+				message: `${storeNickName} 님은 이미 이메일을 등록했습니다.`,
+			});
 			navigate(final || "/");
 			return;
 		}
@@ -139,7 +151,11 @@ const EmailRegistration: FC = () => {
 		setIsEmailRegistered(true);
 		navigate(final || "/");
 
-		alert("로그인 이메일을 등록했습니다.");
+		globalErrorModal.open({
+			variant: "info",
+			title: "이메일 등록 성공",
+			message: "로그인 이메일을 등록했습니다.",
+		});
 	};
 
 	const handleCancle = () => {

--- a/client/src/page/User/Join.tsx
+++ b/client/src/page/User/Join.tsx
@@ -14,6 +14,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { useStringWithValidation } from "../../hook/useStringWithValidation";
 import { FaComments } from "react-icons/fa6";
+import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
 
 const Join: FC = () => {
 	const navigate = useNavigate();
@@ -21,6 +22,8 @@ const Join: FC = () => {
 	const nickname = useStringWithValidation();
 	const password = useStringWithValidation();
 	const requiredPassword = useStringWithValidation();
+
+	const globalErrorModal = useGlobalErrorModal();
 
 	const handleEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
 		email.setValue(e.target.value);
@@ -162,7 +165,11 @@ const Join: FC = () => {
 		}
 
 		if (result) {
-			alert("회원가입이 완료되었습니다.");
+			globalErrorModal.open({
+				variant: "info",
+				title: "축하드립니다",
+				message: "회원가입을 완료했습니다.",
+			});
 			navigate("/login");
 		}
 	};

--- a/client/src/page/User/ProfileUpdate.tsx
+++ b/client/src/page/User/ProfileUpdate.tsx
@@ -20,6 +20,7 @@ import {
 	applySubmitButtonStyle,
 	submitButtonStyle,
 } from "../../component/User/css/SubmitButton.css";
+import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
 
 interface IProfileUpdatePayload {
 	email?: string | undefined;
@@ -44,6 +45,8 @@ const ProfileUpdate: FC = () => {
 	const requiredPassword = useStringWithValidation();
 	const [errorMessage, setErrorMessage] = useState("");
 
+	const globalErrorModal = useGlobalErrorModal();
+
 	const { setNickName: storeSetNickName } = useUserStore.use.actions();
 
 	const storeNickName = useUserStore.use.nickname();
@@ -61,13 +64,19 @@ const ProfileUpdate: FC = () => {
 			err.code === 401 &&
 			err.message === "Unauthorized: 로그인이 필요합니다."
 		) {
-			alert("로그인이 필요합니다.");
+			globalErrorModal.open({
+				title: "오류",
+				message: "로그인이 필요합니다.",
+			});
 			navigate("/login");
 			return;
 		}
 
 		if (err.code !== 200) {
-			alert("검증되지 않은 유저 입니다.");
+			globalErrorModal.open({
+				title: "오류",
+				message: "로그인 정보가 만료되었거나 유효하지 않습니다.",
+			});
 			navigate(`/checkPassword?next=profileUpdate&final=${final}`);
 			return;
 		}
@@ -159,7 +168,11 @@ const ProfileUpdate: FC = () => {
 
 		storeSetNickName(nickname.value);
 
-		alert("유저 정보가 변경되었습니다.");
+		globalErrorModal.open({
+			variant: "info",
+			title: "성공",
+			message: "유저 정보가 변경되었습니다.",
+		});
 	};
 
 	const handleCancle = () => {

--- a/client/src/state/ChatAsideStore.ts
+++ b/client/src/state/ChatAsideStore.ts
@@ -10,12 +10,14 @@ export enum ChatAsideCategory {
 interface IChatAsideState {
 	isOpen: boolean;
 	category: ChatAsideCategory;
+	chatModalContainer: Element | null;
 }
 
 interface IChatAsideActions {
 	open: () => void;
 	close: () => void;
 	setCategory: (category: ChatAsideCategory) => void;
+	setChatModalContainer: (element: Element | null) => void;
 }
 
 export interface TChatAsideStore extends IChatAsideState, IChatAsideActions {}
@@ -30,15 +32,19 @@ export const useChatAside = create<TChatAsideStore>(
 		set => ({
 			isOpen: false,
 			category: ChatAsideCategory.SEARCH,
+			chatModalContainer: null,
 			open: () => set(() => ({ isOpen: true })),
 			close: () => set(() => ({ isOpen: false })),
 			setCategory: category => set(() => ({ category: category })),
+			setChatModalContainer: element =>
+				set(() => ({ chatModalContainer: element })),
 		}),
 		{
 			name: "ChatAsideStore",
 			partialize: state => ({
 				isOpen: state.isOpen,
 				category: state.category,
+				chatModalContainer: null,
 			}),
 		}
 	)

--- a/client/src/state/GlobalErrorModalStore.ts
+++ b/client/src/state/GlobalErrorModalStore.ts
@@ -1,20 +1,24 @@
 import { create } from "zustand";
+import { TModalVariant } from "../component/common/Modal/Modal";
 
 interface IGlobalErrorModalState {
 	isOpen: boolean;
 	callback?: () => void;
 	title: string;
 	message: string;
+	variant: TModalVariant;
 }
 
 interface IOpenActionParam {
 	title: string;
 	message: string;
+	variant?: TModalVariant;
 	callback?: () => void;
 }
 
 interface IOpenWithMessageSplitActionParam {
 	messageWithTitle: string;
+	variant?: TModalVariant;
 	callback?: () => void;
 }
 
@@ -30,6 +34,7 @@ export const useGlobalErrorModal = create<TGlobalErrorModalStore>(set => ({
 	isOpen: false,
 	title: "",
 	message: "",
+	variant: "error",
 
 	open: param =>
 		set(state => ({
@@ -38,22 +43,20 @@ export const useGlobalErrorModal = create<TGlobalErrorModalStore>(set => ({
 			isOpen: true,
 		})),
 
-	openWithMessageSplit: ({ messageWithTitle, callback }) => {
+	openWithMessageSplit: ({ messageWithTitle, ...param }) => {
 		const delimiterIndex = messageWithTitle.indexOf(":");
 
 		if (delimiterIndex >= 0) {
 			set(state => ({
 				...state,
-				callback,
-				isOpen: true,
+				...param,
 				title: messageWithTitle.slice(0, delimiterIndex).trim(),
 				message: messageWithTitle.slice(delimiterIndex + 1).trim(),
 			}));
 		} else {
 			set(state => ({
 				...state,
-				callback,
-				isOpen: true,
+				...param,
 				title: "",
 				message: messageWithTitle.trim(),
 			}));
@@ -67,5 +70,6 @@ export const useGlobalErrorModal = create<TGlobalErrorModalStore>(set => ({
 			callback: undefined,
 			title: "",
 			message: "",
+			variant: "error",
 		})),
 }));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #225
- #268
  - #276

## 📝 작업 내용

- 공통 모달을 로컬 모달로 사용할 수 있는 방법 구현 → 새 채팅방 모달에 적용
  - 모달을 끼워넣을 엘리먼트를 `<Modal>` 컴포넌트의 `container` prop으로 전달하면, 모달을 열 때 해당 엘리먼트에서 열립니다.
  - `container` prop에 `somethingRef.current`를 전달할 수 있습니다.
- `window.confirm()`을 `<ConfirmModal>`로 교체
- `window.alert()`를 글로벌 에러 모달로 교체
  - 에러를 표현하는 내용이 아닐 때도 사용할 수 있도록, 글로벌 에러 모달에 `variant` 옵션을 추가했습니다. (예: 회원가입 완료)

## 💬 리뷰 요구사항

- 다른 작업이 연결되어 있어서 바로 머지하겠습니다.