### PR TITLE
✨ [feat] : Toast 컴포넌트 작성 및 일부 모달을 토스트로 대체

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,6 +16,7 @@
 	<body>
 		<div id="root"></div>
 		<div id="modal-root"></div>
+		<div id="toast-root"></div>
 		<script
 			type="module"
 			src="/src/main.tsx"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,6 +32,7 @@ import UpsertPostPage from "./page/Posts/UpsertPostPage";
 import ProfilePage from "./page/Profile/ProfilePage";
 import { Rank } from "./page/Rank/Rank";
 import useCategory from "./hook/useCategory";
+import Toast from "./component/common/Toast/Toast";
 
 function MainContainer({ children }: { children: React.ReactNode }) {
 	const location = useLocation();
@@ -100,6 +101,8 @@ function App() {
 				<Header />
 
 				<MainContainer>
+					<Toast />
+
 					<GlobalErrorModal
 						isOpen={globalErrorModal.isOpen}
 						variant={globalErrorModal.variant}

--- a/client/src/component/Chats/ChatRoom/SideBar/ChatRoomSideBar.tsx
+++ b/client/src/component/Chats/ChatRoom/SideBar/ChatRoomSideBar.tsx
@@ -4,8 +4,7 @@ import profileIcon from "../../../../assets/icons/profile-icon.svg";
 import { Link } from "react-router-dom";
 import { useChatAside } from "../../../../state/ChatAsideStore";
 import { FiX } from "react-icons/fi";
-import AlertModal from "../../../common/Modal/AlertModal";
-import { useModal } from "../../../../hook/useModal";
+import { useToast } from "../../../../state/ToastStore";
 import { ApiCall } from "../../../../api/api";
 import { sendLeaveRoomRequest } from "../../../../api/chats/crud";
 import { ClientError } from "../../../../api/errors";
@@ -27,7 +26,7 @@ export const ChatRoomSideBar: React.FC<Props> = ({
 	myMemberId,
 	goBack,
 }) => {
-	const alertModal = useModal();
+	const toast = useToast();
 	const { close } = useChatAside();
 
 	const renderMembers = () => {
@@ -55,7 +54,10 @@ export const ChatRoomSideBar: React.FC<Props> = ({
 	const handleLeaveRoom = async () => {
 		members.forEach(member => {
 			if (member.memberId === myMemberId && member.isHost === true) {
-				alertModal.open();
+				toast.add({
+					message: "방장은 탈퇴할 수 없습니다.",
+					variant: "error",
+				});
 				return;
 			}
 		});
@@ -81,14 +83,6 @@ export const ChatRoomSideBar: React.FC<Props> = ({
 
 	return (
 		<>
-			<AlertModal
-				isOpen={alertModal.isOpen}
-				onClose={alertModal.close}
-				variant="info"
-			>
-				<AlertModal.Title>안내</AlertModal.Title>
-				<AlertModal.Body>방장은 탈퇴할 수 없습니다.</AlertModal.Body>
-			</AlertModal>
 			<div
 				className="absolute right-[-15px] top-[-20px] z-10 h-[500px] w-[400px] bg-black bg-opacity-50"
 				onClick={sideBarClose}

--- a/client/src/component/Coupon/coupon.tsx
+++ b/client/src/component/Coupon/coupon.tsx
@@ -1,15 +1,12 @@
 import { RiCoupon3Fill } from "react-icons/ri";
 import { GoAlert } from "react-icons/go";
 import Button from "../common/Button";
-import { useModal } from "../../hook/useModal";
-import AlertModal from "../common/Modal/AlertModal";
-import { useState } from "react";
+import { useToast } from "../../state/ToastStore";
 import { FaStar } from "react-icons/fa";
 import { fetchCoupon } from "../../api/coupon/coupon_crud";
 
 export const Coupon = () => {
-	const alertModal = useModal();
-	const [alertMessage, setAlertMessage] = useState("");
+	const toast = useToast();
 
 	const handleCoupon = async () => {
 		try {
@@ -18,24 +15,34 @@ export const Coupon = () => {
 			console.log(response.status);
 
 			if (response.status === 200) {
-				setAlertMessage("쿠폰이 발급되었습니다.");
+				toast.add({
+					message: "쿠폰이 발급되었습니다.",
+					variant: "success",
+				});
 			} else if (
 				response.status === 409 &&
 				response.message == "Unknown Error: Unknown Error: 중복쿠폰"
 			) {
 				// const errorMessage = await response.message();
-				setAlertMessage("이미 발급된 쿠폰입니다");
+				toast.add({
+					message: "이미 발급된 쿠폰입니다.",
+					variant: "error",
+				});
 			} else if (
 				response.status === 409 &&
 				response.message == "Unknown Error: Unknown Error: 쿠폰없음"
 			) {
 				// const errorMessage = await response.message();
-				setAlertMessage("쿠폰이 모두 소진되었습니다");
+				toast.add({
+					message: "쿠폰이 모두 소진되었습니다",
+					variant: "error",
+				});
 			}
 		} catch (error) {
-			setAlertMessage("오류가 발생했습니다");
-		} finally {
-			alertModal.open();
+			toast.add({
+				message: "오류가 발생했습니다.",
+				variant: "error",
+			});
 		}
 	};
 
@@ -75,20 +82,6 @@ export const Coupon = () => {
 					</Button>
 				</div>
 				<hr />
-
-				<AlertModal
-					isOpen={alertModal.isOpen}
-					variant="info"
-					okButtonLabel="뒤로"
-					onClose={() => {
-						alertModal.close();
-					}}
-				>
-					<AlertModal.Title>안내</AlertModal.Title>
-					<AlertModal.Body>
-						{alertMessage} {/* 응답 메시지 출력 */}
-					</AlertModal.Body>
-				</AlertModal>
 			</div>
 		</div>
 	);

--- a/client/src/component/Posts/Editer/ImageManager.tsx
+++ b/client/src/component/Posts/Editer/ImageManager.tsx
@@ -4,7 +4,7 @@ import ReactQuill from "react-quill";
 import { useModal } from "../../../hook/useModal";
 import { useGlobalErrorModal } from "../../../state/GlobalErrorModalStore";
 import Button from "../../common/Button";
-import AlertModal from "../../common/Modal/AlertModal";
+import { useToast } from "../../../state/ToastStore";
 import ConfirmModal from "../../common/Modal/ConfirmModal";
 
 interface IProps {
@@ -38,7 +38,7 @@ const ImageManager: React.FC<IProps> = ({
 }) => {
 	const globalErrorModal = useGlobalErrorModal();
 	const removalConfirmModal = useModal();
-	const removalSuccessModal = useModal();
+	const toast = useToast();
 
 	const [imageUrlSet, setImageUrlSet] = useState(new Set<string>());
 	const [removalTargetUrl, setRemovalTargetUrl] = useState("");
@@ -97,7 +97,11 @@ const ImageManager: React.FC<IProps> = ({
 
 		setEditorContents(container.innerHTML);
 		setRemovalTargetUrl("");
-		removalSuccessModal.open();
+
+		toast.add({
+			message: "이미지를 본문에서 제거했습니다.",
+			variant: "success",
+		});
 	};
 
 	return (
@@ -119,17 +123,6 @@ const ImageManager: React.FC<IProps> = ({
 					/>
 				</ConfirmModal.Body>
 			</ConfirmModal>
-
-			<AlertModal
-				isOpen={removalSuccessModal.isOpen}
-				onClose={removalSuccessModal.close}
-				variant="info"
-			>
-				<AlertModal.Title>안내</AlertModal.Title>
-				<AlertModal.Body>
-					이미지를 본문에서 제거했습니다.
-				</AlertModal.Body>
-			</AlertModal>
 
 			<div className="ml-1 text-sm font-bold">첨부한 이미지</div>
 

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -16,7 +16,7 @@ import { sendDeletePostRequest } from "../../api/posts/crud";
 import { useModal } from "../../hook/useModal";
 import useCategory from "../../hook/useCategory";
 import { sendJoinRoomRequest } from "../../api/chats/crud";
-import AlertModal from "../common/Modal/AlertModal";
+import { useToast } from "../../state/ToastStore";
 import { FaCheck } from "react-icons/fa";
 import { usePostInfo } from "../../state/PostInfoStore";
 
@@ -28,8 +28,8 @@ const PostInfo: React.FC = () => {
 	const { currentCategory } = useCategory(post.category);
 
 	const deleteModal = useModal();
-	const joinSuccessModal = useModal();
 	const globalErrorModal = useGlobalErrorModal();
+	const toast = useToast();
 
 	const [userLiked, setUserLiked] = useState(false);
 	const [likes, setLikes] = useState(0);
@@ -145,7 +145,10 @@ const PostInfo: React.FC = () => {
 			return;
 		}
 
-		joinSuccessModal.open();
+		toast.add({
+			message: "채팅방 가입에 성공했습니다.",
+			variant: "success",
+		});
 	};
 
 	return (
@@ -163,14 +166,6 @@ const PostInfo: React.FC = () => {
 					정말로 이 게시글을 삭제할까요?
 				</ConfirmModal.Body>
 			</ConfirmModal>
-			<AlertModal
-				isOpen={joinSuccessModal.isOpen}
-				onClose={joinSuccessModal.close}
-				variant="info"
-			>
-				<AlertModal.Title>안내</AlertModal.Title>
-				<AlertModal.Body>채팅방 가입에 성공했습니다</AlertModal.Body>
-			</AlertModal>
 
 			<div className="flex w-[800px] flex-col pb-2.5 pt-2.5">
 				<div className="dark:bg-customGray relative mb-4 mt-4 flex flex-col justify-between rounded-lg bg-blue-900 text-left">

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -111,10 +111,9 @@ const PostInfo: React.FC = () => {
 		}
 
 		deleteModal.close();
-		globalErrorModal.open({
-			variant: "info",
-			title: "게시글 삭제 성공",
+		toast.add({
 			message: "게시글을 성공적으로 삭제했습니다.",
+			variant: "warning",
 		});
 		navigate(currentCategory?.path ?? "/");
 	}, [isAuthor]);

--- a/client/src/component/Posts/PostInfo.tsx
+++ b/client/src/component/Posts/PostInfo.tsx
@@ -113,7 +113,7 @@ const PostInfo: React.FC = () => {
 		deleteModal.close();
 		toast.add({
 			message: "게시글을 성공적으로 삭제했습니다.",
-			variant: "warning",
+			variant: "success",
 		});
 		navigate(currentCategory?.path ?? "/");
 	}, [isAuthor]);

--- a/client/src/component/Profile/Modal/PasswordUpdateModal.tsx
+++ b/client/src/component/Profile/Modal/PasswordUpdateModal.tsx
@@ -4,12 +4,10 @@ import Button from "../../common/Button";
 import { IUpdatePasswordRequest } from "shared";
 import { sendPatchPasswordRequest } from "../../../api/users/crud";
 import { useGlobalErrorModal } from "../../../state/GlobalErrorModalStore";
-import { useModal } from "../../../hook/useModal";
-import AlertModal from "../../common/Modal/AlertModal";
+import { useToast } from "../../../state/ToastStore";
 import TextInput from "../../common/TextInput";
 import { REGEX } from "../../../page/User/constants/constants";
 // import { ApiCall } from "../../../api/api";
-// import { useGlobalErrorModal } from "../../../state/GlobalErrorModalStore";
 
 interface Props {
 	close: React.Dispatch<SetStateAction<boolean>>;
@@ -17,7 +15,7 @@ interface Props {
 
 const PasswordUpdateModal: React.FC<Props> = ({ close }) => {
 	const globalErrorModal = useGlobalErrorModal();
-	const alertModal = useModal();
+	const toast = useToast();
 
 	const [origin, setOrigin] = useState<string>("");
 	const [newPsword, setNewPsword] = useState<string>("");
@@ -37,27 +35,16 @@ const PasswordUpdateModal: React.FC<Props> = ({ close }) => {
 				return;
 			}
 
-			alertModal.open();
+			toast.add({
+				message: "비밀번호를 성공적으로 변경하였습니다.",
+				variant: "success",
+			});
+			close(false);
 		});
 	};
 
 	return (
 		<div className="dark:bg-customGray absolute left-1/2 top-1/2 z-50 w-[600px] -translate-x-1/2 -translate-y-1/2 transform rounded-[5px] border border-gray-300 bg-white text-center">
-			<AlertModal
-				isOpen={alertModal.isOpen}
-				variant="info"
-				okButtonLabel="돌아가기"
-				onClose={() => {
-					alertModal.close();
-					close(false);
-				}}
-			>
-				<AlertModal.Title>안내</AlertModal.Title>
-
-				<AlertModal.Body>
-					비밀번호를 성공적으로 변경하였습니다
-				</AlertModal.Body>
-			</AlertModal>
 			<div className="dark:border-white-500 flex h-fit flex-row flex-wrap justify-between border-b border-gray-500 p-[15px]">
 				<div className="flex items-center justify-center font-extrabold">
 					비밀번호 수정

--- a/client/src/component/User/OAuthLoginButtons.tsx
+++ b/client/src/component/User/OAuthLoginButtons.tsx
@@ -13,6 +13,7 @@ import { ApiCall } from "../../api/api";
 import { sendGetUserMyself } from "../../api/users/crud";
 import { useModal } from "../../hook/useModal";
 import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
+import { useToast } from "../../state/ToastStore";
 import ConfirmModal from "../common/Modal/ConfirmModal";
 import Button from "../common/Button";
 
@@ -37,6 +38,7 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 	const [unlinkTarget, setUnlinkTarget] = useState<TOAuthProvider | "">("");
 	const unlinkConfirmModal = useModal();
 	const globalErrorModal = useGlobalErrorModal();
+	const toast = useToast();
 
 	const location = useLocation();
 
@@ -120,10 +122,9 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 		});
 
 		unlinkConfirmModal.close();
-		globalErrorModal.open({
-			variant: "info",
-			title: "소셜 로그인 연동 해제 성공",
+		toast.add({
 			message: `${providerToName[provider]} 로그인 연동을 해제했습니다.`,
+			variant: "warning",
 		});
 	};
 

--- a/client/src/component/User/OAuthLoginButtons.tsx
+++ b/client/src/component/User/OAuthLoginButtons.tsx
@@ -124,7 +124,7 @@ const OAuthLoginButtons: React.FC<IProps> = ({ loginType }) => {
 		unlinkConfirmModal.close();
 		toast.add({
 			message: `${providerToName[provider]} 로그인 연동을 해제했습니다.`,
-			variant: "warning",
+			variant: "success",
 		});
 	};
 

--- a/client/src/component/common/Toast/Toast.tsx
+++ b/client/src/component/common/Toast/Toast.tsx
@@ -1,50 +1,14 @@
-import { useEffect, useLayoutEffect } from "react";
+import { useEffect } from "react";
 import { createPortal } from "react-dom";
-import { TToastVariant, useToast } from "../../../state/ToastStore";
+import { useToast } from "../../../state/ToastStore";
 import ToastItem from "./ToastItem";
 
 const TOAST_GAP = 8;
 
 const container = document.getElementById("toast-root")!;
 
-// TODO: mock data 제거
-const mockData: {
-	message: string;
-	variant: TToastVariant;
-}[] = [
-	{
-		message: "단순 정보를 전달하는 토스트 (1)",
-		variant: "info",
-	},
-	{
-		message: "성공을 안내하는 토스트 (2)",
-		variant: "success",
-	},
-	{
-		message: "경고 토스트 (3)",
-		variant: "warning",
-	},
-	{
-		message: "에러 안내 토스트 (4)",
-		variant: "error",
-	},
-];
-
 const Toast = () => {
-	const { items, add, updateItem, forceRemove } = useToast();
-
-	// TODO: mock data 제거
-	useLayoutEffect(() => {
-		for (const item of mockData) {
-			add(item);
-		}
-
-		return () => {
-			items.map.forEach((_, key) => {
-				forceRemove(key);
-			});
-		};
-	}, []);
+	const { items, updateItem } = useToast();
 
 	useEffect(() => {
 		const reversedItems = Array.from(items.map.values()).reverse();

--- a/client/src/component/common/Toast/Toast.tsx
+++ b/client/src/component/common/Toast/Toast.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
+import { TToastVariant, useToast } from "../../../state/ToastStore";
+import ToastItem from "./ToastItem";
+
+const TOAST_GAP = 8;
+
+const container = document.getElementById("toast-root")!;
+
+// TODO: mock data 제거
+const mockData: {
+	message: string;
+	variant: TToastVariant;
+}[] = [
+	{
+		message: "단순 정보를 전달하는 토스트 (1)",
+		variant: "info",
+	},
+	{
+		message: "성공을 안내하는 토스트 (2)",
+		variant: "success",
+	},
+	{
+		message: "경고 토스트 (3)",
+		variant: "warning",
+	},
+	{
+		message: "에러 안내 토스트 (4)",
+		variant: "error",
+	},
+];
+
+const Toast = () => {
+	const { items, add, updateItem, forceRemove } = useToast();
+
+	// TODO: mock data 제거
+	useLayoutEffect(() => {
+		for (const item of mockData) {
+			add(item);
+		}
+
+		return () => {
+			items.map.forEach((_, key) => {
+				forceRemove(key);
+			});
+		};
+	}, []);
+
+	useEffect(() => {
+		const reversedItems = Array.from(items.map.values()).reverse();
+		let offsetAcc = 0;
+
+		for (const {
+			id,
+			phase,
+			elementHeight,
+			elementOffsetY,
+		} of reversedItems) {
+			if (elementOffsetY !== offsetAcc) {
+				updateItem(id, { elementOffsetY: offsetAcc });
+			}
+
+			if (phase !== "out" && elementHeight) {
+				offsetAcc += elementHeight + TOAST_GAP;
+			}
+		}
+	}, [items]);
+
+	return createPortal(
+		<div className="fixed left-0 top-0 z-50 h-0 w-0">
+			{Array.from(items.map.values(), ({ id }) => (
+				<ToastItem
+					key={id}
+					id={id}
+				/>
+			))}
+		</div>,
+		container
+	);
+};
+
+export default Toast;

--- a/client/src/component/common/Toast/ToastItem.tsx
+++ b/client/src/component/common/Toast/ToastItem.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useLayoutEffect, useRef } from "react";
+import { twJoin } from "tailwind-merge";
+import { useToast } from "../../../state/ToastStore";
+
+interface IProps {
+	id: number;
+}
+
+const TOAST_DURATION_MS = 3000;
+
+const ToastItem: React.FC<IProps> = ({ id }) => {
+	const toastBoxRef = useRef<HTMLDivElement>(null);
+	const { items, updateItem, dismiss, forceRemove } = useToast();
+	const item = items.map.get(id);
+
+	const handleDismiss = () => {
+		if (item?.phase !== "out") {
+			dismiss(id);
+		}
+	};
+
+	useLayoutEffect(() => {
+		if (!toastBoxRef.current || !item) {
+			return;
+		}
+
+		if (!item.elementHeight) {
+			updateItem(id, {
+				elementHeight:
+					toastBoxRef.current.getBoundingClientRect().height,
+			});
+		}
+	}, [id]);
+
+	useEffect(() => {
+		if (!toastBoxRef.current || !item) {
+			return;
+		}
+
+		let timeoutId: number | null = null;
+		let handleOutTransitionEnd: (() => void) | null = null;
+
+		if (item.phase === "in") {
+			updateItem(id, { phase: "alive" });
+		} else if (item.phase === "alive") {
+			timeoutId = window.setTimeout(() => {
+				handleDismiss();
+			}, TOAST_DURATION_MS);
+		} else if (item.phase === "out") {
+			handleOutTransitionEnd = () => {
+				forceRemove(id);
+			};
+
+			toastBoxRef.current.addEventListener(
+				"transitionend",
+				handleOutTransitionEnd
+			);
+		}
+
+		return () => {
+			if (timeoutId !== null) {
+				window.clearTimeout(timeoutId);
+			}
+
+			if (handleOutTransitionEnd) {
+				toastBoxRef.current?.removeEventListener(
+					"transitionend",
+					handleOutTransitionEnd
+				);
+			}
+		};
+	}, [item?.phase]);
+
+	// TODO: 다크모드 스타일 작성
+	return (
+		<div
+			className="fixed left-1/2 top-20 z-50 w-full max-w-96 -translate-x-1/2 translate-y-0 transition-transform duration-300"
+			style={{
+				"--tw-translate-y": `${item?.elementOffsetY || 0}px`,
+			}}
+		>
+			<div
+				ref={toastBoxRef}
+				onClick={handleDismiss}
+				className={twJoin(
+					"bg-customGray/85 flex w-full cursor-pointer gap-1 rounded px-4 py-3 text-sm text-white shadow-md backdrop-blur transition duration-300",
+					item?.phase === "in" && "opacity-0",
+					item?.phase === "out" && "-translate-y-6 opacity-0"
+				)}
+			>
+				<div className="shrink-0 grow-0">
+					{/* TODO: variant 디테일 작성 */}
+					<b className="text-yellow-400">
+						{String.fromCharCode(
+							0x24d0 +
+								(item?.variant[0].charCodeAt(0) || 0) -
+								0x61
+						)}
+					</b>
+				</div>
+
+				<div className="flex-1">
+					{item?.message}
+					{/* TODO: 메시지만 남기기 */}
+					<br />
+					[id] {id}
+					<br />
+					[phase] {item?.phase}
+					<br />
+					[offsetY] {item?.elementOffsetY}
+					<br />
+					[height] {item?.elementHeight}
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default ToastItem;

--- a/client/src/component/common/Toast/ToastItem.tsx
+++ b/client/src/component/common/Toast/ToastItem.tsx
@@ -1,17 +1,66 @@
 import React, { useEffect, useLayoutEffect, useRef } from "react";
-import { twJoin } from "tailwind-merge";
-import { useToast } from "../../../state/ToastStore";
+import {
+	FiAlertTriangle,
+	FiCheckCircle,
+	FiInfo,
+	FiXCircle,
+} from "react-icons/fi";
+import { IconType } from "react-icons/lib";
+import { twJoin, twMerge } from "tailwind-merge";
+import { TToastVariant, useToast } from "../../../state/ToastStore";
 
 interface IProps {
 	id: number;
 }
 
+interface IToastClassNames {
+	box: string;
+	icon: string;
+}
+
+type TVariantProperties<T> = {
+	[key in TToastVariant]: T;
+};
+
 const TOAST_DURATION_MS = 3000;
+
+const baseClassNames: IToastClassNames = {
+	box: "bg-customGray",
+	icon: "text-lg",
+};
+const variantClassNames: TVariantProperties<IToastClassNames> = {
+	error: {
+		box: "bg-red-900",
+		icon: "text-red-200",
+	},
+	warning: {
+		box: "bg-yellow-900",
+		icon: "text-yellow-200",
+	},
+	success: {
+		box: "bg-green-900",
+		icon: "text-green-200",
+	},
+	info: {
+		box: "",
+		icon: "text-neutral-200",
+	},
+};
+
+const IconComponents: TVariantProperties<IconType> = {
+	error: FiXCircle,
+	warning: FiAlertTriangle,
+	success: FiCheckCircle,
+	info: FiInfo,
+};
 
 const ToastItem: React.FC<IProps> = ({ id }) => {
 	const toastBoxRef = useRef<HTMLDivElement>(null);
 	const { items, updateItem, dismiss, forceRemove } = useToast();
 	const item = items.map.get(id);
+
+	const variant = item?.variant ?? "info";
+	const Icon = IconComponents[variant];
 
 	const handleDismiss = () => {
 		if (item?.phase !== "out") {
@@ -82,35 +131,24 @@ const ToastItem: React.FC<IProps> = ({ id }) => {
 			<div
 				ref={toastBoxRef}
 				onClick={handleDismiss}
-				className={twJoin(
-					"bg-customGray/85 flex w-full cursor-pointer gap-1 rounded px-4 py-3 text-sm text-white shadow-md backdrop-blur transition duration-300",
+				className={twMerge(
+					"bg-customGray flex w-full cursor-pointer gap-2 rounded bg-opacity-85 py-3 pl-3 pr-4 text-sm text-white shadow-md backdrop-blur-xl transition duration-300",
+					baseClassNames.box,
+					variantClassNames[variant].box,
 					item?.phase === "in" && "opacity-0",
 					item?.phase === "out" && "-translate-y-6 opacity-0"
 				)}
 			>
 				<div className="shrink-0 grow-0">
-					{/* TODO: variant 디테일 작성 */}
-					<b className="text-yellow-400">
-						{String.fromCharCode(
-							0x24d0 +
-								(item?.variant[0].charCodeAt(0) || 0) -
-								0x61
+					<Icon
+						className={twJoin(
+							baseClassNames.icon,
+							variantClassNames[variant].icon
 						)}
-					</b>
+					/>
 				</div>
 
-				<div className="flex-1">
-					{item?.message}
-					{/* TODO: 메시지만 남기기 */}
-					<br />
-					[id] {id}
-					<br />
-					[phase] {item?.phase}
-					<br />
-					[offsetY] {item?.elementOffsetY}
-					<br />
-					[height] {item?.elementHeight}
-				</div>
+				<div className="flex-1">{item?.message}</div>
 			</div>
 		</div>
 	);

--- a/client/src/component/common/Toast/ToastItem.tsx
+++ b/client/src/component/common/Toast/ToastItem.tsx
@@ -24,26 +24,22 @@ type TVariantProperties<T> = {
 
 const TOAST_DURATION_MS = 3000;
 
-const baseClassNames: IToastClassNames = {
-	box: "bg-customGray",
-	icon: "text-lg",
-};
 const variantClassNames: TVariantProperties<IToastClassNames> = {
 	error: {
-		box: "bg-red-900",
-		icon: "text-red-200",
+		box: "bg-red-200 dark:bg-red-900",
+		icon: "text-red-900 dark:text-red-200",
 	},
 	warning: {
-		box: "bg-yellow-900",
-		icon: "text-yellow-200",
+		box: "bg-yellow-200 dark:bg-yellow-900",
+		icon: "text-yellow-900 dark:text-yellow-200",
 	},
 	success: {
-		box: "bg-green-900",
-		icon: "text-green-200",
+		box: "bg-green-200 dark:bg-green-900",
+		icon: "text-green-900 dark:text-green-200",
 	},
 	info: {
 		box: "",
-		icon: "text-neutral-200",
+		icon: "text-neutral-800 dark:text-neutral-200",
 	},
 };
 
@@ -120,7 +116,6 @@ const ToastItem: React.FC<IProps> = ({ id }) => {
 		};
 	}, [item?.phase]);
 
-	// TODO: 다크모드 스타일 작성
 	return (
 		<div
 			className="fixed left-1/2 top-20 z-50 w-full max-w-96 -translate-x-1/2 translate-y-0 transition-transform duration-300"
@@ -132,8 +127,7 @@ const ToastItem: React.FC<IProps> = ({ id }) => {
 				ref={toastBoxRef}
 				onClick={handleDismiss}
 				className={twMerge(
-					"bg-customGray flex w-full cursor-pointer gap-2 rounded bg-opacity-85 py-3 pl-3 pr-4 text-sm text-white shadow-md backdrop-blur-xl transition duration-300",
-					baseClassNames.box,
+					"dark:bg-customGray flex w-full cursor-pointer gap-2 rounded border-l border-t border-white/5 bg-neutral-200 py-3 pl-3 pr-4 text-sm text-black shadow-md transition duration-300 dark:text-white",
 					variantClassNames[variant].box,
 					item?.phase === "in" && "opacity-0",
 					item?.phase === "out" && "-translate-y-6 opacity-0"
@@ -142,7 +136,7 @@ const ToastItem: React.FC<IProps> = ({ id }) => {
 				<div className="shrink-0 grow-0">
 					<Icon
 						className={twJoin(
-							baseClassNames.icon,
+							"text-lg",
 							variantClassNames[variant].icon
 						)}
 					/>

--- a/client/src/page/Profile/ProfilePage.tsx
+++ b/client/src/page/Profile/ProfilePage.tsx
@@ -10,6 +10,7 @@ import { useUserStore } from "../../state/store";
 import { ApiCall } from "../../api/api";
 import { uploadImageRequest } from "../../api/posts/crud";
 import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
+import { useToast } from "../../state/ToastStore";
 import { ClientError } from "../../api/errors";
 import {
 	sendPatchProfileRequest,
@@ -25,6 +26,7 @@ const ProfilePage = () => {
 	const navigate = useNavigate();
 	const accountDeleteModal = useModal();
 	const globalErrorModal = useGlobalErrorModal();
+	const toast = useToast();
 	const { nickname, email, imgUrl } = useUserStore();
 	const { setImgUrl, setNickName } = useUserStore.use.actions();
 	const imageInputRef = useRef<HTMLInputElement>(null);
@@ -131,7 +133,10 @@ const ProfilePage = () => {
 
 		sendPostCheckUserRequest({ nickname: newNickname }).then(res => {
 			if (res.error !== "") {
-				console.error("잠시 후 다시 시도해주세요!");
+				toast.add({
+					message: "잠시 후 다시 시도해 주세요!",
+					variant: "error",
+				});
 				return;
 			}
 

--- a/client/src/page/User/CheckPassword.tsx
+++ b/client/src/page/User/CheckPassword.tsx
@@ -111,7 +111,7 @@ const CheckPassword: FC = () => {
 			accountDeleteModal.close();
 			toast.add({
 				message: "회원 탈퇴를 완료했습니다.",
-				variant: "warning",
+				variant: "success",
 			});
 
 			setLogoutUser();

--- a/client/src/page/User/CheckPassword.tsx
+++ b/client/src/page/User/CheckPassword.tsx
@@ -11,6 +11,7 @@ import { useUserStore } from "../../state/store";
 import OAuthLoginButtons from "../../component/User/OAuthLoginButtons";
 import ConfirmModal from "../../component/common/Modal/ConfirmModal";
 import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
+import { useToast } from "../../state/ToastStore";
 import Button from "../../component/common/Button";
 
 const CheckPassword: FC = () => {
@@ -28,6 +29,7 @@ const CheckPassword: FC = () => {
 
 	const globalErrorModal = useGlobalErrorModal();
 	const accountDeleteModal = useModal();
+	const toast = useToast();
 
 	useLayoutEffect(() => {
 		if (next === "accountDelete" && oAuthConfirmed === "true") {
@@ -107,10 +109,9 @@ const CheckPassword: FC = () => {
 			}
 
 			accountDeleteModal.close();
-			globalErrorModal.open({
-				variant: "warning",
-				title: "회원 탈퇴 완료",
+			toast.add({
 				message: "회원 탈퇴를 완료했습니다.",
+				variant: "warning",
 			});
 
 			setLogoutUser();

--- a/client/src/page/User/EmailRegistration.tsx
+++ b/client/src/page/User/EmailRegistration.tsx
@@ -10,6 +10,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useUserStore } from "../../state/store";
 import { useStringWithValidation } from "../../hook/useStringWithValidation";
 import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
+import { useToast } from "../../state/ToastStore";
 import TextInput from "../../component/common/TextInput";
 import Button from "../../component/common/Button";
 
@@ -26,6 +27,7 @@ const EmailRegistration: FC = () => {
 	const [errorMessage, setErrorMessage] = useState("");
 
 	const globalErrorModal = useGlobalErrorModal();
+	const toast = useToast();
 
 	const { setIsEmailRegistered } = useUserStore.use.actions();
 
@@ -142,10 +144,9 @@ const EmailRegistration: FC = () => {
 			setIsEmailRegistered(true);
 			navigate(final || "/");
 
-			globalErrorModal.open({
-				variant: "info",
-				title: "이메일 등록 성공",
+			toast.add({
 				message: "로그인 이메일을 등록했습니다.",
+				variant: "success",
 			});
 		});
 

--- a/client/src/page/User/Join.tsx
+++ b/client/src/page/User/Join.tsx
@@ -10,7 +10,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { useStringWithValidation } from "../../hook/useStringWithValidation";
 import { FaComments } from "react-icons/fa6";
-import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
+import { useToast } from "../../state/ToastStore";
 import TextInput from "../../component/common/TextInput";
 import Button from "../../component/common/Button";
 import { IJoinRequest } from "shared";
@@ -22,7 +22,7 @@ const Join: FC = () => {
 	const password = useStringWithValidation();
 	const requiredPassword = useStringWithValidation();
 
-	const globalErrorModal = useGlobalErrorModal();
+	const toast = useToast();
 
 	const handleEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
 		email.setValue(e.target.value);
@@ -142,10 +142,9 @@ const Join: FC = () => {
 				return;
 			}
 
-			globalErrorModal.open({
-				variant: "info",
-				title: "회원 가입 완료",
+			toast.add({
 				message: "회원가입을 완료했습니다.",
+				variant: "success",
 			});
 
 			navigate("/login");

--- a/client/src/page/User/Login.tsx
+++ b/client/src/page/User/Login.tsx
@@ -2,6 +2,7 @@ import React, { FormEvent, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { REGEX } from "./constants/constants";
 import { useUserStore } from "../../state/store";
+import { useToast } from "../../state/ToastStore";
 import { sendPostLoginRequest } from "../../api/users/crud";
 import OAuthLoginButtons from "../../component/User/OAuthLoginButtons";
 import { useStringWithValidation } from "../../hook/useStringWithValidation";
@@ -17,6 +18,7 @@ const Login: React.FC = () => {
 	const [errorMessage, setErrorMessage] = useState<string>("");
 
 	const { setLoginUser } = useUserStore.use.actions();
+	const toast = useToast();
 
 	// zustand 테스트용
 	// const stateNickName = useUserStore.use.nickname();
@@ -65,6 +67,11 @@ const Login: React.FC = () => {
 			}
 
 			setLoginUser(res.userInfo);
+
+			toast.add({
+				message: `${res.userInfo.nickname}님 환영합니다!`,
+				variant: "success",
+			});
 
 			const redirect =
 				new URLSearchParams(location.search).get("redirect") || "/";

--- a/client/src/page/User/ProfileUpdate.tsx
+++ b/client/src/page/User/ProfileUpdate.tsx
@@ -10,6 +10,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useUserStore } from "../../state/store";
 import { useStringWithValidation } from "../../hook/useStringWithValidation";
 import { useGlobalErrorModal } from "../../state/GlobalErrorModalStore";
+import { useToast } from "../../state/ToastStore";
 import TextInput from "../../component/common/TextInput";
 import Button from "../../component/common/Button";
 
@@ -26,6 +27,7 @@ const ProfileUpdate: FC = () => {
 	const [errorMessage, setErrorMessage] = useState("");
 
 	const globalErrorModal = useGlobalErrorModal();
+	const toast = useToast();
 
 	const { setNickName: storeSetNickName } = useUserStore.use.actions();
 
@@ -145,10 +147,9 @@ const ProfileUpdate: FC = () => {
 
 			storeSetNickName(nickname.value);
 
-			globalErrorModal.open({
-				variant: "info",
-				title: "성공",
-				message: "유저 정보가 변경되었습니다.",
+			toast.add({
+				message: "유저 정보를 변경했습니다.",
+				variant: "success",
 			});
 
 			navigate(final || "/");

--- a/client/src/state/ToastStore.ts
+++ b/client/src/state/ToastStore.ts
@@ -1,0 +1,112 @@
+import { create } from "zustand";
+
+export type TToastVariant = "error" | "warning" | "success" | "info";
+export type TToastItemPhase = "in" | "alive" | "out";
+
+export interface IToastItem {
+	id: number;
+	message: string;
+	variant: TToastVariant;
+	phase: TToastItemPhase;
+	elementHeight: number | null;
+	elementOffsetY: number | null;
+}
+
+interface IToastState {
+	items: {
+		/**
+		 * @prop 데이터 복사 없이 참조만 변경하기 위해 객체로 래핑했습니다.
+		 * `deps` 배열에는 `items.map`을 넣으면 안 되고, `items` 자체를 넣거나
+		 * `items.map(id)` 내의 개별 항목을 넣어야 합니다.
+		 */
+		map: Map<number, IToastItem>;
+	};
+}
+
+interface IAddActionParam {
+	message: string;
+	variant?: TToastVariant;
+}
+
+interface IToastItemUpdate {
+	phase?: TToastItemPhase;
+	elementHeight?: number | null;
+	elementOffsetY?: number | null;
+}
+
+interface IToastActions {
+	/** @prop 토스트 목록에 새 항목을 추가합니다. */
+	add: (item: IAddActionParam) => void;
+
+	/** @prop 토스트 항목의 수정 가능한 필드를 변경합니다. */
+	updateItem: (id: number, modification: IToastItemUpdate) => void;
+
+	/** @prop `id`가 일치하는 토스트를 `out` 상태로 전이합니다. */
+	dismiss: (id: number) => void;
+
+	/** @prop 상태를 무시하고 `id`가 일치하는 토스트를 삭제합니다. */
+	forceRemove: (id: number) => void;
+}
+
+type TGlobalErrorModalStore = IToastState & IToastActions;
+
+let nextId = 1;
+
+export const useToast = create<TGlobalErrorModalStore>((set, get) => ({
+	items: { map: new Map() },
+
+	add: ({ message, variant = "info" }: IAddActionParam) => {
+		if (!message) {
+			console.error("Toast에 표시할 메시지 없음");
+			return;
+		}
+
+		const { map } = get().items;
+		map.set(nextId, {
+			id: nextId,
+			message,
+			variant,
+			phase: "in",
+			elementHeight: null,
+			elementOffsetY: null,
+		});
+
+		nextId += 1;
+		set({
+			items: { map },
+		});
+	},
+
+	updateItem: (id: number, modification: IToastItemUpdate) => {
+		const { map } = get().items;
+		const prevItem: IToastItem | undefined = map.get(id);
+
+		if (!prevItem) {
+			return;
+		}
+
+		const nextItem: IToastItem = {
+			...prevItem,
+			...modification,
+		};
+		map.set(id, nextItem);
+
+		set({
+			items: { map },
+		});
+	},
+
+	dismiss: (id: number) => {
+		get().updateItem(id, { phase: "out" });
+	},
+
+	forceRemove: (id: number) => {
+		const { map } = get().items;
+
+		if (map.delete(id)) {
+			set({
+				items: { map },
+			});
+		}
+	},
+}));

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+// 스타일 객체의 key로 CSS 변수 허용
+declare namespace React {
+	interface CSSProperties {
+		[key: `--${string}`]: string | number;
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #225

## 📝 작업 내용

Toast 컴포넌트 작성

- 전역 상태
  - `client/src/state/ToastStore.ts`
- 컴포넌트 작성 및 연결: Toast, ToastItem
  - `client/src/component/common/Toast/Toast.tsx`
  - `client/src/component/common/Toast/ToastItem.tsx`
- Alert 형태의 모달 일부를 토스트로 교체

### 주요 사용 패턴

```tsx
const Sample: React.FC = () => {
  const toast = useToast();

  const handleClick = () => {
    toast.add({
      message: "토스트 메시지",
      variant: "success", // optional (error, warning, success, 기본값 info)
    });
  };

  return (
    <button onClick={handleClick}>
      클릭하여 토스트 띄우기
    </button>
  );
};
```

### 🖼️ 스크린샷

![toast](https://github.com/user-attachments/assets/7f8eaad8-f36c-472f-af23-50433f8ee53c)