### PR TITLE
[fix] : 랭킹 API 오류 및 카테고리 페이징 수정

### DIFF
--- a/nestjs-migration/src/comment/comment.repository.ts
+++ b/nestjs-migration/src/comment/comment.repository.ts
@@ -134,12 +134,12 @@ export class CommentRepository extends Repository<Comment> {
 
 	async getTopComments() {
 		const queryBuilder = this.createQueryBuilder("comment")
-			.leftJoin("comment.author", "user")
+			.innerJoin("comment.author", "user")
 			.leftJoin("comment.comment_likes", "cl")
-			.leftJoin("comment.post", "post")
+			.innerJoin("comment.post", "post")
 			.select([
 				"user.nickname as nickname",
-				"COUNT(*) as likeCount",
+				"COALESCE(COUNT(cl.id), 0) as likeCount",
 				"comment.id as commentId",
 				"post.id as postId",
 			])

--- a/nestjs-migration/src/post/post.repository.ts
+++ b/nestjs-migration/src/post/post.repository.ts
@@ -92,7 +92,7 @@ export class PostRepository extends Repository<Post> {
 		readPostsQueryDto: ReadPostsQuery,
 		userId: number
 	): Promise<number> {
-		let { keyword } = readPostsQueryDto;
+		let { keyword, category_id } = readPostsQueryDto;
 		userId ? userId : 0;
 
 		const queryBuilder = this.createQueryBuilder("post")
@@ -114,6 +114,11 @@ export class PostRepository extends Repository<Post> {
 		if (keyword) {
 			queryBuilder.andWhere("post.title LIKE :keyword", {
 				keyword: `%${keyword.trim()}%`,
+			});
+		}
+		if (category_id) {
+			queryBuilder.andWhere("post.category_id = :categoryId", {
+				categoryId: category_id,
 			});
 		}
 
@@ -287,13 +292,13 @@ export class PostRepository extends Repository<Post> {
 
 	async getTopPosts() {
 		const queryBuilder = this.createQueryBuilder("post")
-			.leftJoin("post.author", "user")
+			.innerJoin("post.author", "user")
 			.leftJoin("post.likes", "pl")
 			.select([
 				"post.title as title",
 				"post.id as postId",
 				"user.nickname as nickname",
-				"COUNT(*) as likeCount",
+				"COALESCE(COUNT(pl.id), 0) as likeCount",
 			])
 			.where("post.is_delete = :isPostDeleted", { isPostDeleted: false })
 			.andWhere("user.is_delete = :isUserDeleted", {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #293 관련 오류 수정

## 📝 작업 내용

* 포스트, 댓글 랭킹 leftjoin, innerjoin, Count 문법 수정
* 페이지네이션 total - category_id에 따라 올 수 있도록


### 🖼️ 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex: 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
