### PR TITLE
🐛 [fix] : 다크모드에서 TextInput 컴포넌트 invalid 상태 시인성 개선

### DIFF
--- a/client/src/component/common/TextInput.tsx
+++ b/client/src/component/common/TextInput.tsx
@@ -65,7 +65,7 @@ const TextInput: React.FC<ITextInputProps> = ({
 					id={id}
 					className={twMerge(
 						"m-0 box-border h-10 flex-1 rounded-md border border-gray-600 bg-transparent p-2 text-base text-inherit",
-						isValid === false && "border-red-600 bg-red-50"
+						isValid === false && "border-red-600 bg-red-500/5"
 					)}
 					onKeyDown={handleInputKeyDown}
 				/>


### PR DESCRIPTION
## 📝 작업 내용

- `<TextInput>` 컴포넌트가 invalid 상태일 때의 배경색에 불투명도를 부여하여 다크모드에서도 글자와 배경이 구분되도록 수정합니다.
  - 배경색을 `red-50`에서 `red-500`, 불투명도 5%로 변경합니다.

### 🖼️ 스크린샷

<img width="1344" alt="textinput-fix" src="https://github.com/user-attachments/assets/d4713a79-b5f6-442b-940f-c1a9c1d9a286">