### PR TITLE
[FE] Q&A 게시판 API 호출 구현

### DIFF
--- a/client/src/api/posts/qna_crud.ts
+++ b/client/src/api/posts/qna_crud.ts
@@ -1,0 +1,16 @@
+import { HttpMethod, convertToBody, httpRequest } from "../api";
+
+export const sendQnaAcceptedCommentIdsRequest = async (body: {
+	postIds: number[];
+}) => {
+	const requestBody = convertToBody(body);
+	return await httpRequest("post/qna", HttpMethod.POST, requestBody);
+};
+
+export const sendQnaAcceptCommentRequest = async (body: {
+	postId: number;
+	commentId: number;
+}) => {
+	const requestBody = convertToBody(body);
+	return await httpRequest("post/qna/accept", HttpMethod.POST, requestBody);
+};

--- a/client/src/component/Comments/Comments.tsx
+++ b/client/src/component/Comments/Comments.tsx
@@ -179,7 +179,7 @@ const Comments: React.FC = () => {
 				{comments.length > 0 ? (
 					comments.map(comment => (
 						<CommentItem
-							key={comment.id}
+							key={`${comment.id}-${comment.user_liked}`}
 							comment={comment}
 							onUpdate={handleCommentUpdate}
 							onDelete={handleCommentDelete}

--- a/client/src/component/Posts/Editer/ImageManager.tsx
+++ b/client/src/component/Posts/Editer/ImageManager.tsx
@@ -13,11 +13,22 @@ interface IProps {
 	setEditorContents: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const s3ImageUrlPattern =
-	/^https:\/\/codeplay-bucket\.s3\.([a-z0-9_-]+)\.amazonaws\.com\/(.+)$/gi;
+const s3Region = import.meta.env.VITE_REGION;
+const s3Bucket = import.meta.env.VITE_BUCKET_NAME;
+
+const s3ImageUrlPrefixes = [
+	`https://s3.${s3Region}.amazonaws.com/${s3Bucket}/`,
+	`https://${s3Bucket}.s3.${s3Region}.amazonaws.com/`,
+];
 
 const isS3Image = (url: string): boolean => {
-	return s3ImageUrlPattern.test(url);
+	for (const prefix of s3ImageUrlPrefixes) {
+		if (url.startsWith(prefix)) {
+			return true;
+		}
+	}
+
+	return false;
 };
 
 const ImageManager: React.FC<IProps> = ({

--- a/client/src/component/Posts/PostList/EmptyPostListBody.tsx
+++ b/client/src/component/Posts/PostList/EmptyPostListBody.tsx
@@ -1,27 +1,29 @@
+import React from "react";
+
 interface IEmptyPostListBody {
-	className?: string;
 	isFetchFailed: boolean;
 	keyword?: string;
 }
 
-const EmptyPostListBody = ({
-	className,
+const EmptyPostListBody: React.FC<IEmptyPostListBody> = ({
 	isFetchFailed,
 	keyword,
-}: IEmptyPostListBody) => {
+}) => {
 	return (
-		<p className={className}>
-			{isFetchFailed ? (
-				"게시글을 불러오지 못했습니다."
-			) : keyword ? (
-				<>“{keyword}”에 대한 검색 결과가 없습니다.</>
-			) : (
-				<>
-					아직 게시글이 없습니다.
-					<br />첫 게시글을 작성해 보세요.
-				</>
-			)}
-		</p>
+		<div className="my-30 flex min-h-48 items-center justify-center text-center text-lg text-gray-600 dark:text-gray-500">
+			<p>
+				{isFetchFailed ? (
+					"게시글을 불러오지 못했습니다."
+				) : keyword ? (
+					<>“{keyword}”에 대한 검색 결과가 없습니다.</>
+				) : (
+					<>
+						아직 게시글이 없습니다.
+						<br />첫 게시글을 작성해 보세요.
+					</>
+				)}
+			</p>
+		</div>
 	);
 };
 

--- a/client/src/component/Posts/PostList/PostList.tsx
+++ b/client/src/component/Posts/PostList/PostList.tsx
@@ -120,7 +120,6 @@ const PostList: React.FC<IPostListProps> = ({
 				<div className="flex flex-col">
 					{isPostsEmpty ? (
 						<EmptyPostListBody
-							className="my-30 text-center text-lg text-gray-600 dark:text-gray-500"
 							isFetchFailed={isFetchFailed}
 							keyword={keyword}
 						/>

--- a/client/src/hook/usePostList.ts
+++ b/client/src/hook/usePostList.ts
@@ -5,6 +5,7 @@ import {
 	sendGetPostsRequest,
 	TPostListClientSearchParams,
 } from "../api/posts/crud";
+import { sendQnaAcceptedCommentIdsRequest } from "../api/posts/qna_crud";
 
 type TPostListHookProps = Partial<
 	TPostListClientSearchParams & {
@@ -77,12 +78,9 @@ const usePostList = ({
 		}
 
 		const qnaRes = await ApiCall(
-			// TODO: 주어진 게시글 ID 목록으로 채택 댓글 목록 요청
 			() =>
-				Promise.resolve({
-					commentIds: fetchedPostList.map(({ id }) =>
-						id % 2 ? 1 : null
-					),
+				sendQnaAcceptedCommentIdsRequest({
+					postIds: fetchedPostList.map(({ id }) => id),
 				}),
 			() => setAcceptedCommentIds(fetchedPostList.map(() => null))
 		);
@@ -91,7 +89,9 @@ const usePostList = ({
 			return;
 		}
 
-		setAcceptedCommentIds(qnaRes?.commentIds ?? []);
+		setAcceptedCommentIds(
+			qnaRes?.commentIds ?? fetchedPostList.map(() => null)
+		);
 	}, postRequestDeps);
 
 	useEffect(() => {

--- a/client/src/page/error/NotFound.tsx
+++ b/client/src/page/error/NotFound.tsx
@@ -1,30 +1,36 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { TbFileSad } from "react-icons/tb";
+import Button from "../../component/common/Button";
 
 const NotFound: React.FC = () => {
+	const navigate = useNavigate();
+
 	return (
-		<div className="relative flex h-[90vh] items-center justify-center p-5 text-center">
+		<div className="relative z-0 flex h-[75vh] items-center justify-center text-balance break-keep text-center">
 			<div className="max-w-[600px]">
-				<div className="mb-2 text-7xl text-gray-400">
+				<div className="mx-auto mb-2 w-fit text-7xl text-neutral-600 dark:text-neutral-400">
 					<TbFileSad />
 				</div>
-				<h1 className="mb-5 text-2xl font-bold text-gray-400">
+
+				<h1 className="mb-5 text-2xl font-bold text-neutral-600 dark:text-neutral-400">
 					원하시는 페이지를 찾을 수 없습니다.
 				</h1>
-				<p className="mb-10 text-base text-gray-400">
+				<p className="mb-10 text-base text-neutral-600 dark:text-neutral-400">
 					찾으려는 페이지의 주소가 잘못 입력되었거나, 주소의 변경 혹은
 					삭제로 인해 사용하실 수 없습니다. 입력하신 페이지의 주소가
 					정확한지 다시 한 번 확인해 주세요.
 				</p>
-				<Link
-					to="/"
-					className="inline-block rounded-lg bg-black px-6 py-4 text-base text-gray-400 no-underline"
+
+				<Button
+					size="large"
+					onClick={() => navigate("/")}
 				>
 					메인으로 돌아가기
-				</Link>
+				</Button>
 			</div>
-			<div className="pointer-events-none absolute left-1/2 top-1/2 z-[-1] -translate-x-1/2 -translate-y-1/2 transform select-none whitespace-nowrap text-[120px] font-bold text-gray-800">
+
+			<div className="pointer-events-none absolute left-1/2 top-1/2 -z-10 -translate-x-1/2 -translate-y-1/2 transform select-none whitespace-nowrap text-[120px] font-bold text-black/5 dark:text-white/5">
 				404 Not Found
 			</div>
 		</div>

--- a/client/src/style/quill/quill.css
+++ b/client/src/style/quill/quill.css
@@ -10,13 +10,11 @@
 
 	/* Quill 에디터 툴바 박스 */
 	.ql-toolbar.ql-snow {
-		/* TODO: TextInput 컴포넌트 다크모드 작업 후, 다크모드 테두리 컬러 수정 */
 		@apply rounded-t-md border border-gray-600 font-sans;
 	}
 
 	/* Quill 에디터 본문 박스 */
 	.ql-container.ql-snow {
-		/* TODO: TextInput 컴포넌트 다크모드 작업 후, 다크모드 테두리 컬러 수정 */
 		@apply overflow-hidden rounded-b-md border border-gray-600;
 	}
 }

--- a/client/src/style/quill/toolbar.css
+++ b/client/src/style/quill/toolbar.css
@@ -17,7 +17,6 @@
 
 	/* 드롭다운 토글 버튼 (펼침) */
 	.ql-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-label {
-		/* TODO: TextInput 컴포넌트 다크모드 작업 후, 다크모드 테두리 컬러 수정 */
 		@apply rounded-t border-gray-600 text-neutral-500 dark:text-neutral-500;
 	}
 
@@ -28,7 +27,6 @@
 
 	/* 드롭다운 선택지 목록 */
 	.ql-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-options {
-		/* TODO: TextInput 컴포넌트 다크모드 작업 후, 다크모드 테두리 컬러 수정 */
 		@apply dark:bg-customDarkGray rounded-b border-gray-600 bg-white shadow-md;
 	}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #224
- #309
- #230
- #320

## 📝 작업 내용

- Q&A 게시판의 글 목록, 게시글 열람 페이지에서 서버에 실제 데이터를 요청하는 로직을 작성합니다.
- Resolves #316
  - <mark>**중요**: `.env` 파일에 아래 내용이 정의되어야 올바르게 작동합니다.</mark>
    ```sh
    VITE_BUCKET_NAME=${BUCKET_NAME}
    VITE_REGION=${REGION}
    ```
- 임의의 댓글 A의 좋아요를 토글한 상태에서 새 댓글을 작성할 때, 댓글 A의 좋아요 표시가 반전되는 문제를 해결합니다.

### 🖼️ 스크린샷

<details><summary>Details</summary>

> <img width="824" alt="qna" src="https://github.com/user-attachments/assets/92680719-9c1e-4550-a29e-095fd2da0d8f">
>
> ---

</details>

## 💬 리뷰 요구사항

- 잘못 구현되었거나 변경 필요한 부분이 있다면 말씀해 주세요.